### PR TITLE
fix: default namespace issue

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -145,6 +145,8 @@ const (
 
 	fileShareAccountNamePrefix = "f"
 
+	defaultNamespace = "default"
+
 	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey       = "csi.storage.k8s.io/pv/name"
@@ -577,7 +579,11 @@ func (d *Driver) GetAccountInfo(ctx context.Context, volumeID string, secrets, r
 	}
 
 	if secretNamespace == "" {
-		secretNamespace = pvcNamespace
+		if pvcNamespace == "" {
+			secretNamespace = defaultNamespace
+		} else {
+			secretNamespace = pvcNamespace
+		}
 	}
 
 	if len(secrets) == 0 {

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -200,7 +200,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	if secretNamespace == "" {
-		secretNamespace = pvcNamespace
+		if pvcNamespace == "" {
+			secretNamespace = defaultNamespace
+		} else {
+			secretNamespace = pvcNamespace
+		}
 	}
 
 	if !isSupportedFsType(fsType) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: default namespace issue

default namespace should be set if secretNamespace is empty, this PR fixed the following failure:
<details>

```
I0405 12:34:33.357877    7156 utils.go:76] GRPC call: /csi.v1.Node/NodeStageVolume
I0405 12:34:33.357877    7156 utils.go:77] GRPC request: {"staging_target_path":"\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\pv\\azurefile-8081-file.csi.azure.com-preprovsioned-pv-q76d7\\globalmount","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":7}},"volume_id":"capz-bag4b6#fea767f0f8abe4a5ca1e3a0#pre-provisioned-readonly##pre-provisioned-readonly"}
I0405 12:34:33.365081    7156 azurefile.go:605] could not get account(fea767f0f8abe4a5ca1e3a0) key from secret(azure-storage-account-fea767f0f8abe4a5ca1e3a0-secret), error: could not get secret(azure-storage-account-fea767f0f8abe4a5ca1e3a0-secret): an empty namespace may not be set when a resource name is provided, use cluster identity to get account key instead
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: default namespace issue
```
