### PR TITLE
test: fix TestLogGRPC ut failure

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -811,9 +811,9 @@ func (d *Driver) RemoveStorageAccountTag(ctx context.Context, resourceGroup, acc
 }
 
 // GetStorageAccesskey get Azure storage account key from
-// 	1. secrets (if not empty)
-// 	2. use k8s client identity to read from k8s secret
-// 	3. use cluster identity to get from storage account directly
+//  1. secrets (if not empty)
+//  2. use k8s client identity to read from k8s secret
+//  3. use cluster identity to get from storage account directly
 func (d *Driver) GetStorageAccesskey(ctx context.Context, accountOptions *azure.AccountOptions, secrets map[string]string, secretName, secretNamespace string) (string, error) {
 	if len(secrets) > 0 {
 		_, accountKey, err := getStorageAccount(secrets)

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -1004,7 +1004,7 @@ func (d *Driver) getServiceURL(ctx context.Context, sourceVolumeID string, secre
 // Since `ListSharesSegment` lists all file shares and snapshots, the process of checking existence is divided into two steps.
 // 1. Judge if the specify snapshot name already exists.
 // 2. If it exists, we should judge if its source file share name equals that we specify.
-//    As long as the snapshot already exists, returns true. But when the source is different, an error will be returned.
+// As long as the snapshot already exists, returns true. But when the source is different, an error will be returned.
 func (d *Driver) snapshotExists(ctx context.Context, sourceVolumeID, snapshotName string, secrets map[string]string) (bool, azfile.ShareItem, error) {
 	serviceURL, fileShareName, err := d.getServiceURL(ctx, sourceVolumeID, secrets)
 	if err != nil {

--- a/pkg/azurefile/fake_mounter.go
+++ b/pkg/azurefile/fake_mounter.go
@@ -51,7 +51,7 @@ func (f *fakeMounter) MountSensitive(source string, target string, fstype string
 	return nil
 }
 
-//IsLikelyNotMountPoint overrides mount.FakeMounter.IsLikelyNotMountPoint.
+// IsLikelyNotMountPoint overrides mount.FakeMounter.IsLikelyNotMountPoint.
 func (f *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	if strings.Contains(file, "error_is_likely") {
 		return false, fmt.Errorf("fake IsLikelyNotMountPoint: fake error")
@@ -62,7 +62,7 @@ func (f *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-//NewFakeMounter fake mounter
+// NewFakeMounter fake mounter
 func NewFakeMounter() (*mount.SafeFormatAndMount, error) {
 	if runtime.GOOS == "windows" {
 		return mounter.NewSafeMounter()

--- a/pkg/csi-common/server_test.go
+++ b/pkg/csi-common/server_test.go
@@ -19,6 +19,7 @@ package csicommon
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -31,7 +32,10 @@ func TestNewNonBlockingGRPCServer(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	s := NewNonBlockingGRPCServer()
+	// sleep a while to avoid race condition in unit test
+	time.Sleep(time.Millisecond * 500)
 	s.Start("tcp://127.0.0.1:0", nil, nil, nil, true)
+	time.Sleep(time.Millisecond * 500)
 }
 
 func TestServe(t *testing.T) {

--- a/pkg/mounter/safe_mounter_v1beta_windows.go
+++ b/pkg/mounter/safe_mounter_v1beta_windows.go
@@ -104,8 +104,8 @@ func (mounter *csiProxyMounterV1Beta) Mount(source string, target string, fstype
 
 // Rmdir - delete the given directory
 // TODO: Call separate rmdir for pod context and plugin context. v1alpha1 for CSI
-//       proxy does a relaxed check for prefix as c:\var\lib\kubelet, so we can do
-//       rmdir with either pod or plugin context.
+// proxy does a relaxed check for prefix as c:\var\lib\kubelet, so we can do
+// rmdir with either pod or plugin context.
 func (mounter *csiProxyMounterV1Beta) Rmdir(path string) error {
 	klog.V(4).Infof("Remove directory: %s", path)
 	rmdirRequest := &fs.RmdirRequest{
@@ -135,8 +135,8 @@ func (mounter *csiProxyMounterV1Beta) IsMountPointMatch(mp mount.MountPoint, dir
 }
 
 // IsLikelyMountPoint - If the directory does not exists, the function will return os.ErrNotExist error.
-//   If the path exists, call to CSI proxy will check if its a link, if its a link then existence of target
-//   path is checked.
+// If the path exists, call to CSI proxy will check if its a link, if its a link then existence of target
+// path is checked.
 func (mounter *csiProxyMounterV1Beta) IsLikelyNotMountPoint(path string) (bool, error) {
 	klog.V(4).Infof("IsLikelyNotMountPoint: %s", path)
 	isExists, err := mounter.ExistsPath(path)

--- a/pkg/mounter/safe_mounter_windows.go
+++ b/pkg/mounter/safe_mounter_windows.go
@@ -127,8 +127,8 @@ func (mounter *csiProxyMounter) Mount(source string, target string, fstype strin
 
 // Rmdir - delete the given directory
 // TODO: Call separate rmdir for pod context and plugin context. v1alpha1 for CSI
-//       proxy does a relaxed check for prefix as c:\var\lib\kubelet, so we can do
-//       rmdir with either pod or plugin context.
+// proxy does a relaxed check for prefix as c:\var\lib\kubelet, so we can do
+// rmdir with either pod or plugin context.
 func (mounter *csiProxyMounter) Rmdir(path string) error {
 	klog.V(4).Infof("Remove directory: %s", path)
 	rmdirRequest := &fs.RmdirRequest{
@@ -157,8 +157,8 @@ func (mounter *csiProxyMounter) IsMountPointMatch(mp mount.MountPoint, dir strin
 }
 
 // IsLikelyMountPoint - If the directory does not exists, the function will return os.ErrNotExist error.
-//   If the path exists, call to CSI proxy will check if its a link, if its a link then existence of target
-//   path is checked.
+// If the path exists, call to CSI proxy will check if its a link, if its a link then existence of target
+// path is checked.
 func (mounter *csiProxyMounter) IsLikelyNotMountPoint(path string) (bool, error) {
 	klog.V(4).Infof("IsLikelyNotMountPoint: %s", path)
 	isExists, err := mounter.ExistsPath(path)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

fix TestLogGRPC ut failure

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

this PR tries to fix the following issue:
```
==================
WARNING: DATA RACE
Write at 0x000001d620e0 by goroutine 25:
  flag.newBoolValue()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/flag/flag.go:128 +0x208
  flag.(*FlagSet).BoolVar()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/flag/flag.go:715 +0x214
  k8s.io/klog/v2.InitFlags()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:429 +0x1e6
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.TestLogGRPC()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/utils_test.go:87 +0x44
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:[1446](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/7762127363?check_suite_focus=true#step:5:1447) +0x216
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x47

Previous read at 0x000001d620e0 by goroutine 16:
  k8s.io/klog/v2.(*loggingT).output()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:879 +0x375
  k8s.io/klog/v2.(*loggingT).printfDepth()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:737 +0x2f7
  k8s.io/klog/v2.(*loggingT).printf()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:719 +0x98b
  k8s.io/klog/v2.Infof()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:[1465](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/7762127363?check_suite_focus=true#step:5:1466) +0x910
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).serve()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:117 +0x85a
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).Start.func1()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:56 +0xec

Goroutine 25 (running) created at:
  testing.(*T).Run()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:[1493](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/7762127363?check_suite_focus=true#step:5:1494) +0x75d
  testing.runTests.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:79 +0x2e9

Goroutine 16 (finished) created at:
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).Start()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:56 +0x206
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.TestStart()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server_test.go:37 +0xae
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x47
==================
==================
WARNING: DATA RACE
Write at 0x000001d6219a by goroutine 25:
  flag.newBoolValue()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/flag/flag.go:128 +0x2fb
  flag.(*FlagSet).BoolVar()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/flag/flag.go:715 +0x307
  k8s.io/klog/v2.InitFlags()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:432 +0x2d6
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.TestLogGRPC()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/utils_test.go:87 +0x44
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x47

Previous read at 0x000001d6219a by goroutine 16:
  k8s.io/klog/v2.(*loggingT).header()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:656 +0xc8
  k8s.io/klog/v2.(*loggingT).printfDepth()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:723 +0x87
  k8s.io/klog/v2.(*loggingT).printf()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:719 +0x98b
  k8s.io/klog/v2.Infof()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:1465 +0x910
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).serve()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:117 +0x85a
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).Start.func1()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:56 +0xec

Goroutine 25 (running) created at:
  testing.(*T).Run()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:79 +0x2e9

Goroutine 16 (finished) created at:
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).Start()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:56 +0x206
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.TestStart()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server_test.go:37 +0xae
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x47```

**Release note**:
```

**Release note**:
```
none
```
