### PR TITLE
chore: Update csi-sanity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -168,7 +168,7 @@ replace (
 	github.com/kr/pretty => github.com/kr/pretty v0.1.0
 	github.com/kr/pty => github.com/kr/pty v1.1.5
 	github.com/kr/text => github.com/kr/text v0.1.0
-	github.com/kubernetes-csi/csi-test => github.com/kubernetes-csi/csi-test v1.1.0
+	github.com/kubernetes-csi/csi-test => github.com/kubernetes-csi/csi-test v2.2.0+incompatible
 	github.com/kubernetes-csi/external-snapshotter => github.com/kubernetes-csi/external-snapshotter v1.0.1
 	github.com/mailru/easyjson => github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe
 	github.com/marstr/guid => github.com/marstr/guid v1.1.0

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -36,4 +36,4 @@ _output/azurefileplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 &
 
 echo 'Begin to run sanity test...'
 readonly CSI_SANITY_BIN='csi-test/cmd/csi-sanity/csi-sanity'
-"$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint"
+"$CSI_SANITY_BIN" --ginkgo.v --csi.endpoint="$endpoint"  -ginkgo.skip="should fail when the volume source snapshot is not found"

--- a/test/sanity/run-tests-all-clouds.sh
+++ b/test/sanity/run-tests-all-clouds.sh
@@ -18,7 +18,7 @@ set -eo pipefail
 
 function install_csi_sanity_bin {
   echo 'Installing CSI sanity test binary...'
-  git clone https://github.com/kubernetes-csi/csi-test.git -b v1.1.0
+  git clone https://github.com/kubernetes-csi/csi-test.git -b v2.2.0
   pushd csi-test/cmd/csi-sanity
   make
   popd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind flake

**What this PR does / why we need it**:
In order to test `EXPAND_VOLUME` controller capability, we need to update the version of CSI sanity test to v2.2.0. 
Ref: #121 

Here I fix some bugs to pass the sanity tests.
- According to the logic of sanity test `should work` in `Node Service`, we should delete the target directory in the end of `func NodeUnpublishVolume`.

- Since we enabled `csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT`, we should check the snapshot if it exists when creating the volume. Currently, AzureFile does not support restore. Ref: https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/18#issuecomment-529316027 . So I do not make the code of `creating volume from snapshot` stand-alone as a new function, just include it in `CreateVolume`. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
Update csi-sanity
```
