### PR TITLE
remove invalid OWNERS_ALIASES file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,0 @@
-aliases:
-- andyzhangx
-- brendandburns
-- feiskyer
-- khenidak


### PR DESCRIPTION
I'm doing some org/repo-wide OWNERS file parsing, and this is an
invalid OWNERS_ALIASES file. It doesn't actually contain any aliases so
doesn't seem like there's much point in keeping it around. Our
verify-owners plugin should catch these in the future.