### PR TITLE
chore: add linux.enabled parameter to helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,9 @@ ifdef TEST_WINDOWS
 	helm install azurefile-csi-driver charts/latest/azurefile-csi-driver --namespace kube-system --wait --timeout=15m -v=5 --debug \
 		--set image.azurefile.repository=$(REGISTRY)/$(IMAGE_NAME) \
 		--set image.azurefile.tag=$(IMAGE_VERSION) \
-		--set controller.replicas=1 \
-		--set windows.enabled=true
+		--set windows.enabled=true \
+		--set linux.enabled=false \
+		--set controller.replicas=1
 else
 	helm install azurefile-csi-driver charts/latest/azurefile-csi-driver --namespace kube-system --wait --timeout=15m -v=5 --debug \
 		--set image.azurefile.repository=$(REGISTRY)/$(IMAGE_NAME) \

--- a/charts/README.md
+++ b/charts/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the latest Azure File C
 | `serviceAccount.create`                           | whether create service account of csi-azurefile-controller  | true                                                              |
 | `rbac.create`                                     | whether create rbac of csi-azurefile-controller             | true                                                              |
 | `controller.replicas`                             | the replicas of csi-azurefile-controller                    | 2                                                                 |
+| `linux.enabled`                                   | whether enable linux feature                               | true                                                              |
 | `windows.enabled`                                 | whether enable windows feature                             | false                                                             |
 | `windows.image.livenessProbe.repository`          | windows liveness-probe docker image                        | mcr.microsoft.com/oss/kubernetes-csi/livenessprobe                |
 | `windows.image.livenessProbe.tag`                 | windows liveness-probe docker image tag                    | v2.0.1-alpha.1-windows-1809-amd64                                 |

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.windows.enabled false }}
+{{- if .Values.linux.enabled}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/charts/latest/azurefile-csi-driver/values.yaml
+++ b/charts/latest/azurefile-csi-driver/values.yaml
@@ -37,6 +37,9 @@ rbac:
 controller:
   replicas: 2
 
+linux:
+  enabled: true
+
 windows:
   enabled: false
   image:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

We should be able to deploy both Linux and Windows version of csi-azurefile-node via helm chart to clusters containing both Windows and Linux nodes

/assign @andyzhangx 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```
