### PR TITLE
Fix the controllerexpand response to bytes

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -632,8 +632,8 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 		return nil, status.Errorf(codes.Internal, "expand volume error: %v", err)
 	}
 
-	klog.V(2).Infof("ControllerExpandVolume(%s) successfully, currentQuota: %d", volumeID, int(requestGiB))
-	return &csi.ControllerExpandVolumeResponse{CapacityBytes: requestGiB}, nil
+	klog.V(2).Infof("ControllerExpandVolume(%s) successfully, currentQuota: %d Gi", volumeID, int(requestGiB))
+	return &csi.ControllerExpandVolumeResponse{CapacityBytes: capacityBytes}, nil
 }
 
 // getShareURL: sourceVolumeID is the id of source file share, returns a ShareURL of source file share.

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -1419,9 +1419,9 @@ func TestControllerExpandVolume(t *testing.T) {
 				mockFileClient.EXPECT().GetFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(storage.FileShare{FileShareProperties: &storage.FileShareProperties{ShareQuota: &shareQuota}}, nil).AnyTimes()
 				d.cloud.FileClient = mockFileClient
 
-				expectedResp := &csi.ControllerExpandVolumeResponse{CapacityBytes: int64(0)}
+				expectedResp := &csi.ControllerExpandVolumeResponse{CapacityBytes: stdVolSize}
 				resp, err := d.ControllerExpandVolume(ctx, req)
-				if !(reflect.DeepEqual(err, nil) || reflect.DeepEqual(resp, expectedResp)) {
+				if !(reflect.DeepEqual(err, nil) && reflect.DeepEqual(resp, expectedResp)) {
 					t.Errorf("Expected response: %v received response: %v expected error: %v received error: %v", expectedResp, resp, nil, err)
 				}
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix ControllerExpandVolume response.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/477

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
Fix a bug where ControllerExpandVolume return incorrect CapacityBytes
```
