### PR TITLE
enhance(version): Add version flag in azurefile plugin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -987,6 +987,7 @@
     "k8s.io/kubernetes/pkg/cloudprovider/providers/azure",
     "k8s.io/kubernetes/pkg/util/mount",
     "k8s.io/kubernetes/pkg/volume/util",
+    "sigs.k8s.io/yaml",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -29,8 +29,6 @@ import (
 )
 
 const (
-	driverName       = "file.csi.azure.com"
-	vendorVersion    = "v0.2.0-alpha"
 	seperator        = "#"
 	volumeIDTemplate = "%s#%s#%s"
 	fileMode         = "file_mode"
@@ -51,23 +49,20 @@ type Driver struct {
 // NewDriver Creates a NewCSIDriver object. Assumes vendor version is equal to driver version &
 // does not support optional driver plugin info manifest field. Refer to CSI spec for more details.
 func NewDriver(nodeID string) *Driver {
-	if nodeID == "" {
-		klog.Fatalln("NodeID missing")
-		return nil
-	}
-
 	driver := Driver{}
 	driver.Name = driverName
-	driver.Version = vendorVersion
+	driver.Version = driverVersion
 	driver.NodeID = nodeID
-
 	return &driver
 }
 
 // Run driver initialization
 func (d *Driver) Run(endpoint string) {
-	klog.Infof("Driver: %v ", driverName)
-	klog.Infof("Version: %s", vendorVersion)
+	versionMeta, err := GetVersionYAML()
+	if err != nil {
+		klog.Fatalf("%v", err)
+	}
+	klog.Infof("\nDRIVER INFORMATION:\n-------------------\n%s\n\nStreaming logs below:", versionMeta)
 
 	cloud, err := GetCloudProvider()
 	if err != nil {

--- a/pkg/azurefile/version.go
+++ b/pkg/azurefile/version.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurefile
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// These are set during build time via -ldflags
+var (
+	driverVersion = "N/A"
+	gitCommit     = "N/A"
+	buildDate     = "N/A"
+	driverName    = "N/A"
+)
+
+// VersionInfo holds the version information of the driver
+type VersionInfo struct {
+	DriverName    string `json:"Driver Name"`
+	DriverVersion string `json:"Driver Version"`
+	GitCommit     string `json:"Git Commit"`
+	BuildDate     string `json:"Build Date"`
+	GoVersion     string `json:"Go Version"`
+	Compiler      string `json:"Compiler"`
+	Platform      string `json:"Platform"`
+}
+
+// GetVersion returns the version information of the driver
+func GetVersion() VersionInfo {
+	return VersionInfo{
+		DriverName:    driverName,
+		DriverVersion: driverVersion,
+		GitCommit:     gitCommit,
+		BuildDate:     buildDate,
+		GoVersion:     runtime.Version(),
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// GetVersionYAML returns the version information of the driver
+// in YAML format
+func GetVersionYAML() (string, error) {
+	info := GetVersion()
+	marshalled, err := yaml.Marshal(&info)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(marshalled)), nil
+}

--- a/pkg/azurefileplugin/main.go
+++ b/pkg/azurefileplugin/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/kubernetes-sigs/azurefile-csi-driver/pkg/azurefile"
@@ -31,12 +32,20 @@ func init() {
 var (
 	endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	nodeID   = flag.String("nodeid", "", "node id")
+	version  = flag.Bool("version", false, "Print the version and exit.")
 )
 
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
-
+	if *version {
+		info, err := azurefile.GetVersionYAML()
+		if err != nil {
+			klog.Fatalln(err)
+		}
+		fmt.Println(info)
+		os.Exit(0)
+	}
 	if *nodeID == "" {
 		klog.Error("--nodeid is a required parameter")
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This commit adds version flag in azurefile plugin along with some metadata information like commit id and build date. Output of `azurefileplugin --version`:

```
$ ./_output/azurefileplugin --version
Build Date: "2019-03-28T17:26:19Z"
Compiler: gc
Driver Name: file.csi.azure.com
Driver Version: v0.2.0-alpha
Git Commit: b5400fb179d78cdb8c4562ceb184e05f6e2381c8
Go Version: go1.11.5
Platform: linux/amd64
```

The same information is now also printed in logs as well. Below is an example of this:
```
$ kubectl logs -f csi-azurefile-k6htj -n kube-system -c azurefile
I0328 17:30:58.727473       1 azurefile.go:65] 
DRIVER INFORMATION:
-------------------
Build Date: "2019-03-28T17:26:19Z"
Compiler: gc
Driver Name: file.csi.azure.com
Driver Version: v0.2.0-alpha
Git Commit: b5400fb179d78cdb8c4562ceb184e05f6e2381c8
Go Version: go1.11.5
Platform: linux/amd64

Streaming logs below:
I0328 17:30:58.727717       1 azure.go:34] AZURE_CREDENTIAL_FILE env var set as /etc/kubernetes/azure.json
I0328 17:30:58.728349       1 azure_auth.go:81] azure: using client_id+client_secret to retrieve access token
I0328 17:30:58.728371       1 azure.go:258] Azure cloudprovider (read ops) using rate limit config: QPS=3, bucket=10
I0328 17:30:58.728378       1 azure.go:262] Azure cloudprovider (write ops) using rate limit config: QPS=1, bucket=5
I0328 17:30:58.728537       1 azure.go:324] Azure cloudprovider using try backoff: retries=6, exponent=1.500000, duration=5, jitter=1.000000
I0328 17:30:58.728675       1 mount_linux.go:165] Detected OS without systemd
I0328 17:30:58.728691       1 driver.go:80] Enabling controller service capability: CREATE_DELETE_VOLUME
I0328 17:30:58.728697       1 driver.go:99] Enabling volume access mode: SINGLE_NODE_WRITER
```

**Release note**:
```
enhance(version): Add version flag in azurefile plugin
```
