### PR TITLE
Rephrase block volume error

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -973,7 +973,7 @@ func isValidVolumeCapabilities(volCaps []*csi.VolumeCapability) error {
 	}
 	hasSupport := func(cap *csi.VolumeCapability) error {
 		if blk := cap.GetBlock(); blk != nil {
-			return fmt.Errorf("driver only supports mount access type volume capability")
+			return fmt.Errorf("driver does not support block volumes")
 		}
 		for _, c := range volumeCaps {
 			if c.GetMode() == cap.AccessMode.GetMode() {

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -163,7 +163,7 @@ func TestCreateVolume(t *testing.T) {
 						csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 					})
 
-				expectedErr := status.Error(codes.InvalidArgument, "CreateVolume Volume capabilities not valid: driver only supports mount access type volume capability")
+				expectedErr := status.Error(codes.InvalidArgument, "CreateVolume Volume capabilities not valid: driver does not support block volumes")
 				_, err := d.CreateVolume(ctx, req)
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`"driver only supports mount access type volume capability"` message is user facing and users don't really know what a `"mount access type volume capability"` is. They requested a block volume. Rephrase the message to be more clear.

Before:
`
E1118 03:05:11.172891       1 controller.go:956] error syncing claim "76757277-3dc9-4403-bed8-e170b5f48e46": failed to provision volume with StorageClass "azurefile-csi": rpc error: code = InvalidArgument desc = CreateVolume Volume capabilities not valid: driver only supports mount access type volume capability
`

After:
`
E1118 03:05:11.172891       1 controller.go:956] error syncing claim "76757277-3dc9-4403-bed8-e170b5f48e46": failed to provision volume with StorageClass "azurefile-csi": rpc error: code = InvalidArgument desc = CreateVolume Volume capabilities not valid: driver does not support block volumes
`

**Which issue(s) this PR fixes**:

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
