### PR TITLE
chore(dockerfile/makefile): Update build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,16 @@ container:
 azurefile-container:
 ifdef CI
 	az acr login --name $(REGISTRY_NAME)
-	make azurefile azurefile-windows
-	az acr build --registry $(REGISTRY_NAME) -t $(IMAGE_TAG)-linux-amd64 -f ./pkg/azurefileplugin/Dockerfile --platform linux .
-	az acr build --registry $(REGISTRY_NAME) -t $(IMAGE_TAG)-windows-1809-amd64 -f ./pkg/azurefileplugin/Windows.Dockerfile --platform windows .
+	# make azurefile azurefile-windows
+	# az acr build --registry $(REGISTRY_NAME) -t $(IMAGE_TAG)-linux-amd64 -f ./pkg/azurefileplugin/Dockerfile --platform linux .
+	# az acr build --registry $(REGISTRY_NAME) -t $(IMAGE_TAG)-windows-1809-amd64 -f ./pkg/azurefileplugin/Windows.Dockerfile --platform windows .
+
+	docker buildx rm container-builder || true
+	docker buildx create --use --name=container-builder
+	docker buildx build --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG)-linux-amd64 -f ./pkg/azurefileplugin/Dockerfile --platform="linux/amd64" --push .
+	make azuredisk-windows
+	docker buildx build  -t $(IMAGE_TAG)-windows-1809-amd64 -f ./pkg/azurefileplugin/Windows.Dockerfile --platform="windows/amd64" --push .
+
 	docker manifest create $(IMAGE_TAG) $(IMAGE_TAG)-linux-amd64 $(IMAGE_TAG)-windows-1809-amd64
 	docker manifest inspect $(IMAGE_TAG)
 else

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ ifdef CI
 	docker buildx rm container-builder || true
 	docker buildx create --use --name=container-builder
 	docker buildx build --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG)-linux-amd64 -f ./pkg/azurefileplugin/Dockerfile --platform="linux/amd64" --push .
-	make azuredisk-windows
+	make azurefile-windows
 	docker buildx build  -t $(IMAGE_TAG)-windows-1809-amd64 -f ./pkg/azurefileplugin/Windows.Dockerfile --platform="windows/amd64" --push .
 
 	docker manifest create $(IMAGE_TAG) $(IMAGE_TAG)-linux-amd64 $(IMAGE_TAG)-windows-1809-amd64

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ azurefile-windows:
 	CGO_ENABLED=0 GOOS=windows go build -a -ldflags ${LDFLAGS} -o _output/azurefileplugin.exe ./pkg/azurefileplugin
 
 .PHONY: container	
-container: azurefile	
-	docker build --no-cache -t $(IMAGE_TAG) -f ./pkg/azurefileplugin/Dockerfile .
+container:	
+	docker build --no-cache --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE_TAG) -f ./pkg/azurefileplugin/Dockerfile .
 
 .PHONY: azurefile-container
 azurefile-container:

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "${LDFLAGS:--X sigs.k8s.io/azu
 
 FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0
 COPY --from=builder /go/src/sigs.k8s.io/azurefile-csi-driver/_output/azurefileplugin /azurefileplugin
-RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
+RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
 
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/aks/fundamental/base-ubuntu:v0.0.5
-RUN apt-get update && apt-get install -y ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
+FROM golang:1.13.10-alpine3.10 as builder
+WORKDIR /go/src/sigs.k8s.io/azurefile-csi-driver
+ADD . .
+ARG LDFLAGS
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "${LDFLAGS:--X sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.driverVersion=latest}" -o _output/azurefileplugin ./pkg/azurefileplugin
+
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0
+COPY --from=builder /go/src/sigs.k8s.io/azurefile-csi-driver/_output/azurefileplugin /azurefileplugin
+RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
+
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"
 
-COPY ./_output/azurefileplugin /azurefileplugin
 ENTRYPOINT ["/azurefileplugin"]

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -15,8 +15,10 @@
 FROM golang:1.13.10-alpine3.10 as builder
 WORKDIR /go/src/sigs.k8s.io/azurefile-csi-driver
 ADD . .
+ARG TARGETARCH
+ARG TARGETOS
 ARG LDFLAGS
-RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "${LDFLAGS:--X sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.driverVersion=latest}" -o _output/azurefileplugin ./pkg/azurefileplugin
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS:--X sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.driverVersion=latest}" -o _output/azurefileplugin ./pkg/azurefileplugin
 
 FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0
 COPY --from=builder /go/src/sigs.k8s.io/azurefile-csi-driver/_output/azurefileplugin /azurefileplugin

--- a/pkg/azurefileplugin/Windows.Dockerfile
+++ b/pkg/azurefileplugin/Windows.Dockerfile
@@ -1,9 +1,17 @@
+FROM --platform=$BUILDPLATFORM golang:1.13.10-alpine3.10 as builder
+WORKDIR /go/src/sigs.k8s.io/azurefile-csi-driver
+ADD . .
+ARG TARGETARCH
+ARG TARGETOS
+ARG LDFLAGS
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS:--X sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.driverVersion=latest}" -o _output/azurefileplugin.exe ./pkg/azurefileplugin
+
 FROM mcr.microsoft.com/windows/servercore:1809 as core
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
 LABEL description="CSI Azure file plugin"
 
-COPY ./_output/azurefileplugin.exe /azurefileplugin.exe
+COPY --from=builder /go/src/sigs.k8s.io/azurefile-csi-driver/_output/azurefileplugin.exe /azurefileplugin.exe
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 USER ContainerAdministrator
 ENTRYPOINT ["/azurefileplugin.exe"]


### PR DESCRIPTION
* Use debian-base:v2.1.0
* Build linux binary in container when running make container
* Build both linux/windows container images using buildx instead of acr build tasks.

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Changes the base image to debian-base:v2.1.0 which is more in line with upstream work. Also builds the linux binary in a builder container and then copies it to the main container. This workflow is more idiomatic. This also changes the workflow for building the windows container to use buildx instead of relying on acr.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```
