### PR TITLE
Fix tolerations in the daemon-set.

### DIFF
--- a/deploy/csi-azurefile-node.yaml
+++ b/deploy/csi-azurefile-node.yaml
@@ -19,8 +19,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
       containers:
         - name: liveness-probe
           volumeMounts:


### PR DESCRIPTION

**What type of PR is this?**

Stops deploying the daemon-set pod to virtual-kubelet.

/kind bug

**What this PR does / why we need it**:

AFAIK, virtual-kubelet on Azure doesn't support CSI.

**Which issue(s) this PR fixes**:

None.

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
