### PR TITLE
update base image to bullseye

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ container-linux:
 .PHONY: container-windows
 container-windows:
 	docker buildx build --pull --output=type=$(OUTPUT_TYPE) --platform="windows/$(ARCH)" \
-		 -t $(IMAGE_TAG)-windows-$(OSVERSION)-$(ARCH) --build-arg OSVERSION=$(OSVERSION) \
-		 --build-arg ARCH=${ARCH} -f ./pkg/azurefileplugin/Windows.Dockerfile .
+		-t $(IMAGE_TAG)-windows-$(OSVERSION)-$(ARCH) --build-arg OSVERSION=$(OSVERSION) \
+		--build-arg ARCH=${ARCH} -f ./pkg/azurefileplugin/Windows.Dockerfile .
 
 .PHONY: container-all
 container-all: azurefile-windows

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 ARG ARCH
-FROM k8s.gcr.io/build-image/debian-base:buster-v1.6.0
-ARG ARCH
+
+FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0
+
 COPY ./_output/${ARCH}/azurefileplugin /azurefileplugin
-RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs
-# this is a workaround to install nfs-common and don't quit with error
-RUN apt update && apt install nfs-common -y || true
+
+RUN apt update && apt-mark unhold libcap2
+RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs nfs-common
 
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ARCH
-
 FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0
 
+ARG ARCH
 COPY ./_output/${ARCH}/azurefileplugin /azurefileplugin
 
 RUN apt update && apt-mark unhold libcap2


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Update base image to debian bullseye which should fix the installation issue with nfs-common

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
```console
# docker images | grep debian-base
k8s.gcr.io/build-image/debian-base                         bullseye-v1.0.0    316d9421ac48   7 days ago      62.7MB
k8s.gcr.io/build-image/debian-base-arm64                   buster-v1.6.0      88e0bf68d41c   4 months ago    60.1MB
k8s.gcr.io/build-image/debian-base-amd64                   buster-v1.6.0      a064b44e3aa7   4 months ago    60.8MB
k8s.gcr.io/build-image/debian-base                         buster-v1.6.0      a064b44e3aa7   4 months ago    60.8MB
```

**Release note**:
```
Update Linux base image to k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0
```
