### PR TITLE
fix: NodePublishVolume idempotent issue

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -439,6 +439,27 @@ func (d *Driver) ensureMountPoint(target string) (bool, error) {
 		}
 	}
 
+	if runtime.GOOS != "windows" {
+		// Check all the mountpoints in case IsLikelyNotMountPoint
+		// cannot handle --bind mount
+		mountList, err := d.mounter.List()
+		if err != nil {
+			return !notMnt, err
+		}
+
+		targetAbs, err := filepath.Abs(target)
+		if err != nil {
+			return !notMnt, err
+		}
+
+		for _, mountPoint := range mountList {
+			if mountPoint.Path == targetAbs {
+				notMnt = false
+				break
+			}
+		}
+	}
+
 	if !notMnt {
 		// testing original mount point, make sure the mount link is valid
 		_, err := ioutil.ReadDir(target)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

NodePublishVolume need to be idempotent. Currently NodePublishVolume will mount a volume to the same mountpoint repeatedly when it's called with the same parameters multiply time. This may happen when CO encounter some failures. Such as, when NodePublishVolume is called but timeout, CO will call it with same parameters again.

This issue mainly due to `IsLikelyNotMountPoint` can't handle bind mount. See [IsLikelyNotMountPoint doc](https://pkg.go.dev/k8s.io/utils/mount#Mounter.IsLikelyNotMountPoint). So, list all the mount points to confirm the mountpoint exists or not.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: NodePublishVolume idempotent issue
```
