### PR TITLE
fix: ignore the NotFound error when patching pv

### DIFF
--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/azurefile-csi-driver/pkg/azurefile"
@@ -317,6 +318,10 @@ func (t *TestPersistentVolumeClaim) removeFinalizers() {
 	framework.ExpectNoError(err)
 
 	_, err = t.client.CoreV1().PersistentVolumes().Patch(context.TODO(), pvClone.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	// Because the pv might be deleted successfully before patched, if so, ignore the error.
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return
+	}
 	framework.ExpectNoError(err)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The e2e test is flaky due to the following reason.
```
Dynamic Provisioning should delete PV with reclaimPolicy "Delete" [kubernetes.io/azure-file] [file.csi.azure.com] [Windows]
/home/prow/go/src/sigs.k8s.io/azurefile-csi-driver/test/e2e/dynamic_provisioning_test.go:198
Unexpected error:
    <*errors.StatusError | 0xc000640aa0>: {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "persistentvolumes \"pvc-e3c79ec2-117c-4195-ae82-5b297078b06f\" not found",
            Reason: "NotFound",
            Details: {
                Name: "pvc-e3c79ec2-117c-4195-ae82-5b297078b06f",
                Group: "",
                Kind: "persistentvolumes",
                UID: "",
                Causes: nil,
                RetryAfterSeconds: 0,
            },
            Code: 404,
        },
    }
    persistentvolumes "pvc-e3c79ec2-117c-4195-ae82-5b297078b06f" not found
occurred
/home/prow/go/src/sigs.k8s.io/azurefile-csi-driver/test/e2e/testsuites/testsuites.go:320
```
In the scenario, the PV is deleted successfully. We don't need the patching workaround any more. Then should ignore the NotFound error.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
