### PR TITLE
fix: cancel the context when timeout of deleting file share

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -755,7 +755,7 @@ func (d *Driver) CreateFileShare(accountOptions *azure.AccountOptions, shareOpti
 }
 
 // DeleteFileShare deletes a file share using storage account name and key
-func (d *Driver) DeleteFileShare(subsID, resourceGroup, accountName, shareName string, secrets map[string]string) error {
+func (d *Driver) DeleteFileShare(ctx context.Context, subsID, resourceGroup, accountName, shareName string, secrets map[string]string) error {
 	return wait.ExponentialBackoff(d.cloud.RequestBackoff(), func() (bool, error) {
 		var err error
 		if len(secrets) > 0 {
@@ -763,7 +763,7 @@ func (d *Driver) DeleteFileShare(subsID, resourceGroup, accountName, shareName s
 			if rerr != nil {
 				return true, rerr
 			}
-			err = d.fileClient.deleteFileShare(accountName, accountKey, shareName)
+			err = d.fileClient.deleteFileShare(ctx, accountName, accountKey, shareName)
 		} else {
 			err = d.cloud.DeleteFileShare(subsID, resourceGroup, accountName, shareName)
 		}

--- a/pkg/azurefile/azurefile_client.go
+++ b/pkg/azurefile/azurefile_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azurefile
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -82,7 +83,7 @@ func (f *azureFileClient) createFileShare(accountName, accountKey, name string, 
 }
 
 // delete a file share
-func (f *azureFileClient) deleteFileShare(accountName, accountKey, name string) error {
+func (f *azureFileClient) deleteFileShare(ctx context.Context, accountName, accountKey, name string) error {
 	fileClient, err := f.getFileSvcClient(accountName, accountKey)
 	if err != nil {
 		return err

--- a/pkg/azurefile/azurefile_client_test.go
+++ b/pkg/azurefile/azurefile_client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azurefile
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -144,7 +145,7 @@ func TestDeleteFileShare(t *testing.T) {
 			StorageEndpointSuffix: "ut",
 		},
 	}
-	actualErr := f.deleteFileShare(accountName, accountKey, "")
+	actualErr := f.deleteFileShare(context.TODO(), accountName, accountKey, "")
 	expectedErr := fmt.Errorf("error creating azure client: azure: account name is not valid: it must be between 3 and 24 characters, and only may contain numbers and lowercase letters: ut")
 	if !reflect.DeepEqual(actualErr, expectedErr) {
 		t.Errorf("actualErr: (%v), expectedErr: (%v)", actualErr, expectedErr)

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -600,7 +600,7 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		mc.ObserveOperationWithResult(isOperationSucceeded, VolumeID, volumeID)
 	}()
 
-	if err := d.DeleteFileShare(subsID, resourceGroupName, accountName, fileShareName, secret); err != nil {
+	if err := d.DeleteFileShare(ctx, subsID, resourceGroupName, accountName, fileShareName, secret); err != nil {
 		return nil, status.Errorf(codes.Internal, "DeleteFileShare %s under account(%s) rg(%s) failed with error: %v", fileShareName, accountName, resourceGroupName, err)
 	}
 	klog.V(2).Infof("azure file(%s) under subsID(%s) rg(%s) account(%s) volume(%s) is deleted successfully", fileShareName, subsID, resourceGroupName, accountName, volumeID)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
As the description in the issue https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1083, here we reuse the context from external-provisioner to cancel the context when timeout. Then the volume won't be locked in driver.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1083 

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: cancel the context when timeout of deleting file share
```
