### PR TITLE
test: fix windows e2e test failure

### DIFF
--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -350,7 +350,7 @@ func NewTestDeployment(c clientset.Interface, ns *v1.Namespace, command string, 
 		testDeployment.deployment.Spec.Template.Spec.NodeSelector = map[string]string{
 			"kubernetes.io/os": "windows",
 		}
-		testDeployment.deployment.Spec.Template.Spec.Containers[0].Image = "e2eteam/busybox:1.29"
+		testDeployment.deployment.Spec.Template.Spec.Containers[0].Image = "mcr.microsoft.com/dotnet/framework/samples:aspnetapp"
 		testDeployment.deployment.Spec.Template.Spec.Containers[0].Command = []string{"powershell.exe"}
 		testDeployment.deployment.Spec.Template.Spec.Containers[0].Args = []string{command}
 	}
@@ -452,7 +452,7 @@ func NewTestPod(c clientset.Interface, ns *v1.Namespace, command string, isWindo
 		testPod.pod.Spec.NodeSelector = map[string]string{
 			"kubernetes.io/os": "windows",
 		}
-		testPod.pod.Spec.Containers[0].Image = "e2eteam/busybox:1.29"
+		testPod.pod.Spec.Containers[0].Image = "mcr.microsoft.com/dotnet/framework/samples:aspnetapp"
 		testPod.pod.Spec.Containers[0].Command = []string{"powershell.exe"}
 		testPod.pod.Spec.Containers[0].Args = []string{command}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
fix windows e2e test failure, this is just a workaround since `mcr.microsoft.com/dotnet/framework/samples:aspnetapp` is 1.9GB, too large


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```
