### PR TITLE
feat: bring your own account key for dynamic provisioning

### DIFF
--- a/deploy/example/storageclass-azurefile-secret.yaml
+++ b/deploy/example/storageclass-azurefile-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: azurefile-csi
+provisioner: file.csi.azure.com
+parameters:
+  csi.storage.k8s.io/provisioner-secret-name: azure-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/node-stage-secret-name: azure-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: default

--- a/pkg/azurefile/azurefile_client.go
+++ b/pkg/azurefile/azurefile_client.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurefile
+
+import (
+	"fmt"
+	"net/http"
+
+	azs "github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"k8s.io/klog/v2"
+	"k8s.io/legacy-cloud-providers/azure/clients/fileclient"
+	"k8s.io/legacy-cloud-providers/azure/retry"
+)
+
+const (
+	useHTTPS = true
+)
+
+var (
+	// refer https://github.com/Azure/azure-sdk-for-go/blob/master/storage/client.go#L88.
+	defaultValidStatusCodes = []int{
+		http.StatusRequestTimeout,      // 408
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusServiceUnavailable,  // 503
+		http.StatusGatewayTimeout,      // 504
+	}
+)
+
+type azureFileClient struct {
+	env     *azure.Environment
+	backoff *retry.Backoff
+}
+
+func newAzureFileClient(env *azure.Environment, backoff *retry.Backoff) *azureFileClient {
+	return &azureFileClient{
+		env:     env,
+		backoff: backoff,
+	}
+}
+
+func (f *azureFileClient) CreateFileShare(accountName, accountKey string, shareOptions *fileclient.ShareOptions) error {
+	if shareOptions == nil {
+		return fmt.Errorf("shareOptions is nil")
+	}
+	return f.createFileShare(accountName, accountKey, shareOptions.Name, shareOptions.RequestGiB)
+}
+
+func (f *azureFileClient) createFileShare(accountName, accountKey, name string, sizeGiB int) error {
+	fileClient, err := f.getFileSvcClient(accountName, accountKey)
+	if err != nil {
+		return err
+	}
+	share := fileClient.GetShareReference(name)
+	share.Properties.Quota = sizeGiB
+	newlyCreated, err := share.CreateIfNotExists(nil)
+	if err != nil {
+		return fmt.Errorf("failed to create file share, err: %v", err)
+	}
+	if !newlyCreated {
+		klog.V(2).Infof("file share(%s) under account(%s) already exists", name, accountName)
+	}
+	return nil
+}
+
+// delete a file share
+func (f *azureFileClient) deleteFileShare(accountName, accountKey, name string) error {
+	fileClient, err := f.getFileSvcClient(accountName, accountKey)
+	if err != nil {
+		return err
+	}
+	return fileClient.GetShareReference(name).Delete(nil)
+}
+
+func (f *azureFileClient) resizeFileShare(accountName, accountKey, name string, sizeGiB int) error {
+	fileClient, err := f.getFileSvcClient(accountName, accountKey)
+	if err != nil {
+		return err
+	}
+	share := fileClient.GetShareReference(name)
+	if share.Properties.Quota >= sizeGiB {
+		klog.Warningf("file share size(%dGi) is already greater or equal than requested size(%dGi), accountName: %s, shareName: %s",
+			share.Properties.Quota, sizeGiB, accountName, name)
+		return nil
+	}
+	share.Properties.Quota = sizeGiB
+	if err = share.SetProperties(nil); err != nil {
+		return fmt.Errorf("failed to set quota on file share %s, err: %v", name, err)
+	}
+	klog.V(4).Infof("resize file share completed, accountName: %s, shareName: %s, sizeGiB: %d", accountName, name, sizeGiB)
+	return nil
+}
+
+func (f *azureFileClient) getFileSvcClient(accountName, accountKey string) (*azs.FileServiceClient, error) {
+	fileClient, err := azs.NewClient(accountName, accountKey, f.env.StorageEndpointSuffix, azs.DefaultAPIVersion, useHTTPS)
+	if err != nil {
+		return nil, fmt.Errorf("error creating azure client: %v", err)
+	}
+
+	if f.backoff != nil {
+		fileClient.Sender = &azs.DefaultSender{
+			RetryAttempts:    f.backoff.Steps,
+			ValidStatusCodes: defaultValidStatusCodes,
+			RetryDuration:    f.backoff.Duration,
+		}
+	}
+
+	fc := fileClient.GetFileService()
+	return &fc, nil
+}

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -673,7 +673,7 @@ func TestCheckFileShareCapacity(t *testing.T) {
 		mockFileClient := mockfileclient.NewMockInterface(ctrl)
 		d.cloud.FileClient = mockFileClient
 		mockFileClient.EXPECT().GetFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(test.mockedFileShareResp, test.mockedFileShareErr).AnyTimes()
-		err := d.checkFileShareCapacity(resourceGroupName, accountName, fileShareName, requestGiB)
+		err := d.checkFileShareCapacity(resourceGroupName, accountName, fileShareName, requestGiB, map[string]string{})
 		if !reflect.DeepEqual(err, test.expectedError) {
 			t.Errorf("Unexpected error: %v", err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: bring your own account key

In some scenarios, user's cluster does not have permission to a storage account(in some case, the storage account is in another subscription), we already provide static provisioning for that scenario. While that's not enough, user still wants to only bring own storage account key and driver could provide storage class support(dynamic provisioning).

CSI driver already supports specifying secret in every CSI methods, and current file share operations are all based on management API, so here is the solution, when user specifying secret in below CSI methods, CSI driver should switch to use storage account key way(example code is [here](https://github.com/kubernetes/kubernetes/blob/release-1.18/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go)) to operate file share.

 - create `azure-secret` to store account name & key
```
kubectl create secret generic azure-secret --from-literal accountname=NAME --from-literal accountkey="KEY" --type=Opaque
```
 - create azure file storage class referencing `azure-secret` in create/delete/mount process:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: azurefile-csi
provisioner: file.csi.azure.com
allowVolumeExpansion: true
parameters:
  csi.storage.k8s.io/provisioner-secret-name: azure-secret
  csi.storage.k8s.io/provisioner-secret-namespace: default
  csi.storage.k8s.io/node-stage-secret-name: azure-secret
  csi.storage.k8s.io/node-stage-secret-namespace: default
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #385

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
feat: bring your own account key for dynamic provisioning
```
