### PR TITLE
fix: not schedule driver pod on virtual node

### DIFF
--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node-windows.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node-windows.yaml
@@ -17,6 +17,15 @@ spec:
       serviceAccountName: csi-azurefile-node-sa
       nodeSelector:
         kubernetes.io/os: windows
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
       priorityClassName: system-node-critical
       tolerations:
         - operator: "Exists"

--- a/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
+++ b/charts/latest/azurefile-csi-driver/templates/csi-azurefile-node.yaml
@@ -19,6 +19,15 @@ spec:
       serviceAccountName: csi-azurefile-node-sa
       nodeSelector:
         kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
       priorityClassName: system-node-critical
       tolerations:
         - operator: "Exists"

--- a/deploy/csi-azurefile-node-windows.yaml
+++ b/deploy/csi-azurefile-node-windows.yaml
@@ -16,6 +16,15 @@ spec:
       serviceAccountName: csi-azurefile-node-sa
       nodeSelector:
         kubernetes.io/os: windows
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
       priorityClassName: system-node-critical
       containers:
         - name: liveness-probe

--- a/deploy/csi-azurefile-node.yaml
+++ b/deploy/csi-azurefile-node.yaml
@@ -18,6 +18,15 @@ spec:
       serviceAccountName: csi-azurefile-node-sa
       nodeSelector:
         kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
       priorityClassName: system-node-critical
       tolerations:
         - operator: "Exists"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: not schedule driver pod on virtual node
original error:
```
# k get po -n kube-system -o wide | grep csi
csi-azurefile-controller-58ffc59848-pjqb6    6/6     Running            9          12d    10.240.0.115   aks-agentpool-20968559-vmss000003   <none>           <none>
csi-azurefile-node-cvzr8                     3/3     Running            0          13d    10.240.0.115   aks-agentpool-20968559-vmss000003   <none>           <none>
csi-azurefile-node-g9x24                     3/3     Running            0          13d    10.240.0.4     aks-agentpool-20968559-vmss000002   <none>           <none>
csi-azurefile-node-hkn59                     0/3     ProviderFailed     0          12d    <none>         virtual-node-aci-linux              <none>           <none>
csi-blob-controller-8599fcbcdf-jjpcj         3/3     Running            1          10d    10.240.0.115   aks-agentpool-20968559-vmss000003   <none>           <none>
csi-blob-controller-8599fcbcdf-x68wg         3/3     Running            0          10d    10.240.0.4     aks-agentpool-20968559-vmss000002   <none>           <none>
csi-blob-node-gwjlp                          3/3     Running            0          10d    10.240.0.4     aks-agentpool-20968559-vmss000002   <none>           <none>
csi-blob-node-nhh4m                          0/3     ProviderFailed     0          10d    <none>         virtual-node-aci-linux              <none>           <none>
csi-blob-node-vsk69                          3/3     Running            0          10d    10.240.0.115   aks-agentpool-20968559-vmss000003   <none>


# k get no virtual-node-aci-linux --show-labels
NAME                     STATUS   ROLES   AGE   VERSION                        LABELS
virtual-node-aci-linux   Ready    agent   14d   v1.14.3-vk-azure-aci-vv1.3.0   alpha.service-controller.kubernetes.io/exclude-balancer=true,beta.kubernetes.io/os=linux,kubernetes.azure.com/role=agent,kubernetes.io/hostname=virtual-node-aci-linux,kubernetes.io/os=linux,kubernetes.io/role=agent,node-role.kubernetes.io/agent=,type=virtual-kubelet
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: not schedule driver pod on virtual node
```
