### PR TITLE
Azure files - add support to run the tests for in-tree

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -22,3 +22,11 @@ REGISTRY=<your Docker Hub ID / registry> make e2e-test
 # Run E2E tests on an existing Azure File CSI Driver image
 REGISTRY=<your Docker Hub ID / registry> IMAGE_VERSION=<desired image version> make e2e-test
 ```
+
+### Run the test for in-tree driver
+
+```
+export KUBECONFIG='<path to kubeconfig>'
+export AZURE_STORAGE_DRIVER="kubernetes.io/azure-file"
+make e2e-test
+```

--- a/test/e2e/driver/driver.go
+++ b/test/e2e/driver/driver.go
@@ -29,25 +29,29 @@ const (
 )
 
 type PVTestDriver interface {
-	DynamicPVTestDriver
-	PreProvisionedVolumeTestDriver
-	VolumeSnapshotTestDriver
+	GetDynamicProvisionStorageClass(parameters map[string]string, mountOptions []string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, bindingMode *storagev1.VolumeBindingMode, allowedTopologyValues []string, namespace string) *storagev1.StorageClass
+	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string) *v1.PersistentVolume
+	GetVolumeSnapshotClass(namespace string) *v1alpha1.VolumeSnapshotClass
+	IsInTree() bool
 }
 
 // DynamicPVTestDriver represents an interface for a CSI driver that supports DynamicPV
 type DynamicPVTestDriver interface {
 	// GetDynamicProvisionStorageClass returns a StorageClass dynamic provision Persistent Volume
 	GetDynamicProvisionStorageClass(parameters map[string]string, mountOptions []string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, bindingMode *storagev1.VolumeBindingMode, allowedTopologyValues []string, namespace string) *storagev1.StorageClass
+	IsInTree() bool
 }
 
 // PreProvisionedVolumeTestDriver represents an interface for a CSI driver that supports pre-provisioned volume
 type PreProvisionedVolumeTestDriver interface {
 	// GetPersistentVolume returns a PersistentVolume with pre-provisioned volumeHandle
 	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string) *v1.PersistentVolume
+	IsInTree() bool
 }
 
 type VolumeSnapshotTestDriver interface {
 	GetVolumeSnapshotClass(namespace string) *v1alpha1.VolumeSnapshotClass
+	IsInTree() bool
 }
 
 func getStorageClass(

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -34,7 +34,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 	var (
 		cs         clientset.Interface
 		ns         *v1.Namespace
-		testDriver driver.PVTestDriver
+		testDriver driver.DynamicPVTestDriver
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -42,7 +42,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		ns = f.Namespace
 	})
 
-	testDriver = driver.InitAzureFileCSIDriver()
+	testDriver = driver.InitAzureFileDriver()
 	ginkgo.It(fmt.Sprintf("should create a volume on demand"), func() {
 		pods := []testsuites.PodDetails{
 			{
@@ -169,6 +169,12 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 	})
 
 	ginkgo.It(fmt.Sprintf("[env] should retain PV with reclaimPolicy %q", v1.PersistentVolumeReclaimRetain), func() {
+		// This tests uses the CSI driver to delete the PV.
+		// TODO: Go via the k8s interfaces and also make it more reliable for in-tree and then
+		//       test can be enabled.
+		if testDriver.IsInTree() {
+			ginkgo.Skip("Test running with in tree configuration. Skip the ")
+		}
 		reclaimPolicy := v1.PersistentVolumeReclaimRetain
 		volumes := []testsuites.VolumeDetails{
 			{

--- a/test/e2e/pre_provisioning_test.go
+++ b/test/e2e/pre_provisioning_test.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("[azurefile-csi-e2e] [single-az] Pre-Provisioned", func(
 	ginkgo.BeforeEach(func() {
 		cs = f.ClientSet
 		ns = f.Namespace
-		testDriver = driver.InitAzureFileCSIDriver()
+		testDriver = driver.InitAzureFileDriver()
 	})
 
 	ginkgo.AfterEach(func() {
@@ -64,6 +64,10 @@ var _ = ginkgo.Describe("[azurefile-csi-e2e] [single-az] Pre-Provisioned", func(
 	})
 
 	ginkgo.It("[env] should use a pre-provisioned volume and mount it as readOnly in a pod", func() {
+		// Az tests are not yet working for in-tree
+		if testDriver.IsInTree() {
+			ginkgo.Skip("Test running with in tree configuration")
+		}
 		req := makeCreateVolumeReq("pre-provisioned-readOnly")
 		resp, err := azurefileDriver.CreateVolume(context.Background(), req)
 		if err != nil {
@@ -98,6 +102,10 @@ var _ = ginkgo.Describe("[azurefile-csi-e2e] [single-az] Pre-Provisioned", func(
 	})
 
 	ginkgo.It(fmt.Sprintf("[env] should use a pre-provisioned volume and retain PV with reclaimPolicy %q", v1.PersistentVolumeReclaimRetain), func() {
+		// Az tests are not yet working for in tree driver
+		if testDriver.IsInTree() {
+			ginkgo.Skip("Test running with in tree configuration")
+		}
 		req := makeCreateVolumeReq("pre-provisioned-retain-reclaimPolicy")
 		resp, err := azurefileDriver.CreateVolume(context.Background(), req)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind test

> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Azure files - add support to run the tests for in-tree
Document steps to run azure file e2e in-tree tests

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Note: This PR is focussed on functionality and basic name changes. Upcoming PRs will convert the names of files, structs and functions to indicate this is now a generic tests.

**Release note**:
```

```
