### PR TITLE
fix the wrong unit in CreateVolume

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -50,7 +50,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
-	requestGiB := int(volumehelper.RoundUpBytes(volSizeBytes))
+	requestGiB := int(volumehelper.RoundUpGiB(volSizeBytes))
 
 	parameters := req.GetParameters()
 	var sku, resourceGroup, location, account string


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

**What this PR does / why we need it**:

The unit used in CreateVolume should be GiB, not Byte.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


**Release note**:
```
fix the wrong unit in CreateVolume
```
