### PR TITLE
fix: libssl1.1 vulnerability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ azurefile-darwin:
 
 .PHONY: container
 container: azurefile
-	docker build --no-cache -t $(IMAGE_TAG) -f ./pkg/azurefileplugin/dev.Dockerfile .
+	docker build --no-cache -t $(IMAGE_TAG) --output=type=docker -f ./pkg/azurefileplugin/dev.Dockerfile .
 
 .PHONY: container-linux
 container-linux:

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -18,7 +18,7 @@ ARG ARCH
 COPY ./_output/${ARCH}/azurefileplugin /azurefileplugin
 
 RUN apt update && apt-mark unhold libcap2
-RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs nfs-common
+RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs nfs-common libssl1.1
 
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"

--- a/pkg/azurefileplugin/dev.Dockerfile
+++ b/pkg/azurefileplugin/dev.Dockerfile
@@ -14,7 +14,7 @@
 
 FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0
 RUN apt update && apt-mark unhold libcap2
-RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs nfs-common
+RUN clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs nfs-common libssl1.1
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: libssl1.1 vulnerability

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
```console
# trivy --ignore-unfixed mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.6.0
2021-09-21T12:37:57.259Z        INFO    Detecting Debian vulnerabilities...
2021-09-21T12:37:57.277Z        INFO    Trivy skips scanning programming language libraries because no supported file was detected

mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.6.0 (debian 11.0)
=======================================================================
Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 1)

+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
|  LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
| libssl1.1 | CVE-2021-3711    | CRITICAL | 1.1.1k-1          | 1.1.1k-1+deb11u1 | openssl: SM2 Decryption              |
|           |                  |          |                   |                  | Buffer Overflow                      |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3711 |
+           +------------------+----------+                   +                  +--------------------------------------+
|           | CVE-2021-3712    | HIGH     |                   |                  | openssl: Read buffer overruns        |
|           |                  |          |                   |                  | processing ASN.1 strings             |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3712 |
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
```

**Release note**:
```
fix: libssl1.1 vulnerability
```
