### PR TITLE
fix: gid conflict issue between sc and fsGroup setting

### DIFF
--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -831,40 +831,24 @@ func TestNodeExpandVolume(t *testing.T) {
 
 func TestCheckGidPresentInMountFlags(t *testing.T) {
 	tests := []struct {
-		desc             string
-		VolumeMountGroup string
-		MountFlags       []string
-		expectedErr      error
-		result           bool
+		desc       string
+		MountFlags []string
+		result     bool
 	}{
 		{
-			desc:             "[Error] VolumeMountGroup is different from gid in mount options",
-			VolumeMountGroup: "2000",
-			MountFlags:       []string{"gid=3000"},
-			expectedErr:      status.Error(codes.InvalidArgument, "gid(3000) in storageClass and pod fsgroup(2000) are not equal"),
-			result:           false,
+			desc:       "[Success] Gid present in mount flags",
+			MountFlags: []string{"gid=3000"},
+			result:     true,
 		},
 		{
-			desc:             "[Success] Gid present in mount flags",
-			VolumeMountGroup: "",
-			MountFlags:       []string{"gid=3000"},
-			expectedErr:      nil,
-			result:           true,
-		},
-		{
-			desc:             "[Success] Gid not present in mount flags",
-			VolumeMountGroup: "",
-			MountFlags:       []string{},
-			expectedErr:      nil,
-			result:           false,
+			desc:       "[Success] Gid not present in mount flags",
+			MountFlags: []string{},
+			result:     false,
 		},
 	}
 
 	for _, test := range tests {
-		gIDPresent, err := checkGidPresentInMountFlags(test.VolumeMountGroup, test.MountFlags)
-		if !reflect.DeepEqual(err, test.expectedErr) {
-			t.Errorf("[%s]: Unexpected Error: %v, expected error: %v", test.desc, err, test.expectedErr)
-		}
+		gIDPresent := checkGidPresentInMountFlags(test.MountFlags)
 		if gIDPresent != test.result {
 			t.Errorf("[%s]: Expected result : %t, Actual result: %t", test.desc, test.result, gIDPresent)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: gid conflict issue between sc and fsGroup setting

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
<details>

I have a case, where after cluster upgraded to aks 1.22 cx seeing his deployments struck in creating with below issuekubelet MountVolume.MountDevice failed for volume "pvc-bf7e2615-62da-45ac-98a2-ad4a00978fa5" : rpc error: code = InvalidArgument desc = gid(0) in storageClass and pod fsgroup(2000) are not equalWarning FailedMount 29m (x26 over 4h57m) kubelet Unable to attach or mount volumes: unmounted volumes=[log-volume], unattached volumes=[kube-api-access-gj4w6 log-volume config-volume secrets-sell-inline]: timed out waiting for the condition

These deployments were working in 1.21 and having issues after upgrade

</details>

**Release note**:
```
fix: gid conflict issue between sc and fsGroup setting
```
