### PR TITLE
Remove deprecated csi-provisioner args

### DIFF
--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -29,9 +29,7 @@ spec:
           image: "{{ .Values.image.csiProvisioner.repository }}:{{ .Values.image.csiProvisioner.tag }}"
           args:
             - "-v=5"
-            - "--provisioner=file.csi.azure.com"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
           env:

--- a/charts/v0.4.0/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/v0.4.0/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -23,9 +23,7 @@ spec:
           image: "{{ .Values.image.csiProvisioner.repository }}:{{ .Values.image.csiProvisioner.tag }}"
           args:
             - "-v=5"
-            - "--provisioner=file.csi.azure.com"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
           env:

--- a/charts/v0.5.0/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/v0.5.0/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -29,9 +29,7 @@ spec:
           image: "{{ .Values.image.csiProvisioner.repository }}:{{ .Values.image.csiProvisioner.tag }}"
           args:
             - "-v=5"
-            - "--provisioner=file.csi.azure.com"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
           env:

--- a/charts/v0.6.0/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/v0.6.0/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -29,9 +29,7 @@ spec:
           image: "{{ .Values.image.csiProvisioner.repository }}:{{ .Values.image.csiProvisioner.tag }}"
           args:
             - "-v=5"
-            - "--provisioner=file.csi.azure.com"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
           env:

--- a/deploy/csi-azurefile-controller.yaml
+++ b/deploy/csi-azurefile-controller.yaml
@@ -29,9 +29,7 @@ spec:
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
           args:
             - "-v=5"
-            - "--provisioner=file.csi.azure.com"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
           env:

--- a/deploy/v0.4.0/csi-azurefile-controller.yaml
+++ b/deploy/v0.4.0/csi-azurefile-controller.yaml
@@ -23,9 +23,7 @@ spec:
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
           args:
             - "-v=5"
-            - "--provisioner=file.csi.azure.com"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
           env:

--- a/deploy/v0.5.0/csi-azurefile-controller.yaml
+++ b/deploy/v0.5.0/csi-azurefile-controller.yaml
@@ -29,9 +29,7 @@ spec:
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
           args:
             - "-v=5"
-            - "--provisioner=file.csi.azure.com"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
           env:

--- a/deploy/v0.6.0/csi-azurefile-controller.yaml
+++ b/deploy/v0.6.0/csi-azurefile-controller.yaml
@@ -29,9 +29,7 @@ spec:
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
           args:
             - "-v=5"
-            - "--provisioner=file.csi.azure.com"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
           env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`--provisioner` and `--connection-timeout` flags are deprecated and have no effect since v1.1.0 of csi-provisioner. Ref https://github.com/kubernetes-csi/external-provisioner/blob/v1.6.0/CHANGELOG-1.1.md

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
