### PR TITLE
feat: install kernel 5.3.0-1020-azure

### DIFF
--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM mcr.microsoft.com/aks/fundamental/base-ubuntu:v0.0.5
-RUN apt-get update && apt-get install -y ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
+RUN apt-get update && apt-get install -y linux-image-5.3.0-1020-azure ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: install kernel 5.3.0-1020-azure to include some imporant SMB fixes


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```
Fetched 25.2 MB in 0s (57.2 MB/s)
Selecting previously unselected package dmsetup.
(Reading database ... 8721 files and directories currently installed.)
Preparing to unpack .../00-dmsetup_2%3a1.02.145-4.1ubuntu3.18.04.2_amd64.deb ...
Unpacking dmsetup (2:1.02.145-4.1ubuntu3.18.04.2) ...
Preparing to unpack .../01-libkmod2_24-1ubuntu3.3_amd64.deb ...
Unpacking libkmod2:amd64 (24-1ubuntu3.3) over (24-1ubuntu3.2) ...
Selecting previously unselected package kmod.
Preparing to unpack .../02-kmod_24-1ubuntu3.3_amd64.deb ...
Unpacking kmod (24-1ubuntu3.3) ...
Selecting previously unselected package linux-base.
Preparing to unpack .../03-linux-base_4.5ubuntu1.1_all.deb ...
Unpacking linux-base (4.5ubuntu1.1) ...
Selecting previously unselected package gettext-base.
Preparing to unpack .../04-gettext-base_0.19.8.1-6ubuntu0.3_amd64.deb ...
Unpacking gettext-base (0.19.8.1-6ubuntu0.3) ...
Selecting previously unselected package libpng16-16:amd64.
Preparing to unpack .../05-libpng16-16_1.6.34-1ubuntu0.18.04.2_amd64.deb ...
Unpacking libpng16-16:amd64 (1.6.34-1ubuntu0.18.04.2) ...
Selecting previously unselected package libfreetype6:amd64.
Preparing to unpack .../06-libfreetype6_2.8.1-2ubuntu2_amd64.deb ...
Unpacking libfreetype6:amd64 (2.8.1-2ubuntu2) ...
Selecting previously unselected package grub-common.
Preparing to unpack .../07-grub-common_2.02-2ubuntu8.15_amd64.deb ...
Unpacking grub-common (2.02-2ubuntu8.15) ...
Selecting previously unselected package grub2-common.
Preparing to unpack .../08-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
Unpacking grub2-common (2.02-2ubuntu8.15) ...
Selecting previously unselected package grub-pc-bin.
Preparing to unpack .../09-grub-pc-bin_2.02-2ubuntu8.15_amd64.deb ...
Unpacking grub-pc-bin (2.02-2ubuntu8.15) ...
Selecting previously unselected package grub-pc.
Preparing to unpack .../10-grub-pc_2.02-2ubuntu8.15_amd64.deb ...
Unpacking grub-pc (2.02-2ubuntu8.15) ...
Selecting previously unselected package grub-gfxpayload-lists.
Preparing to unpack .../11-grub-gfxpayload-lists_0.7_amd64.deb ...
Unpacking grub-gfxpayload-lists (0.7) ...
Selecting previously unselected package linux-base-sgx.
Preparing to unpack .../12-linux-base-sgx_4.5ubuntu1.1_all.deb ...
Unpacking linux-base-sgx (4.5ubuntu1.1) ...
Selecting previously unselected package linux-modules-5.3.0-1020-azure.
Preparing to unpack .../13-linux-modules-5.3.0-1020-azure_5.3.0-1020.21~18.04.1_amd64.deb ...
Unpacking linux-modules-5.3.0-1020-azure (5.3.0-1020.21~18.04.1) ...
Selecting previously unselected package linux-image-5.3.0-1020-azure.
Preparing to unpack .../14-linux-image-5.3.0-1020-azure_5.3.0-1020.21~18.04.1_amd64.deb ...
Unpacking linux-image-5.3.0-1020-azure (5.3.0-1020.21~18.04.1) ...
Selecting previously unselected package os-prober.
Preparing to unpack .../15-os-prober_1.74ubuntu1_amd64.deb ...
Unpacking os-prober (1.74ubuntu1) ...
Setting up libpng16-16:amd64 (1.6.34-1ubuntu0.18.04.2) ...
Setting up linux-base-sgx (4.5ubuntu1.1) ...
Setting up linux-base (4.5ubuntu1.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.26.1 /usr/local/share/perl/5.26.1 /usr/lib/x86_64-linux-gnu/perl5/5.26 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.26 /usr/share/perl/5.26 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up gettext-base (0.19.8.1-6ubuntu0.3) ...
Setting up libkmod2:amd64 (24-1ubuntu3.3) ...
Setting up libfreetype6:amd64 (2.8.1-2ubuntu2) ...
Setting up grub-common (2.02-2ubuntu8.15) ...
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Setting up dmsetup (2:1.02.145-4.1ubuntu3.18.04.2) ...
Setting up linux-modules-5.3.0-1020-azure (5.3.0-1020.21~18.04.1) ...
Setting up kmod (24-1ubuntu3.3) ...
Setting up grub-pc-bin (2.02-2ubuntu8.15) ...
Setting up grub2-common (2.02-2ubuntu8.15) ...
Setting up os-prober (1.74ubuntu1) ...
Setting up linux-image-5.3.0-1020-azure (5.3.0-1020.21~18.04.1) ...
I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.3.0-1020-azure
I: /initrd.img.old is now a symlink to boot/initrd.img-5.3.0-1020-azure
I: /vmlinuz is now a symlink to boot/vmlinuz-5.3.0-1020-azure
I: /initrd.img is now a symlink to boot/initrd.img-5.3.0-1020-azure
Setting up grub-pc (2.02-2ubuntu8.15) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.26.1 /usr/local/share/perl/5.26.1 /usr/lib/x86_64-linux-gnu/perl5/5.26 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.26 /usr/share/perl/5.26 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype

Creating config file /etc/default/grub with new version
Setting up grub-gfxpayload-lists (0.7) ...
Processing triggers for libc-bin (2.27-3ubuntu1) ...
Processing triggers for systemd (237-3ubuntu10.31) ...
Processing triggers for linux-image-5.3.0-1020-azure (5.3.0-1020.21~18.04.1) ...
Removing intermediate container c36bdf332ef6
 ---> 0f4491c09a62
Step 4/7 : LABEL maintainers="andyzhangx"
 ---> Running in e8ba6d894bab
Removing intermediate container e8ba6d894bab
 ---> 09138a33696e
Step 5/7 : LABEL description="AzureFile CSI Driver"
 ---> Running in 091ece813b35
Removing intermediate container 091ece813b35
 ---> 6104363b571d
Step 6/7 : COPY ./_output/azurefileplugin /azurefileplugin
 ---> 6c877246b54d
Step 7/7 : ENTRYPOINT ["/azurefileplugin"]
 ---> Running in 975c7cc8199a
Removing intermediate container 975c7cc8199a
 ---> e988d8216d76
Successfully built e988d8216d76

```

 - `apt-get install --install-recommends linux-generic-hwe-18.04 -y` won't work in CI test
```
-RUN apt-get install --install-recommends linux-generic-hwe-18.04 -y
+RUN apt install linux-image-5.3.0-1020-azure -y
```

```
Setting up shared-mime-info (1.9-2) ...
Setting up initramfs-tools-bin (0.130ubuntu3.9) ...
ERROR: The command failed with an unexpected error. Here is the traceback:

ERROR: 'ascii' codec can't encode character u'\u2192' in position 1402: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/knack/cli.py", line 206, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/local/lib/python2.7/dist-packages/azure/cli/core/commands/__init__.py", line 608, in execute
    raise ex
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2192' in position 1402: ordinal not in range(128)
WARNING: 
```

**Release note**:
```
feat: install kernel 5.3.0-1020-azure
```
