### PR TITLE
Add value in Helm chart for secret used to pull Docker images

### DIFF
--- a/charts/latest/azurefile-csi-driver/templates/_helpers.tpl
+++ b/charts/latest/azurefile-csi-driver/templates/_helpers.tpl
@@ -9,3 +9,13 @@ labels:
   chart: "{{ .Chart.Name }}"
   chartVersion: "{{ .Chart.Version }}"
 {{- end -}}
+
+{{/* pull secrets for containers */}}
+{{- define "azurefile.pullSecrets" -}}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -24,6 +24,7 @@ spec:
           operator: "Equal"
           value: "true"
           effect: "NoSchedule"
+      {{- include "azurefile.pullSecrets" . | indent 6 }}
       containers:
         - name: csi-provisioner
           image: "{{ .Values.image.csiProvisioner.repository }}:{{ .Values.image.csiProvisioner.tag }}"

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node-windows.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node-windows.yaml
@@ -20,6 +20,7 @@ spec:
       priorityClassName: system-node-critical
       tolerations:
         - operator: "Exists"
+      {{- include "azurefile.pullSecrets" . | indent 6 }}
       containers:
         - name: liveness-probe
           volumeMounts:

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
@@ -21,6 +21,7 @@ spec:
       priorityClassName: system-node-critical
       tolerations:
         - operator: "Exists"
+      {{- include "azurefile.pullSecrets" . | indent 6 }}
       containers:
         - name: liveness-probe
           volumeMounts:

--- a/charts/latest/azurefile-csi-driver/templates/csi-snapshot-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-snapshot-controller.yaml
@@ -24,6 +24,7 @@ spec:
           operator: "Equal"
           value: "true"
           effect: "NoSchedule"
+      {{- include "azurefile.pullSecrets" . | indent 6 }}
       containers:
         - name: csi-snapshot-controller
           image: "{{ .Values.snapshot.image.csiSnapshotController.repository }}:{{ .Values.snapshot.image.csiSnapshotController.tag }}"

--- a/charts/latest/azurefile-csi-driver/values.yaml
+++ b/charts/latest/azurefile-csi-driver/values.yaml
@@ -23,6 +23,9 @@ image:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
     tag: v1.2.0
     pullPolicy: IfNotPresent
+## Name of secrets (present in namespace) containing Docker credentials used to pull images
+# imagePullSecrets:
+#   - myRegistryKeySecretName
 
 serviceAccount:
   create: true


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Allow to specify a secret in Helm chart used to provide credentials for Docker repositories (when they are private).

**Which issue(s) this PR fixes**:
Fixes #371 

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
