### PR TITLE
chore: refine metrics naming

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -155,6 +155,10 @@ const (
 	pvNameKey       = "csi.storage.k8s.io/pv/name"
 
 	defaultStorageEndPointSuffix = "core.windows.net"
+
+	VolumeID         = "volumeid"
+	SourceResourceID = "source_resource_id"
+	SnapshotID       = "snapshotid"
 )
 
 var (

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -427,7 +427,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	mc := metrics.NewMetricContext(azureFileCSIDriverName, "controller_create_volume", d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)
 	isOperationSucceeded := false
 	defer func() {
-		mc.ObserveOperationWithResult(isOperationSucceeded, volumeID, "")
+		mc.ObserveOperationWithResult(isOperationSucceeded, VolumeID, volumeID)
 	}()
 
 	klog.V(2).Infof("begin to create file share(%s) on account(%s) type(%s) rg(%s) location(%s) size(%d) protocol(%s)", validFileShareName, accountName, sku, resourceGroup, location, fileShareSize, shareProtocol)
@@ -575,7 +575,7 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 	mc := metrics.NewMetricContext(azureFileCSIDriverName, "controller_delete_volume", d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)
 	isOperationSucceeded := false
 	defer func() {
-		mc.ObserveOperationWithResult(isOperationSucceeded, volumeID, "")
+		mc.ObserveOperationWithResult(isOperationSucceeded, VolumeID, volumeID)
 	}()
 
 	if err := d.DeleteFileShare(resourceGroupName, accountName, fileShareName, secret); err != nil {
@@ -781,7 +781,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 	mc := metrics.NewMetricContext(azureFileCSIDriverName, "controller_create_snapshot", d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)
 	isOperationSucceeded := false
 	defer func() {
-		mc.ObserveOperationWithResult(isOperationSucceeded, sourceVolumeID, snapshotName)
+		mc.ObserveOperationWithResult(isOperationSucceeded, SourceResourceID, sourceVolumeID, SnapshotID, snapshotName)
 	}()
 
 	exists, item, err := d.snapshotExists(ctx, sourceVolumeID, snapshotName, req.GetSecrets())
@@ -866,7 +866,7 @@ func (d *Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequ
 	mc := metrics.NewMetricContext(azureFileCSIDriverName, "controller_delete_snapshot", d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)
 	isOperationSucceeded := false
 	defer func() {
-		mc.ObserveOperationWithResult(isOperationSucceeded, req.SnapshotId, "")
+		mc.ObserveOperationWithResult(isOperationSucceeded, SnapshotID, req.SnapshotId)
 	}()
 
 	if _, err := shareURL.WithSnapshot(snapshot).Delete(ctx, azfile.DeleteSnapshotsOptionNone); err != nil {
@@ -917,7 +917,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 	mc := metrics.NewMetricContext(azureFileCSIDriverName, "controller_expand_volume", d.cloud.ResourceGroup, d.cloud.SubscriptionID, d.Name)
 	isOperationSucceeded := false
 	defer func() {
-		mc.ObserveOperationWithResult(isOperationSucceeded, volumeID, "")
+		mc.ObserveOperationWithResult(isOperationSucceeded, VolumeID, volumeID)
 	}()
 
 	secrets := req.GetSecrets()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
chore: refine metrics naming

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
<details>

```
"Observed Request Latency" latency_seconds=0.156082089 request="azurefile_csi_driver_controller_create_volume" resource_group="kubetest-b0nxmhvx" subscription_id="0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e" source="file.csi.azure.com" volumeid="kubetest-b0nxmhvx#fa63d62dbd07047a9a41210#pre-provisioned-existing-credentials##pvc-9ac5e93f-3cc1-47eb-b7af-30a9f26729a0#azurefile-5466" result_code="succeeded"

"Observed Request Latency" latency_seconds=0.164151136 request="azurefile_csi_driver_controller_delete_volume" resource_group="kubetest-b0nxmhvx" subscription_id="0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e" source="file.csi.azure.com" volumeid="kubetest-b0nxmhvx#f186751dd98d649b49fa8b4#pvc-43ba5e3a-39c7-49b5-9000-27b9be7b0055###azurefile-5356" result_code="succeeded"

"Observed Request Latency" latency_seconds=0.190095921 request="azurefile_csi_driver_controller_expand_volume" resource_group="kubetest-b0nxmhvx" subscription_id="0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e" source="file.csi.azure.com" volumeid="kubetest-b0nxmhvx#fa63d62dbd07047a9a41210#pvc-872f3ce8-06b1-4460-b9c7-e248670690ed###azurefile-2546" result_code="succeeded"

"Observed Request Latency" latency_seconds=0.077016824 request="azurefile_csi_driver_controller_create_snapshot" resource_group="kubetest-b0nxmhvx" subscription_id="0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e" source="file.csi.azure.com" source_resource_id="kubetest-b0nxmhvx#fa63d62dbd07047a9a41210#pvc-27bbff8e-0bc1-4a4e-8230-12f96e0dfbbf###azurefile-7578" snapshotid="snapshot-de406faa-73be-4443-9563-dfebec241700" result_code="succeeded"

"Observed Request Latency" latency_seconds=0.01021077 request="azurefile_csi_driver_controller_delete_snapshot" resource_group="kubetest-b0nxmhvx" subscription_id="0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e" source="file.csi.azure.com" snapshotid="kubetest-b0nxmhvx#fa63d62dbd07047a9a41210#pvc-27bbff8e-0bc1-4a4e-8230-12f96e0dfbbf###azurefile-7578#2022-04-24T08:42:11.0000000Z" result_code="succeeded"
```

</details>

**Release note**:
```
none
```
