### PR TITLE
fix: set timeout(30s) for csi-provisioner

### DIFF
--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -33,6 +33,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
+            - "--timeout=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/deploy/csi-azurefile-controller.yaml
+++ b/deploy/csi-azurefile-controller.yaml
@@ -32,6 +32,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
+            - "--timeout=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/deploy/example/nfs/README.md
+++ b/deploy/example/nfs/README.md
@@ -54,7 +54,7 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/azurefile-cs
 
  - enter pod to check
 ```console
-$ exec -it statefulset-azurefile-0 bash
+$ kubectl exec -it statefulset-azurefile-0 sh
 # df -h
 Filesystem      Size  Used Avail Use% Mounted on
 ...


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: set timeout(30s) for csi-provisioner
By default it's 15s which may cause timeout when create a new storage account and file share 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
 - error logs
```
# k describe pvc persistent-storage-statefulset-azurefile-0
Name:          persistent-storage-statefulset-azurefile-0
Namespace:     default
StorageClass:  azurefile-csi
Status:        Bound
Volume:        pvc-ec5b7089-97f5-4d1b-bde2-73ebbb45683b
Labels:        app=nginx
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-class: azurefile-csi
               volume.beta.kubernetes.io/storage-provisioner: file.csi.azure.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      100Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    statefulset-azurefile-0
Events:
  Type     Reason                 Age                From                                                                                       Message
  ----     ------                 ----               ----                                                                                       -------
  Normal   ExternalProvisioning   15s (x2 over 22s)  persistentvolume-controller                                                                waiting for a volume to be created, either by external provisioner "file.csi.azure.com" or manually created by system administrator
  Warning  ProvisioningFailed     12s                file.csi.azure.com_aks-nodepool1-13451060-vmss000009_8c8f361e-cc51-4ea0-a6ac-fa4f13ca6584  failed to provision volume with StorageClass "azurefile-csi": rpc error: code = DeadlineExceeded desc = context deadline exceeded
  Normal   Provisioning           11s (x2 over 22s)  file.csi.azure.com_aks-nodepool1-13451060-vmss000009_8c8f361e-cc51-4ea0-a6ac-fa4f13ca6584  External provisioner is provisioning volume for claim "default/persistent-storage-statefulset-azurefile-0"
  Normal   ProvisioningSucceeded  3s                 file.csi.azure.com_aks-nodepool1-13451060-vmss000009_8c8f361e-cc51-4ea0-a6ac-fa4f13ca6584  Successfully provisioned volume pvc-ec5b7089-97f5-4d1b-bde2-73ebbb45683b
```

 - below logs shows it costs around 20s:
```
I0912 14:50:43.350566       1 utils.go:108] GRPC call: /csi.v1.Controller/CreateVolume
I0912 14:50:43.350707       1 utils.go:109] GRPC request: {"capacity_range":{"required_bytes":107374182400},"name":"pvc-a7e6f4ba-9305-4afc-8b86-c14cd34147e9","parameters":{"protocol":"nfs","skuName":"Premium_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":1}}]}
I0912 14:50:43.351011       1 controllerserver.go:128] set vnetResourceID(/subscriptions/xxx/resourceGroups/mc_andy-aks1179_andy-aks1179_eastus/providers/Microsoft.Network/virtualNetworks/aks-vnet-13451060/subnets/aks-subnet) for NFS protocol
I0912 14:50:43.776500       1 azure_storageaccount.go:154] subnetID(/subscriptions/xxx/resourceGroups/mc_andy-aks1179_andy-aks1179_eastus/providers/Microsoft.Network/virtualNetworks/aks-vnet-13451060/subnets/aks-subnet) has been set
I0912 14:50:43.776540       1 azure_storageaccount.go:182] azure - no matching account found, begin to create a new account fc3842bb099694a9a94920d in resource group mc_andy-aks1179_andy-aks1179_eastus, location: eastus, accountType: Premium_LRS, accountKind: FileStorage, tags: map[created-by:azure]
I0912 14:50:54.354452       1 utils.go:108] GRPC call: /csi.v1.Controller/CreateVolume
I0912 14:50:54.354586       1 utils.go:109] GRPC request: {"capacity_range":{"required_bytes":107374182400},"name":"pvc-a7e6f4ba-9305-4afc-8b86-c14cd34147e9","parameters":{"protocol":"nfs","skuName":"Premium_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":1}}]}
I0912 14:50:54.354722       1 controllerserver.go:128] set vnetResourceID(/subscriptions/xxx/resourceGroups/mc_andy-aks1179_andy-aks1179_eastus/providers/Microsoft.Network/virtualNetworks/aks-vnet-13451060/subnets/aks-subnet) for NFS protocol
I0912 14:50:54.398684       1 azure_storageaccount.go:141] found a matching account fc3842bb099694a9a94920d type Premium_LRS location eastus
I0912 14:50:54.457135       1 azure_storageaccountclient.go:185] Received error in storageaccount.listkeys.request: resourceID: /subscriptions/xxx/resourceGroups/mc_andy-aks1179_andy-aks1179_eastus/providers/Microsoft.Storage/storageAccounts/fc3842bb099694a9a94920d, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: {"error":{"code":"StorageAccountIsNotProvisioned","message":"The storage account provisioning state must be 'Succeeded' before executing the operation."}}
W0912 14:50:54.457188       1 controllerserver.go:181] EnsureStorageAccount() failed with error(could not get storage key for storage account fc3842bb099694a9a94920d: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: {"error":{"code":"StorageAccountIsNotProvisioned","message":"The storage account provisioning state must be 'Succeeded' before executing the operation."}}), waiting for retring
I0912 14:50:59.826921       1 azure_storageaccount.go:141] found a matching account fc3842bb099694a9a94920d type Premium_LRS location eastus
I0912 14:50:59.905591       1 azure_storageaccountclient.go:185] Received error in storageaccount.listkeys.request: resourceID: /subscriptions/xxx/resourceGroups/mc_andy-aks1179_andy-aks1179_eastus/providers/Microsoft.Storage/storageAccounts/fc3842bb099694a9a94920d, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: {"error":{"code":"StorageAccountIsNotProvisioned","message":"The storage account provisioning state must be 'Succeeded' before executing the operation."}}
W0912 14:50:59.905733       1 controllerserver.go:181] EnsureStorageAccount() failed with error(could not get storage key for storage account fc3842bb099694a9a94920d: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: {"error":{"code":"StorageAccountIsNotProvisioned","message":"The storage account provisioning state must be 'Succeeded' before executing the operation."}}), waiting for retring
I0912 14:51:02.066922       1 controllerserver.go:203] begin to create file share(pvcn-a7e6f4ba-9305-4afc-8b86-c14cd34147e9) on account(fc3842bb099694a9a94920d) type(Premium_LRS) rg(mc_andy-aks1179_andy-aks1179_eastus) location() size(100) protocol(NFS)
I0912 14:51:02.115500       1 azure_storageaccount.go:141] found a matching account fc3842bb099694a9a94920d type Premium_LRS location eastus
I0912 14:51:02.679112       1 azure_storage.go:64] created share pvcn-a7e6f4ba-9305-4afc-8b86-c14cd34147e9 in account
I0912 14:51:02.679160       1 controllerserver.go:222] create file share pvcn-a7e6f4ba-9305-4afc-8b86-c14cd34147e9 on storage account fc3842bb099694a9a94920d successfully
```

**Release note**:
```
fix: set timeout(30s) for csi-provisioner
```
