### PR TITLE
test: Run e2e test suite with JUnit reporter

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -22,22 +22,27 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/gomega"
+	"github.com/pborman/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
 	"sigs.k8s.io/azurefile-csi-driver/pkg/azurefile"
 	"sigs.k8s.io/azurefile-csi-driver/test/utils/azure"
 	"sigs.k8s.io/azurefile-csi-driver/test/utils/credentials"
 	"sigs.k8s.io/azurefile-csi-driver/test/utils/testutil"
-
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
-	"github.com/pborman/uuid"
-	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-const kubeconfigEnvVar = "KUBECONFIG"
+const (
+	kubeconfigEnvVar = "KUBECONFIG"
+	reportDirEnv     = "ARTIFACTS"
+	defaultReportDir = "/workspace/_artifacts"
+)
 
 var azurefileDriver *azurefile.Driver
 
@@ -127,5 +132,10 @@ var _ = ginkgo.AfterSuite(func() {
 
 func TestE2E(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "AzureFile CSI Driver End-to-End Tests")
+	reportDir := os.Getenv(reportDirEnv)
+	if reportDir == "" {
+		reportDir = defaultReportDir
+	}
+	r := []ginkgo.Reporter{reporters.NewJUnitReporter(path.Join(reportDir, "junit_01.xml"))}
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "AzureFile CSI Driver End-to-End Tests", r)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR should enable testgrid to list all test cases we ran in https://testgrid.k8s.io/provider-azure-master#pr-azurefile-csi-driver-e2e.

/assign @andyzhangx  

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
None.
```
