### PR TITLE
feat: support read cloud config from secret

### DIFF
--- a/charts/latest/azurefile-csi-driver/templates/rbac-csi-azurefile-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/rbac-csi-azurefile-controller.yaml
@@ -211,4 +211,33 @@ roleRef:
   kind: ClusterRole
   name: azurefile-external-resizer-role
   apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: azure-cloud-provider-secret-getter
+  namespace: {{ .Release.Namespace }}
+{{ include "azurefile.labels" . | indent 2 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["azure-cloud-provider"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: azure-cloud-provider-secret-getter
+  namespace: {{ .Release.Namespace }}
+{{ include "azurefile.labels" . | indent 2 }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-azurefile-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: azure-cloud-provider-secret-getter
 {{ end }}

--- a/deploy/rbac-csi-azurefile-controller.yaml
+++ b/deploy/rbac-csi-azurefile-controller.yaml
@@ -202,3 +202,30 @@ roleRef:
   kind: ClusterRole
   name: azurefile-external-resizer-role
   apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: azure-cloud-provider-secret-getter
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["azure-cloud-provider"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: azure-cloud-provider-secret-getter
+subjects:
+  - kind: ServiceAccount
+    name: csi-azurefile-controller-sa
+    namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: azure-cloud-provider-secret-getter
+
+---


### PR DESCRIPTION
fix yamllint error

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: support read cloud config from secret
This PR is to support Setting Azure cloud provider from Kubernetes secrets:
Since `v1.15.0`, Azure cloud provider supports reading the cloud config from Kubernetes secrets. The secret is a serialized version of `azure.json` file with key cloud-config. The secret should be put in `kube-system` namespace and its name should be `azure-cloud-provider`.

details:
https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/docs/cloud-provider-config.md#setting-azure-cloud-provider-from-kubernetes-secrets

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #223

**Special notes for your reviewer**:
cc @feiskyer 

**Release note**:
```
feat: support read cloud config from secret
```
