### PR TITLE
feat: implement DeleteSnapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ jobs:
       name: "sanity test"
       install:
         - sudo apt update && sudo apt install cifs-utils procps -y
-      script: make sanity-test
+      script: 
+        - make azurefile
+        - make sanity-test
       # after_failure: TRAVIS_TEST_RESULT=0
     - stage: test
       name: "integration test"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test:
 integration-test:
 	test/integration/run-tests-all-clouds.sh
 sanity-test:
-	test/sanity/run-test.sh
+	test/sanity/run-tests-all-clouds.sh
 e2e-test:
 	test/e2e/run-test.sh
 azurefile:

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -95,7 +95,7 @@ func (d *Driver) Run(endpoint string) {
 	d.AddControllerServiceCapabilities(
 		[]csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-			//csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
+			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
 			//csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 		})
 	d.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
@@ -267,4 +267,15 @@ func checkShareNameBeginAndEnd(fileShareName string) bool {
 	}
 
 	return false
+}
+
+// get snapshot name according to snapshot id, e.g.
+// input: "rg#f5713de20cde511e8ba4900#csivolumename#2019-08-22T07:17:53.0000000Z"
+// output: 2019-08-22T07:17:53.0000000Z
+func getSnapshot(id string) (string, error) {
+	segments := strings.Split(id, seperator)
+	if len(segments) != 4 {
+		return "", fmt.Errorf("error parsing volume id: %q, should at least contain three #", id)
+	}
+	return segments[3], nil
 }

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -288,3 +288,44 @@ func TestCheckShareNameBeginAndEnd(t *testing.T) {
 		}
 	}
 }
+
+func TestGetSnapshot(t *testing.T) {
+	tests := []struct {
+		options   string
+		expected1 string
+		expected2 error
+	}{
+		{
+			options:   "rg#f123#csivolumename#2019-08-22T07:17:53.0000000Z",
+			expected1: "2019-08-22T07:17:53.0000000Z",
+			expected2: nil,
+		},
+		{
+			options:   "rg#f123#csivolumename",
+			expected1: "",
+			expected2: fmt.Errorf("error parsing volume id: \"rg#f123#csivolumename\", should at least contain three #"),
+		},
+		{
+			options:   "rg#f123",
+			expected1: "",
+			expected2: fmt.Errorf("error parsing volume id: \"rg#f123\", should at least contain three #"),
+		},
+		{
+			options:   "rg",
+			expected1: "",
+			expected2: fmt.Errorf("error parsing volume id: \"rg\", should at least contain three #"),
+		},
+		{
+			options:   "",
+			expected1: "",
+			expected2: fmt.Errorf("error parsing volume id: \"\", should at least contain three #"),
+		},
+	}
+
+	for _, test := range tests {
+		result1, result2 := getSnapshot(test.options)
+		if !reflect.DeepEqual(result1, test.expected1) || !reflect.DeepEqual(result2, test.expected2) {
+			t.Errorf("input: %q, getSnapshot result1: %q, expected1: %q, result2: %q, expected2: %q, ", test.options, result1, test.expected1, result2, test.expected2)
+		}
+	}
+}

--- a/test/sanity/run-tests-all-clouds.sh
+++ b/test/sanity/run-tests-all-clouds.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [ ! -v AZURE_CREDENTIAL_FILE ]; then
+	export set AZURE_CREDENTIAL_FILE=/tmp/azure.json
+fi
+
+GO_BIN_PATH=`which go`
+
+# run test on AzurePublicCloud
+if [ -v aadClientSecret ]; then
+	cp test/integration/azure.json $AZURE_CREDENTIAL_FILE
+
+	sed -i "s/tenantId-input/$tenantId/g" $AZURE_CREDENTIAL_FILE
+	sed -i "s/subscriptionId-input/$subscriptionId/g" $AZURE_CREDENTIAL_FILE
+	sed -i "s/aadClientId-input/$aadClientId/g" $AZURE_CREDENTIAL_FILE
+	sed -i "s#aadClientSecret-input#$aadClientSecret#g" $AZURE_CREDENTIAL_FILE
+	sed -i "s/resourceGroup-input/$resourceGroup/g" $AZURE_CREDENTIAL_FILE
+	sed -i "s/location-input/$location/g" $AZURE_CREDENTIAL_FILE
+
+	test/sanity/run-test.sh $nodeid
+else
+	if [ -v subscriptionId ]; then
+		echo "skip sanity test in CI env"
+	else
+		# run test in user mode
+		go test -v ./test/sanity/...
+	fi
+fi


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- implement DeleteSnapshot
- use `shareURL` to delete fileshare instead of `fileServiceClient`. Then we can use `x-ms-delete-snapshots=include` to delete all share snapshots with the share.
- enable `csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT`
- change the way to run sanity test in CI

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18 

**Special notes for your reviewer**:


**Release note**:
```
implement DeleteSnapshot
```
