### PR TITLE
fix: set vhd name as fileshare name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Please refer to [install azurefile csi driver](https://github.com/kubernetes-sig
 
 ### Examples
  - [Basic usage](./deploy/example/e2e_usage.md)
- - [Snapshot(alpha)](./deploy/example/snapshot)
- - [Fast attach disk(alpha)](./deploy/example/disk)
+ - [Snapshot](./deploy/example/snapshot)
+ - [Fast attach disk](./deploy/example/disk)
 
 ## Kubernetes Development
 Please refer to [development guide](./docs/csi-dev.md)

--- a/deploy/example/disk/README.md
+++ b/deploy/example/disk/README.md
@@ -82,23 +82,19 @@ Filesystem      Size  Used Avail Use% Mounted on
 ```
 In the above example, there is a `/mnt/azurefile` directory mounted as ext4 filesystem.
 
-#### Example#2. create 10 pods with vhd disk mount in parallel
+#### Example#2. create 5 pods with vhd disk mount in parallel
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/deploy/example/disk/statefulset-stress.yaml
 ```
+> note: create multiple vhd disks in parallel in one storage account may cause IO throttling, user could set `storageAccount` to specify different storage accounts for different vhd disks
 
- - output
-```console
-# kubectl get po
-NAME                      READY   STATUS    RESTARTS   AGE
-statefulset-azurefile-0   1/1     Running   0          2m14s
-statefulset-azurefile-1   1/1     Running   0          2m14s
-statefulset-azurefile-2   1/1     Running   0          2m14s
-statefulset-azurefile-3   1/1     Running   0          2m14s
-statefulset-azurefile-4   1/1     Running   0          2m14s
-statefulset-azurefile-5   1/1     Running   0          2m14s
-statefulset-azurefile-6   1/1     Running   0          2m14s
-statefulset-azurefile-7   1/1     Running   0          2m14s
-statefulset-azurefile-8   1/1     Running   0          2m14s
-statefulset-azurefile-9   1/1     Running   0          2m14s
 ```
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: file.csi.azure.com
+provisioner: file.csi.azure.com
+parameters:
+  storageAccount: EXISTING_STORAGE_ACCOUNT_NAME
+  fsType: ext4  # available values: ext4, ext3, ext2, xfs
+---

--- a/deploy/example/disk/statefulset-stress.yaml
+++ b/deploy/example/disk/statefulset-stress.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   podManagementPolicy: Parallel  # OrderedReady
   serviceName: statefulset-azurefile
-  replicas: 10
+  replicas: 5
   template:
     metadata:
       labels:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
set vhd name as file share name
Sometimes create vhd disk retuened failure while vhd disk was created successfully, in such condition, azure file share is already occupied by the original vhd disk file and new vhd disk creation would fail:

```
I0312 02:49:06.599846       1 azure_storageaccount.go:106] found a matching account fb849da22ea8841d2865b11 type Premium_LRS location southeastasia
I0312 02:49:06.644905       1 azure_file.go:71] file share(pvc-3a29cb90-6370-4650-a313-313129787bc5) under account(fb849da22ea8841d2865b11) already exists
I0312 02:49:06.644922       1 azure_storage.go:52] created share pvc-3a29cb90-6370-4650-a313-313129787bc5 in account fb849da22ea8841d2865b11
I0312 02:49:06.644931       1 controllerserver.go:130] create file share pvc-3a29cb90-6370-4650-a313-313129787bc5 on storage account fb849da22ea8841d2865b11 successfully
I0312 02:49:06.646963       1 controllerserver.go:140] begin to create vhd file(0a7b74a5-640c-11ea-a275-000d3ac83b36.vhd) size(107374182400) on share(pvc-3a29cb90-6370-4650-a313-313129787bc5) on account() type(Premium_LRS) rg() location()
E0312 02:49:07.862798       1 utils.go:116] GRPC error: rpc error: code = Internal desc = failed to create VHD disk: -> github.com/Azure/azure-pipeline-go/pipeline.NewError, /root/go/pkg/mod/github.com/!azure/azure-pipeline-go@v0.2.1/pipeline/error.go:154
HTTP request failed

Put https://fb849da22ea8841d2865b11.file.core.windows.net/pvc-3a29cb90-6370-4650-a313-313129787bc5/0a7b74a5-640c-11ea-a275-000d3ac83b36.vhd?comp=range&timeout=1: context deadline exceeded
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```
