### PR TITLE
fix: remove "proto=tcp" in nfs mount

### DIFF
--- a/deploy/example/nfs/README.md
+++ b/deploy/example/nfs/README.md
@@ -1,5 +1,5 @@
 ## NFS support
-[NFS volume on Azure Files](https://github.com/RenaShahMSFT/Azure-Files-NFS-Preview) is now in Private Preivew on Azure Canary(centraluseuap) region. This service is optimized for random access workloads with in-place data updates. It provides full POSIX file system support. 
+[NFS volume on Azure Files](https://github.com/RenaShahMSFT/Azure-Files-NFS-Preview) is now in Private Preview on Azure Canary(centraluseuap) region. This service is optimized for random access workloads with in-place data updates. It provides full POSIX file system support.
 </br>This page shows how to use NFS feature by Azure File CSI driver on Azure Kubernetes cluster.
 
 #### Feature Status: Alpha

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -168,7 +168,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 	var mountOptions, sensitiveMountOptions []string
 	if fsType == nfs {
-		mountOptions = []string{"vers=4,minorversion=1,proto=tcp,sec=sys"}
+		mountOptions = []string{"vers=4,minorversion=1,sec=sys"}
 	} else {
 		if runtime.GOOS == "windows" {
 			mountOptions = []string{fmt.Sprintf("AZURE\\%s", accountName), accountKey}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: disable tcp in nfs mount, due to following mount failure:
```
  Warning  FailedMount             4s (x9 over 2m52s)   kubelet, k8s-agentpool-25062338-vmss000000  MountVolume.MountDevice failed for volume "pvc-a5aa59f6-161c-494c-b2cc-5f2945f7bbba" : rpc error: code = Internal desc = volume(andy-1185#andynfstest#pvc-a5aa59f6-161c-494c-b2cc-5f2945f7bbba#) mount "andynfstest.file.core.windows.net:/andynfstest/pvc-a5aa59f6-161c-494c-b2cc-5f2945f7bbba" on "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-a5aa59f6-161c-494c-b2cc-5f2945f7bbba/globalmount" failed with mount failed: exit status 32
Mounting command: mount
Mounting arguments: -t nfs -o vers=4,minorversion=1,proto=tcp,sec=sys andynfstest.file.core.windows.net:/andynfstest/pvc-a5aa59f6-161c-494c-b2cc-5f2945f7bbba /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-a5aa59f6-161c-494c-b2cc-5f2945f7bbba/globalmount
Output: mount.nfs: Failed to find 'tcp' protocol
```


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
