### PR TITLE
feat: use `azure-cred-file` configmap in `kube-system` namespace to specify azure-cred-file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ Please refer to [`file.csi.azure.com` driver parameters](./docs/driver-parameter
  > storage class `file.csi.azure.com` parameters are compatible with built-in [azurefile](https://kubernetes.io/docs/concepts/storage/volumes/#azurefile) plugin
 
 ### Prerequisite
- - The driver initialization depends on a [Cloud provider config file](https://github.com/kubernetes/cloud-provider-azure/blob/master/docs/cloud-provider-config.md), usually it's `/etc/kubernetes/azure.json` on all kubernetes nodes deployed by [AKS](https://docs.microsoft.com/en-us/azure/aks/) or [aks-engine](https://github.com/Azure/aks-engine), here is an [azure.json example](./deploy/example/azure.json). This driver also supports [read cloud config from kuberenetes secret](./docs/read-from-secret.md).
- > if cluster identity is [Managed Service Identity(MSI)](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity), make sure user assigned identity has `Contributor` role on node resource group
+ - The driver depends on [cloud provider config file](https://github.com/kubernetes/cloud-provider-azure/blob/master/docs/cloud-provider-config.md), usually it's `/etc/kubernetes/azure.json` on all kubernetes nodes deployed by [AKS](https://docs.microsoft.com/en-us/azure/aks/) or [aks-engine](https://github.com/Azure/aks-engine), here is [azure.json example](./deploy/example/azure.json).
+ > To specify a different cloud provider config file, create `azure-cred-file` configmap before driver installation, e.g. for OpenShift, it's `/etc/kubernetes/cloud.conf`
+ > ```console
+ > kubectl create configmap azure-cred-file --from-literal=path="/etc/kubernetes/cloud.conf" --from-literal=path-windows="C:\\k\\cloud.conf" -n kube-system
+ > ```
+ - This driver also supports [read cloud config from kuberenetes secret](./docs/read-from-secret.md).
+ - If cluster identity is [Managed Service Identity(MSI)](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity), make sure user assigned identity has `Contributor` role on node resource group
 
 ### Install azurefile CSI driver on a kubernetes cluster
 Please refer to [install azurefile csi driver](https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/install-azurefile-csi-driver.md)

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -147,7 +147,11 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: "/etc/kubernetes/azure.json"
+              valueFrom:
+                configMapKeyRef:
+                  name: azure-cred-file
+                  key: path
+                  optional: true
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
           imagePullPolicy: {{ .Values.image.azurefile.pullPolicy }}

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node-windows.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node-windows.yaml
@@ -90,7 +90,11 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: "C:\\k\\azure.json"
+              valueFrom:
+                configMapKeyRef:
+                  name: azure-cred-file
+                  key: path-windows
+                  optional: true
             - name: CSI_ENDPOINT
               value: unix://C:\\csi\\csi.sock
             - name: KUBE_NODE_NAME

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
@@ -89,7 +89,11 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: "/etc/kubernetes/azure.json"
+              valueFrom:
+                configMapKeyRef:
+                  name: azure-cred-file
+                  key: path
+                  optional: true
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: KUBE_NODE_NAME

--- a/deploy/csi-azurefile-controller.yaml
+++ b/deploy/csi-azurefile-controller.yaml
@@ -142,7 +142,11 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: "/etc/kubernetes/azure.json"
+              valueFrom:
+                configMapKeyRef:
+                  name: azure-cred-file
+                  key: path
+                  optional: true
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
           volumeMounts:

--- a/deploy/csi-azurefile-node-windows.yaml
+++ b/deploy/csi-azurefile-node-windows.yaml
@@ -88,7 +88,11 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: "C:\\k\\azure.json"
+              valueFrom:
+                configMapKeyRef:
+                  name: azure-cred-file
+                  key: path-windows
+                  optional: true
             - name: CSI_ENDPOINT
               value: unix://C:\\csi\\csi.sock
             - name: KUBE_NODE_NAME

--- a/deploy/csi-azurefile-node.yaml
+++ b/deploy/csi-azurefile-node.yaml
@@ -85,7 +85,11 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: "/etc/kubernetes/azure.json"
+              valueFrom:
+                configMapKeyRef:
+                  name: azure-cred-file
+                  key: path
+                  optional: true
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: KUBE_NODE_NAME

--- a/pkg/azurefile/azure.go
+++ b/pkg/azurefile/azure.go
@@ -19,6 +19,7 @@ package azurefile
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -29,7 +30,8 @@ import (
 
 var (
 	DefaultAzureCredentialFileEnv = "AZURE_CREDENTIAL_FILE"
-	DefaultCredFilePath           = "/etc/kubernetes/azure.json"
+	DefaultCredFilePathLinux      = "/etc/kubernetes/azure.json"
+	DefaultCredFilePathWindows    = "C:\\k\\azure.json"
 )
 
 // GetCloudProvider get Azure Cloud Provider
@@ -52,7 +54,11 @@ func GetCloudProvider(kubeconfig string) (*azure.Cloud, error) {
 		if ok {
 			klog.V(2).Infof("%s env var set as %v", DefaultAzureCredentialFileEnv, credFile)
 		} else {
-			credFile = DefaultCredFilePath
+			if runtime.GOOS == "windows" {
+				credFile = DefaultCredFilePathWindows
+			} else {
+				credFile = DefaultCredFilePathLinux
+			}
 			klog.V(2).Infof("use default %s env var: %v", DefaultAzureCredentialFileEnv, credFile)
 		}
 

--- a/pkg/azurefile/azure_test.go
+++ b/pkg/azurefile/azure_test.go
@@ -73,12 +73,12 @@ users:
 		{
 			desc:        "[failure] out of cluster, no kubeconfig, no credential file",
 			kubeconfig:  "",
-			expectedErr: fmt.Errorf("Failed to load config from file: %s, cloud not get azure cloud provider", DefaultCredFilePath),
+			expectedErr: fmt.Errorf("Failed to load config from file: %s, cloud not get azure cloud provider", DefaultCredFilePathLinux),
 		},
 		{
 			desc:        "[failure] out of cluster & in cluster, specify a non-exist kubeconfig, no credential file",
 			kubeconfig:  "/tmp/non-exist.json",
-			expectedErr: fmt.Errorf("Failed to load config from file: %s, cloud not get azure cloud provider", DefaultCredFilePath),
+			expectedErr: fmt.Errorf("Failed to load config from file: %s, cloud not get azure cloud provider", DefaultCredFilePathLinux),
 		},
 		{
 			desc:        "[failure] out of cluster & in cluster, specify a empty kubeconfig, no credential file",
@@ -88,7 +88,7 @@ users:
 		{
 			desc:        "[failure] out of cluster & in cluster, specify a fake kubeconfig, no credential file",
 			kubeconfig:  fakeKubeConfig,
-			expectedErr: fmt.Errorf("Failed to load config from file: %s, cloud not get azure cloud provider", DefaultCredFilePath),
+			expectedErr: fmt.Errorf("Failed to load config from file: %s, cloud not get azure cloud provider", DefaultCredFilePathLinux),
 		},
 		{
 			desc:        "[success] out of cluster & in cluster, no kubeconfig, a fake credential file",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: use `azure-cred-file` configmap in `kube-system` namespace to specify azure-cred-file path

> To specify a different cloud provider config file, create `azure-cred-file` configmap before driver installation, e.g. for OpenShift, it's `/etc/kubernetes/cloud.conf`
 > ```console
 > kubectl create configmap azure-cred-file --from-literal=path="/etc/kubernetes/cloud.conf" --from-literal=path-windows="C:\\k\\cloud.conf" -n kube-system
 > ```


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #282

**Special notes for your reviewer**:


**Release note**:
```
feat: use `azure-cred-file` configmap in `kube-system` namespace to specify azure-cred-file path
```
