### PR TITLE
feat: provides initial support for vhd disk mount on azure file

### DIFF
--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
@@ -105,12 +105,8 @@ spec:
             - mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
               name: msi
-            - mountPath: /devhost #use /devhost to avoid conflict
+            - mountPath: /dev
               name: device-dir
-            - mountPath: /sys/bus/scsi/devices
-              name: sys-devices-dir
-            - mountPath: /sys/class/scsi_host/
-              name: scsi-host-dir
           resources:
             limits:
               cpu: 2
@@ -142,11 +138,3 @@ spec:
             path: /dev
             type: Directory
           name: device-dir
-        - hostPath:
-            path: /sys/bus/scsi/devices
-            type: Directory
-          name: sys-devices-dir
-        - hostPath:
-            path: /sys/class/scsi_host/
-            type: Directory
-          name: scsi-host-dir

--- a/deploy/csi-azurefile-node.yaml
+++ b/deploy/csi-azurefile-node.yaml
@@ -105,6 +105,8 @@ spec:
             - mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
               name: msi
+            - mountPath: /dev
+              name: device-dir
           resources:
             limits:
               cpu: 2
@@ -132,4 +134,8 @@ spec:
         - hostPath:
             path: /var/lib/waagent/ManagedIdentity-Settings
           name: msi
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: device-dir
 ---

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -57,6 +57,9 @@ const (
 
 	// key of snapshot name in metadata
 	snapshotNameKey = "initiator"
+
+	diskNameField = "diskname"
+	proxyMount    = "proxy-mount"
 )
 
 // Driver implements all interfaces of CSI drivers

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -59,7 +59,9 @@ const (
 	snapshotNameKey = "initiator"
 
 	diskNameField = "diskname"
+	fsTypeField   = "fstype"
 	proxyMount    = "proxy-mount"
+	cifs          = "cifs"
 )
 
 // Driver implements all interfaces of CSI drivers

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -76,6 +76,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		case "sharename":
 			fileShareName = v
 		case diskNameField:
+		case fsTypeField:
 		default:
 			return nil, fmt.Errorf("invalid option %q", k)
 		}

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -75,6 +75,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			resourceGroup = v
 		case "sharename":
 			fileShareName = v
+		case diskNameField:
 		default:
 			return nil, fmt.Errorf("invalid option %q", k)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR provides initial support of vhd disk mount on azure file share. 
There are two mainly two parts:
1.	Provision storage(create an azure file share and create an empty vhd in that file share)
2.	Mount storage(cifs mount file share and mount vhd as a block device)

This PR only supports static provisioning(user provides vhd file in azure file) by following config(with two new parameters `diskName`, `fstype` added in azure file storage class):

```
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: file.csi.azure.com
provisioner: file.csi.azure.com
parameters:
  storageAccount: andypremium
  resourceGroup: andy-dev
  shareName: test
  diskName: test.vhd
  fstype: ext4
reclaimPolicy: Delete
volumeBindingMode: Immediate


$ kubectl exec -it nginx-azurefile bash
root@nginx-azurefile:/# df -h
Filesystem      Size  Used Avail Use% Mounted on
...
/dev/loop0      9.8G   71M  9.2G   1% /mnt/azurefile
/dev/sda1        29G   20G  9.1G  69% /etc/hosts
...
root@nginx-azurefile:/# ls -lt /mnt/azurefile
total 40
-rw-r--r-- 1 root   root    12376 Mar  4 14:57 outfile
-rw-r--r-- 1 root   root        6 Mar  4 13:48 20200304
drwx------ 2 root   root    16384 Mar  3 08:02 lost+found
drwxr-xr-x 5 nobody nogroup  4096 Dec 18 22:16 wordpress
root@nginx-azurefile:/# echo hello2020 > /mnt/azurefile/hello2020
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
next plan:
 - provides dynamic provisioning
 - fix concurrent issue in node disk mount(currently it's using /dev/loop which has race condition)
 - fix corruption issue when azure file or network is broken intermittently
 - disk mount option support (need test)
 - azure file mount options performance tuning
 - windows support


**Release note**:
```
feat: provides initial support of vhd disk mount on azure file
```

/hold