### PR TITLE
fix: create vhd pipline timeout issue

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -36,6 +36,7 @@ import (
 
 // CreateVolume provisions an azure file
 func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+	klog.V(2).Infof("CreateVolume called with request %v", *req)
 	if err := d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		klog.Errorf("invalid create volume req: %v", req)
 		return nil, err
@@ -147,6 +148,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 // DeleteVolume delete an azure file
 func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+	klog.V(2).Infof("DeleteVolume called with request %v", *req)
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID missing in request")
 	}
@@ -205,7 +207,7 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 
 // ControllerGetCapabilities returns the capabilities of the Controller plugin
 func (d *Driver) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default ControllerGetCapabilities")
+	klog.V(2).Infof("ControllerGetCapabilities called with request %v", *req)
 
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: d.Cap,
@@ -310,6 +312,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 
 // DeleteSnapshot delete a snapshot (todo)
 func (d *Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+	klog.V(2).Infof("DeleteSnapshot: called with args %+v", *req)
 	if len(req.SnapshotId) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Snapshot ID must be provided")
 	}
@@ -346,6 +349,7 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 
 // ControllerExpandVolume controller expand volume
 func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+	klog.V(2).Infof("ControllerExpandVolume: called with args %+v", *req)
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID missing in request")
 	}
@@ -358,6 +362,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 		return nil, err
 	}
 
+	klog.V(2).Infof("ControllerExpandVolume(%s) successfully, currentQuota: %d", req.VolumeId, currentQuota)
 	return &csi.ControllerExpandVolumeResponse{CapacityBytes: currentQuota}, nil
 }
 

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -40,6 +40,7 @@ import (
 
 // NodePublishVolume mount the volume from staging to target path
 func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	klog.V(2).Infof("NodePublishVolume called with request %v", *req)
 	if req.GetVolumeCapability() == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume capability missing in request")
 	}
@@ -110,6 +111,7 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 
 // NodeStageVolume mount the volume to a staging path
 func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	klog.V(2).Infof("NodeStageVolume called with request %v", *req)
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID missing in request")
 	}
@@ -267,8 +269,7 @@ func (d *Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolu
 
 // NodeGetCapabilities return the capabilities of the Node plugin
 func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	klog.V(2).Infof("Using default NodeGetCapabilities")
-
+	klog.V(2).Infof("NodeGetCapabilities called with request %v", *req)
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: d.NSCap,
 	}, nil
@@ -276,8 +277,7 @@ func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabi
 
 // NodeGetInfo return info of the node on which this plugin is running
 func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	klog.V(5).Infof("Using default NodeGetInfo")
-
+	klog.V(2).Infof("NodeGetInfo called with request %v", *req)
 	return &csi.NodeGetInfoResponse{
 		NodeId: d.NodeID,
 	}, nil

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM mcr.microsoft.com/aks/fundamental/base-ubuntu:v0.0.5
-RUN apt-get update && apt-get install -y ca-certificates cifs-utils
+RUN apt-get update && apt-get install -y ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"
 

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			CSIDriver:              testDriver,
 			Pods:                   pods,
 			ColocatePods:           true,
-			StorageClassParameters: map[string]string{"skuName": "Standard_ZRS"},
+			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
 		}
 		test.Run(cs, ns)
 	})
@@ -249,7 +249,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "Premium_ZRS"},
+			StorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
 		}
 		test.Run(cs, ns)
 	})

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -345,7 +345,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test := testsuites.DynamicallyProvisionedReadOnlyVolumeTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "Premium_GRS", "fsType": "ext3"},
+			StorageClassParameters: map[string]string{"skuName": "Premium_LRS", "fsType": "ext3"},
 		}
 		test.Run(cs, ns)
 	})

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			CSIDriver:              testDriver,
 			Pods:                   pods,
 			ColocatePods:           true,
-			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
+			StorageClassParameters: map[string]string{"skuName": "Standard_LRS", "fsType": "cifs"},
 		}
 		test.Run(cs, ns)
 	})
@@ -249,18 +249,21 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
+			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
 		}
 		test.Run(cs, ns)
 	})
 
 	ginkgo.It(fmt.Sprintf("should create a vhd disk volume on demand [kubernetes.io/azurefile] [file.csi.azure.com][disk]"), func() {
+		if testDriver.IsInTree() {
+			ginkgo.Skip("Test running with in tree configuration. Skip the ")
+		}
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
 				Volumes: []testsuites.VolumeDetails{
 					{
-						ClaimSize: "10Gi",
+						ClaimSize: "1024Gi", // test with big size
 						VolumeMount: testsuites.VolumeMountDetails{
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
@@ -272,12 +275,15 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
 			CSIDriver:              testDriver,
 			Pods:                   pods,
-			StorageClassParameters: map[string]string{"skuName": "Premium_LRS", "fsType": "ext4"},
+			StorageClassParameters: map[string]string{"skuName": "Standard_LRS", "fsType": "ext4"},
 		}
 		test.Run(cs, ns)
 	})
 
 	ginkgo.It("should create multiple PV objects, bind to PVCs and attach all to different pods on the same node [kubernetes.io/azurefile] [file.csi.azure.com][disk]", func() {
+		if testDriver.IsInTree() {
+			ginkgo.Skip("Test running with in tree configuration. Skip the ")
+		}
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "while true; do echo $(date -u) >> /mnt/test-1/data; sleep 1; done",
@@ -310,7 +316,80 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			CSIDriver:              testDriver,
 			Pods:                   pods,
 			ColocatePods:           true,
-			StorageClassParameters: map[string]string{"skuName": "Standard_LRS", "fsType": "xfs"},
+			StorageClassParameters: map[string]string{"skuName": "Premium_LRS", "fsType": "xfs"},
+		}
+		test.Run(cs, ns)
+	})
+
+	// Track issue https://github.com/kubernetes/kubernetes/issues/70505
+	ginkgo.It("should create a vhd disk volume on demand and mount it as readOnly in a pod [kubernetes.io/azurefile] [file.csi.azure.com][disk]", func() {
+		if testDriver.IsInTree() {
+			ginkgo.Skip("Test running with in tree configuration. Skip the ")
+		}
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "touch /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						FSType:    "ext4",
+						ClaimSize: "10Gi",
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+							ReadOnly:          true,
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedReadOnlyVolumeTest{
+			CSIDriver:              testDriver,
+			Pods:                   pods,
+			StorageClassParameters: map[string]string{"skuName": "Premium_GRS", "fsType": "ext3"},
+		}
+		test.Run(cs, ns)
+	})
+
+	ginkgo.It(fmt.Sprintf("should delete PV with reclaimPolicy %q [kubernetes.io/azurefile] [file.csi.azure.com] [disk]", v1.PersistentVolumeReclaimDelete), func() {
+		if testDriver.IsInTree() {
+			ginkgo.Skip("Test running with in tree configuration. Skip the ")
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		volumes := []testsuites.VolumeDetails{
+			{
+				FSType:        "ext4",
+				ClaimSize:     "10Gi",
+				ReclaimPolicy: &reclaimPolicy,
+			},
+		}
+		test := testsuites.DynamicallyProvisionedReclaimPolicyTest{
+			CSIDriver:              testDriver,
+			Volumes:                volumes,
+			StorageClassParameters: map[string]string{"skuName": "Standard_RAGRS", "fsType": "ext2"},
+		}
+		test.Run(cs, ns)
+	})
+
+	ginkgo.It(fmt.Sprintf("[env] should retain PV with reclaimPolicy %q [file.csi.azure.com] [disk]", v1.PersistentVolumeReclaimRetain), func() {
+		// This tests uses the CSI driver to delete the PV.
+		// TODO: Go via the k8s interfaces and also make it more reliable for in-tree and then
+		//       test can be enabled.
+		if testDriver.IsInTree() {
+			ginkgo.Skip("Test running with in tree configuration. Skip the ")
+		}
+		reclaimPolicy := v1.PersistentVolumeReclaimRetain
+		volumes := []testsuites.VolumeDetails{
+			{
+				FSType:        "ext4",
+				ClaimSize:     "10Gi",
+				ReclaimPolicy: &reclaimPolicy,
+			},
+		}
+		test := testsuites.DynamicallyProvisionedReclaimPolicyTest{
+			CSIDriver:              testDriver,
+			Volumes:                volumes,
+			Azurefile:              azurefileDriver,
+			StorageClassParameters: map[string]string{"skuName": "Premium_LRS", "fsType": "xfs"},
 		}
 		test.Run(cs, ns)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR would fix following issue(only appears in e2e test):
```
16:52:17.604694       1 controllerserver.go:129] begin to create vhd file(d6907ac4-5fca-11ea-b40e-000d3a0fbba7.vhd) size(10737418240) on share(pvc-559ddcc8-fcfd-41a4-8dc8-41bf3235e72d) on account() type(Premium_LRS) rg() location()
16:52:17.715770       1 azure_file.go:71] file share(pvc-559ddcc8-fcfd-41a4-8dc8-41bf3235e72d) under account(fc3ed76b6256c43ea871fa6) already exists
16:52:17.715795       1 azure_storage.go:52] created share pvc-559ddcc8-fcfd-41a4-8dc8-41bf3235e72d in account fc3ed76b6256c43ea871fa6
16:52:17.715806       1 controllerserver.go:120] create file share pvc-559ddcc8-fcfd-41a4-8dc8-41bf3235e72d on storage account fc3ed76b6256c43ea871fa6 successfully
16:52:17.718411       1 controllerserver.go:129] begin to create vhd file(d6a1d4fd-5fca-11ea-b40e-000d3a0fbba7.vhd) size(10737418240) on share(pvc-559ddcc8-fcfd-41a4-8dc8-41bf3235e72d) on account() type(Premium_LRS) rg() location()
[pod/csi-azurefile-controller-5675677f7c-qzfd8/azurefile] E0306 16:52:17.718953       1 utils.go:116] GRPC error: rpc error: code = Internal desc = failed to create VHD disk: -> github.com/Azure/azure-pipeline-go/pipeline.NewError, /home/prow/go/pkg/mod/github.com/!azure/azure-pipeline-go@v0.2.1/pipeline/error.go:154
[pod/csi-azurefile-controller-5675677f7c-qzfd8/azurefile] HTTP request failed
[pod/csi-azurefile-controller-5675677f7c-qzfd8/azurefile] 
[pod/csi-azurefile-controller-5675677f7c-qzfd8/azurefile] Put https://fc3ed76b6256c43ea871fa6.file.core.windows.net/pvc-559ddcc8-fcfd-41a4-8dc8-41bf3235e72d/d6a1d4fd-5fca-11ea-b40e-000d3a0fbba7.vhd?timeout=1: context canceled
16:52:17.720933       1 controllerserver.go:134] create vhd file(d6907ac4-5fca-11ea-b40e-000d3a0fbba7.vhd) size(10737418240) on share(pvc-559ddcc8-fcfd-41a4-8dc8-41bf3235e72d) on account() type(Premium_LRS) rg() location() successfully
16:52:17.720952       1 utils.go:118] GRPC response: volume:<capacity_bytes:10737418240 volume_id:"#fc3ed76b6256c43ea871fa6#pvc-559ddcc8-fcfd-41a4-8dc8-41bf3235e72d" volume_context:<key:"diskname" value:"d6907ac4-5fca-11ea-b40e-000d3a0fbba7.vhd" > volume_context:<key:"fsType" value:"ext4" > volume_context:<key:"skuName" value:"Premium_LRS" > > 
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```
