### PR TITLE
add new option to allow VHD feature opt-out

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -184,6 +184,7 @@ type DriverOptions struct {
 	UserAgentSuffix                        string
 	AllowEmptyCloudConfig                  bool
 	AllowInlineVolumeKeyAccessWithIdentity bool
+	EnableVHDDiskFeature                   bool
 	EnableGetVolumeStats                   bool
 	MountPermissions                       uint64
 	FSGroupChangePolicy                    string
@@ -200,6 +201,7 @@ type Driver struct {
 	fsGroupChangePolicy                    string
 	allowEmptyCloudConfig                  bool
 	allowInlineVolumeKeyAccessWithIdentity bool
+	enableVHDDiskFeature                   bool
 	enableGetVolumeStats                   bool
 	mountPermissions                       uint64
 	fileClient                             *azureFileClient
@@ -238,6 +240,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	driver.userAgentSuffix = options.UserAgentSuffix
 	driver.allowEmptyCloudConfig = options.AllowEmptyCloudConfig
 	driver.allowInlineVolumeKeyAccessWithIdentity = options.AllowInlineVolumeKeyAccessWithIdentity
+	driver.enableVHDDiskFeature = options.EnableVHDDiskFeature
 	driver.enableGetVolumeStats = options.EnableGetVolumeStats
 	driver.mountPermissions = options.MountPermissions
 	driver.fsGroupChangePolicy = options.FSGroupChangePolicy

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -59,6 +59,14 @@ func NewFakeDriver() *Driver {
 	return driver
 }
 
+func NewFakeDriverCustomOptions(opts DriverOptions) *Driver {
+	driverOptions := opts
+	driver := NewDriver(&driverOptions)
+	driver.Name = fakeDriverName
+	driver.Version = vendorVersion
+	return driver
+}
+
 func TestNewFakeDriver(t *testing.T) {
 	driverOptions := DriverOptions{
 		NodeID:     fakeNodeID,

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -228,6 +228,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 	}
 
+	if !d.enableVHDDiskFeature && fsType != "" {
+		return nil, status.Errorf(codes.InvalidArgument, "fsType storage class parameter enables experimental VDH disk feature which is currently disabled, use --enable-vhd driver option to enable it")
+	}
+
 	if !isSupportedFsType(fsType) {
 		return nil, status.Errorf(codes.InvalidArgument, "fsType(%s) is not supported, supported fsType list: %v", fsType, supportedFsTypeList)
 	}

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -215,8 +215,9 @@ func TestCreateVolume(t *testing.T) {
 				ctx := context.Background()
 
 				driverOptions := DriverOptions{
-					NodeID:                   fakeNodeID,
-					DriverName:               DefaultDriverName,
+					NodeID:               fakeNodeID,
+					DriverName:           DefaultDriverName,
+					EnableVHDDiskFeature: true,
 				}
 				d := NewFakeDriverCustomOptions(driverOptions)
 
@@ -279,8 +280,9 @@ func TestCreateVolume(t *testing.T) {
 				ctx := context.Background()
 
 				driverOptions := DriverOptions{
-					NodeID:                   fakeNodeID,
-					DriverName:               DefaultDriverName,
+					NodeID:               fakeNodeID,
+					DriverName:           DefaultDriverName,
+					EnableVHDDiskFeature: true,
 				}
 				d := NewFakeDriverCustomOptions(driverOptions)
 
@@ -776,8 +778,9 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				driverOptions := DriverOptions{
-					NodeID:                   fakeNodeID,
-					DriverName:               DefaultDriverName,
+					NodeID:               fakeNodeID,
+					DriverName:           DefaultDriverName,
+					EnableVHDDiskFeature: true,
 				}
 				d := NewFakeDriverCustomOptions(driverOptions)
 

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -213,7 +213,12 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				ctx := context.Background()
-				d := NewFakeDriver()
+
+				driverOptions := DriverOptions{
+					NodeID:                   fakeNodeID,
+					DriverName:               DefaultDriverName,
+				}
+				d := NewFakeDriverCustomOptions(driverOptions)
 
 				d.AddControllerServiceCapabilities(
 					[]csi.ControllerServiceCapability_RPC_Type{
@@ -272,7 +277,12 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				ctx := context.Background()
-				d := NewFakeDriver()
+
+				driverOptions := DriverOptions{
+					NodeID:                   fakeNodeID,
+					DriverName:               DefaultDriverName,
+				}
+				d := NewFakeDriverCustomOptions(driverOptions)
 
 				d.AddControllerServiceCapabilities(
 					[]csi.ControllerServiceCapability_RPC_Type{
@@ -765,7 +775,12 @@ func TestCreateVolume(t *testing.T) {
 					Parameters:         allParam,
 				}
 
-				d := NewFakeDriver()
+				driverOptions := DriverOptions{
+					NodeID:                   fakeNodeID,
+					DriverName:               DefaultDriverName,
+				}
+				d := NewFakeDriverCustomOptions(driverOptions)
+
 				d.cloud = &azure.Cloud{}
 				d.cloud.KubeClient = fake.NewSimpleClientset()
 

--- a/pkg/azurefileplugin/main.go
+++ b/pkg/azurefileplugin/main.go
@@ -51,6 +51,7 @@ var (
 	mountPermissions                       = flag.Uint64("mount-permissions", 0777, "mounted folder permissions")
 	allowInlineVolumeKeyAccessWithIdentity = flag.Bool("allow-inline-volume-key-access-with-identity", false, "allow accessing storage account key using cluster identity for inline volume")
 	fsGroupChangePolicy                    = flag.String("fsgroup-change-policy", "", "indicates how the volume's ownership will be changed by the driver, OnRootMismatch is the default value")
+	enableVHDDiskFeature                   = flag.Bool("enable-vhd", true, "enable VHD disk feature (experimental)")
 )
 
 func main() {
@@ -87,6 +88,7 @@ func handle() {
 		MountPermissions:                       *mountPermissions,
 		AllowInlineVolumeKeyAccessWithIdentity: *allowInlineVolumeKeyAccessWithIdentity,
 		FSGroupChangePolicy:                    *fsGroupChangePolicy,
+		EnableVHDDiskFeature:                   *enableVHDDiskFeature,
 	}
 	driver := azurefile.NewDriver(&driverOptions)
 	if driver == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Currently when users configure Azure file storage class with fstype param any non-admin users will get permission denied errors.

```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: mystorageclass
provisioner: file.csi.azure.com
parameters:
  fstype: ext4
reclaimPolicy: Delete
allowVolumeExpansion: true
volumeBindingMode: WaitForFirstConsumer
```

When trying to access the volume on a pod:
```
Can not read/write into mounted volume due to "permission denied Error"
 ERROR: cannot create regular file '/mnt/storage/hello': Permission denied
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1012 

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:
```
users can now opt-out of VHD disk feature using new option --enable-vhd (default: true)
```
