### PR TITLE
chore: reduce limit of CPU and Memory

### DIFF
--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -41,8 +41,8 @@ spec:
               name: socket-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -62,8 +62,8 @@ spec:
             name: socket-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -82,8 +82,8 @@ spec:
               mountPath: /csi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -103,8 +103,8 @@ spec:
               mountPath: /csi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -121,8 +121,8 @@ spec:
               mountPath: /csi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -166,8 +166,8 @@ spec:
               name: msi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node-windows.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node-windows.yaml
@@ -37,8 +37,8 @@ spec:
           imagePullPolicy: {{ .Values.windows.image.livenessProbe.pullPolicy }}
           resources:
             limits:
-              cpu: 2
-              memory: 2Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -65,8 +65,8 @@ spec:
               mountPath: C:\registration
           resources:
             limits:
-              cpu: 2
-              memory: 2Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -118,8 +118,8 @@ spec:
               mountPath: \\.\pipe\csi-proxy-smb-v1alpha1
           resources:
             limits:
-              cpu: 2
-              memory: 2Gi
+              cpu: 400m
+              memory: 400Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
@@ -35,8 +35,8 @@ spec:
           imagePullPolicy: {{ .Values.image.livenessProbe.pullPolicy }}
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -63,8 +63,8 @@ spec:
               mountPath: /registration
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -118,8 +118,8 @@ spec:
               name: device-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/charts/latest/azurefile-csi-driver/templates/csi-snapshot-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-snapshot-controller.yaml
@@ -32,8 +32,8 @@ spec:
             - "--leader-election=false"
           resources:
             limits:
-              cpu: 1000m
-              memory: 1000Mi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/deploy/csi-azurefile-controller.yaml
+++ b/deploy/csi-azurefile-controller.yaml
@@ -40,8 +40,8 @@ spec:
               name: socket-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -60,8 +60,8 @@ spec:
               name: socket-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -79,8 +79,8 @@ spec:
               mountPath: /csi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -98,8 +98,8 @@ spec:
               mountPath: /csi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -115,8 +115,8 @@ spec:
               mountPath: /csi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -160,8 +160,8 @@ spec:
               name: msi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/deploy/csi-azurefile-node-windows.yaml
+++ b/deploy/csi-azurefile-node-windows.yaml
@@ -33,8 +33,8 @@ spec:
               value: unix://C:\\csi\\csi.sock
           resources:
             limits:
-              cpu: 2
-              memory: 2Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -60,8 +60,8 @@ spec:
               mountPath: C:\registration
           resources:
             limits:
-              cpu: 2
-              memory: 2Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -116,8 +116,8 @@ spec:
               mountPath: \\.\pipe\csi-proxy-smb-v1alpha1
           resources:
             limits:
-              cpu: 2
-              memory: 2Gi
+              cpu: 400m
+              memory: 400Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/deploy/csi-azurefile-node.yaml
+++ b/deploy/csi-azurefile-node.yaml
@@ -33,8 +33,8 @@ spec:
             - --v=5
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -60,8 +60,8 @@ spec:
               mountPath: /registration
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -115,8 +115,8 @@ spec:
               name: device-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/deploy/csi-snapshot-controller.yaml
+++ b/deploy/csi-snapshot-controller.yaml
@@ -31,8 +31,8 @@ spec:
             - "--leader-election=false"
           resources:
             limits:
-              cpu: 1000m
-              memory: 1000Mi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Set the reasonable CPU and Memory.

- Reduce limit of azurefile container CPU and Memory to one fifth.

- Reduce limit of sidecar containers  CPU and Memory to one tenth.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Use `kubectl top pod` command to get the usage data.
```
POD                                         NAME              CPU(cores)   MEMORY(bytes)   
csi-azurefile-controller-849f745f84-lwpc7   csi-provisioner   1m           11Mi            
csi-azurefile-controller-849f745f84-lwpc7   csi-attacher      1m           10Mi            
csi-azurefile-controller-849f745f84-lwpc7   csi-resizer       1m           9Mi             
csi-azurefile-controller-849f745f84-lwpc7   azurefile         1m           9Mi             
csi-azurefile-controller-849f745f84-lwpc7   liveness-probe    1m           5Mi 
csi-azuredisk-controller-849f745f84-lwpc7   csi-snapshotter   1m           9Mi
```
```
POD                        NAME                    CPU(cores)   MEMORY(bytes)   
csi-azurefile-node-hqp6w   liveness-probe          1m           7Mi             
csi-azurefile-node-hqp6w   node-driver-registrar   0m           7Mi             
csi-azurefile-node-hqp6w   azurefile               1m           8Mi  
```
```
POD                                        NAME                      CPU(cores)   MEMORY(bytes)   
csi-snapshot-controller-695d98454d-zf9xz csi-snapshot-controller   1m           8Mi
```

Enter the node where the pods run. Then use `top -p <pid>` to get the usage data.
```
   PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
 3507 root      20   0  136.8m  29.3m  18.9m S   0.3  0.4   0:00.49 csi-provisioner 
 3565 root      20   0  717.6m  32.1m  21.5m S   0.0  0.5   0:00.53 csi-attacher   
 3619 root      20   0  131.3m  24.8m  16.4m S   0.0  0.4   0:00.46 csi-resizer 
 3677 root      20   0  133.0m  29.7m  21.1m S   0.0  0.4   0:00.09 csi-snapshotter
 3684 root      20   0  110.5m  14.5m   6.3m S   0.0  0.2   0:00.07 livenessprobe 
 3728 root      20   0  136.4m  28.3m  19.8m S   0.0  0.4   0:00.10 azurefileplugin 
```
```
   PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND 
 3288 root      20   0  110.5m  11.6m   3.4m S   0.0  0.2   0:00.06 livenessprobe
 3348 root      20   0  111.0m  13.0m   6.8m S   0.0  0.2   0:00.02 csi-node-driver
 3402 root      20   0  136.4m  28.8m  20.4m S   0.0  0.4   0:00.08 azurefileplugin 
```
```
   PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
 17165 root      20   0  131772  26752  17992 S   0.0  0.4   0:15.20 snapshot-controller
```


**Release note**:
```
none
```
