### PR TITLE
Revert "fix: create nonroot user in Dockerfile"

### DIFF
--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-controller.yaml
@@ -129,8 +129,6 @@ spec:
               memory: 20Mi
         - name: azurefile
           image: "{{ .Values.image.azurefile.repository }}:{{ .Values.image.azurefile.tag }}"
-          securityContext:
-            runAsUser: 0
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
@@ -108,7 +108,6 @@ spec:
           imagePullPolicy: {{ .Values.image.azurefile.pullPolicy }}
           securityContext:
             privileged: true
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/csi-azurefile-controller.yaml
+++ b/deploy/csi-azurefile-controller.yaml
@@ -123,8 +123,6 @@ spec:
         - name: azurefile
           image: mcr.microsoft.com/k8s/csi/azurefile-csi:latest
           imagePullPolicy: IfNotPresent
-          securityContext:
-            runAsUser: 0
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/csi-azurefile-node.yaml
+++ b/deploy/csi-azurefile-node.yaml
@@ -104,7 +104,6 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -20,8 +20,5 @@ RUN apt update && apt install nfs-common -y || true
 
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"
-# Create a nonroot user
-RUN useradd -u 10001 nonroot
-USER nonroot
 
 ENTRYPOINT ["/azurefileplugin"]

--- a/pkg/azurefileplugin/dev.Dockerfile
+++ b/pkg/azurefileplugin/dev.Dockerfile
@@ -16,9 +16,6 @@ FROM mcr.microsoft.com/aks/fundamental/base-ubuntu:v0.0.5
 RUN apt-get update && apt-get install -y ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs nfs-common
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"
-# Create a nonroot user
-RUN useradd -u 10001 nonroot
-USER nonroot
 
 COPY ./_output/azurefileplugin /azurefileplugin
 ENTRYPOINT ["/azurefileplugin"]


### PR DESCRIPTION
Reverts kubernetes-sigs/azurefile-csi-driver#439

Original PR did not improve the security, that PR is just for bypass security scanning, while would introduce various permission setting issue.