### PR TITLE
test: Improve UTs for nodeserver

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Test
-      run: sudo go test -covermode=count -coverprofile=profile.cov ./pkg/...
+      run: go test -covermode=count -coverprofile=profile.cov ./pkg/...
         
     - name: Send coverage
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ before_install:
   - GO111MODULE=off go get github.com/mattn/goveralls
 
 script:
-  - sudo -E env "PATH=$PATH" go test -covermode=count -coverprofile=profile.cov ./pkg/...
+  - go test -covermode=count -coverprofile=profile.cov ./pkg/...
   - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci

--- a/pkg/azurefile/fake_mounter.go
+++ b/pkg/azurefile/fake_mounter.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurefile
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/utils/mount"
+)
+
+type fakeMounter struct {
+	mount.FakeMounter
+}
+
+// Mount overrides mount.FakeMounter.Mount.
+func (f *fakeMounter) Mount(source string, target string, fstype string, options []string) error {
+	if strings.Contains(source, "error_mount") {
+		return fmt.Errorf("fake Mount: source error")
+	} else if strings.Contains(target, "error_mount") {
+		return fmt.Errorf("fake Mount: target error")
+	}
+
+	return nil
+}
+
+// MountSensitive overrides mount.FakeMounter.MountSensitive.
+func (f *fakeMounter) MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	if strings.Contains(source, "error_mount_sens") {
+		return fmt.Errorf("fake MountSensitive: source error")
+	} else if strings.Contains(target, "error_mount_sens") {
+		return fmt.Errorf("fake MountSensitive: target error")
+	}
+
+	return nil
+}
+
+//IsLikelyNotMountPoint overrides mount.FakeMounter.IsLikelyNotMountPoint.
+func (f *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
+	if strings.Contains(file, "error_is_likely") {
+		return false, fmt.Errorf("fake IsLikelyNotMountPoint: fake error")
+	}
+	if strings.Contains(file, "false_is_likely") {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/azurefile/fake_mounter_test.go
+++ b/pkg/azurefile/fake_mounter_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurefile
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/utils/mount"
+)
+
+func TestMount(t *testing.T) {
+	tests := []struct {
+		desc        string
+		source      string
+		target      string
+		expectedErr error
+	}{
+		{
+			desc:        "[Error] Mocked source error",
+			source:      "./error_mount_source",
+			target:      targetTest,
+			expectedErr: fmt.Errorf("fake Mount: source error"),
+		},
+		{
+			desc:        "[Error] Mocked target error",
+			source:      sourceTest,
+			target:      "./error_mount_target",
+			expectedErr: fmt.Errorf("fake Mount: target error"),
+		},
+		{
+			desc:        "[Success] Successful run",
+			source:      sourceTest,
+			target:      targetTest,
+			expectedErr: nil,
+		},
+	}
+
+	d := NewFakeDriver()
+	fakeMounter := &fakeMounter{}
+	d.mounter = &mount.SafeFormatAndMount{
+		Interface: fakeMounter,
+	}
+	for _, test := range tests {
+		err := d.mounter.Mount(test.source, test.target, "", nil)
+		if !reflect.DeepEqual(err, test.expectedErr) {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}
+
+func TestMountSensitive(t *testing.T) {
+	tests := []struct {
+		desc        string
+		source      string
+		target      string
+		expectedErr error
+	}{
+		{
+			desc:        "[Error] Mocked source error",
+			source:      "./error_mount_sens_source",
+			target:      targetTest,
+			expectedErr: fmt.Errorf("fake MountSensitive: source error"),
+		},
+		{
+			desc:        "[Error] Mocked target error",
+			source:      sourceTest,
+			target:      "./error_mount_sens_target",
+			expectedErr: fmt.Errorf("fake MountSensitive: target error"),
+		},
+		{
+			desc:        "[Success] Successful run",
+			source:      sourceTest,
+			target:      targetTest,
+			expectedErr: nil,
+		},
+	}
+
+	d := NewFakeDriver()
+	fakeMounter := &fakeMounter{}
+	d.mounter = &mount.SafeFormatAndMount{
+		Interface: fakeMounter,
+	}
+	for _, test := range tests {
+		err := d.mounter.MountSensitive(test.source, test.target, "", nil, nil)
+		if !reflect.DeepEqual(err, test.expectedErr) {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}
+
+func TestIsLikelyNotMountPoint(t *testing.T) {
+	tests := []struct {
+		desc        string
+		file        string
+		expectedErr error
+	}{
+		{
+			desc:        "[Error] Mocked file error",
+			file:        "./error_is_likely_target",
+			expectedErr: fmt.Errorf("fake IsLikelyNotMountPoint: fake error"),
+		},
+		{desc: "[Success] Successful run",
+			file:        targetTest,
+			expectedErr: nil,
+		},
+		{
+			desc:        "[Success] Successful run not a mount",
+			file:        "./false_is_likely_target",
+			expectedErr: nil,
+		},
+	}
+
+	d := NewFakeDriver()
+	fakeMounter := &fakeMounter{}
+	d.mounter = &mount.SafeFormatAndMount{
+		Interface: fakeMounter,
+	}
+	for _, test := range tests {
+		_, err := d.mounter.IsLikelyNotMountPoint(test.file)
+		if !reflect.DeepEqual(err, test.expectedErr) {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

 /kind test
**What this PR does / why we need it**:
Improves the unit tests for azurefile/nodeserver. Now, root privileges are not required to run the UTs.
This is achieved by creating a new file fake_mounter where the methods of FakeMounter are overridden
**Which issue(s) this PR fixes**:.
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
test: Improve nodeserver unit tests
ci: Remove root privileges to run unit test
```
