### PR TITLE
cleanup: remove redundant unmount volume code since it's already handled by mount-utils

### DIFF
--- a/pkg/azurefile/azure_common_linux.go
+++ b/pkg/azurefile/azure_common_linux.go
@@ -22,7 +22,6 @@ package azurefile
 import (
 	"os"
 
-	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 )
 
@@ -39,10 +38,6 @@ func RemoveStageTarget(m *mount.SafeFormatAndMount, target string) error {
 }
 
 func CleanupSMBMountPoint(m *mount.SafeFormatAndMount, target string, extensiveMountCheck bool) error {
-	// unmount first since if remote SMB directory is not found, linked path cannot be deleted if not mounted
-	if err := m.Unmount(target); err != nil {
-		klog.Errorf("Unmount(%s) failed with %v", target, err)
-	}
 	return CleanupMountPoint(m, target, extensiveMountCheck)
 }
 

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -865,7 +865,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test.Run(cs, ns)
 	})
 
-	ginkgo.It("should be able to unmount volume if volume is already deleted [file.csi.azure.com]", func() {
+	ginkgo.It("should be able to unmount smb volume if volume is already deleted [file.csi.azure.com]", func() {
 		skipIfUsingInTreeVolumePlugin()
 
 		pod := testsuites.PodDetails{
@@ -896,6 +896,46 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			PodCheck: &testsuites.PodExecCheck{
 				Cmd:            podCheckCmd,
 				ExpectedString: expectedString, // pod will be restarted so expect to see 2 instances of string
+			},
+		}
+		test.Run(cs, ns)
+	})
+
+	ginkgo.It("should be able to unmount nfs volume if volume is already deleted [file.csi.azure.com]", func() {
+		skipIfUsingInTreeVolumePlugin()
+		skipIfTestingInWindowsCluster()
+
+		pod := testsuites.PodDetails{
+			Cmd: convertToPowershellCommandIfNecessary("echo 'hello world' >> /mnt/test-1/data && while true; do sleep 3600; done"),
+			Volumes: []testsuites.VolumeDetails{
+				{
+					ClaimSize: "10Gi",
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+			IsWindows:    isWindowsCluster,
+			WinServerVer: winServerVer,
+			UseCMD:       false,
+		}
+		podCheckCmd := []string{"cat", "/mnt/test-1/data"}
+		expectedString := "hello world\n"
+		if isWindowsCluster {
+			podCheckCmd = []string{"cmd", "/c", "type C:\\mnt\\test-1\\data.txt"}
+			expectedString = "hello world\r\n"
+		}
+		test := testsuites.DynamicallyProvisionedVolumeUnmountTest{
+			CSIDriver: testDriver,
+			Azurefile: azurefileDriver,
+			Pod:       pod,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:            podCheckCmd,
+				ExpectedString: expectedString, // pod will be restarted so expect to see 2 instances of string
+			},
+			StorageClassParameters: map[string]string{
+				"protocol": "nfs",
 			},
 		}
 		test.Run(cs, ns)

--- a/test/e2e/testsuites/dynamically_provisioned_restart_driver_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_restart_driver_tester.go
@@ -35,7 +35,7 @@ type DynamicallyProvisionedRestartDriverTest struct {
 }
 
 func (t *DynamicallyProvisionedRestartDriverTest) Run(client clientset.Interface, namespace *v1.Namespace) {
-	tDeployment, cleanup := t.Pod.SetupDeployment(client, namespace, t.CSIDriver, t.StorageClassParameters)
+	tDeployment, cleanup, _ := t.Pod.SetupDeployment(client, namespace, t.CSIDriver, t.StorageClassParameters)
 	// defer must be called here for resources not get removed before using them
 	for i := range cleanup {
 		defer cleanup[i]()

--- a/test/e2e/testsuites/specs.go
+++ b/test/e2e/testsuites/specs.go
@@ -171,7 +171,7 @@ func (pod *PodDetails) SetupWithPreProvisionedVolumes(client clientset.Interface
 	return tpod, cleanupFuncs
 }
 
-func (pod *PodDetails) SetupDeployment(client clientset.Interface, namespace *v1.Namespace, csiDriver driver.DynamicPVTestDriver, storageClassParameters map[string]string) (*TestDeployment, []func()) {
+func (pod *PodDetails) SetupDeployment(client clientset.Interface, namespace *v1.Namespace, csiDriver driver.DynamicPVTestDriver, storageClassParameters map[string]string) (*TestDeployment, []func(), string) {
 	cleanupFuncs := make([]func(), 0)
 	volume := pod.Volumes[0]
 	ginkgo.By("setting up the StorageClass")
@@ -189,7 +189,11 @@ func (pod *PodDetails) SetupDeployment(client clientset.Interface, namespace *v1
 	tDeployment := NewTestDeployment(client, namespace, pod.Cmd, tpvc.persistentVolumeClaim, fmt.Sprintf("%s%d", volume.VolumeMount.NameGenerate, 1), fmt.Sprintf("%s%d", volume.VolumeMount.MountPathGenerate, 1), volume.VolumeMount.ReadOnly, pod.IsWindows, pod.WinServerVer)
 
 	cleanupFuncs = append(cleanupFuncs, tDeployment.Cleanup)
-	return tDeployment, cleanupFuncs
+	var volumeID string
+	if tpvc.persistentVolume != nil && tpvc.persistentVolume.Spec.CSI != nil {
+		volumeID = tpvc.persistentVolume.Spec.CSI.VolumeHandle
+	}
+	return tDeployment, cleanupFuncs, volumeID
 }
 
 func (pod *PodDetails) SetupStatefulset(client clientset.Interface, namespace *v1.Namespace, csiDriver driver.DynamicPVTestDriver) (*TestStatefulset, []func()) {

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -678,7 +678,6 @@ func NewTestPod(c clientset.Interface, ns *v1.Namespace, command string, isWindo
 
 func (t *TestPod) Create() {
 	var err error
-
 	t.pod, err = t.client.CoreV1().Pods(t.namespace.Name).Create(context.TODO(), t.pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
cleanup: remove redundant unmount volume code since it's already handled by mount-utils (fixed by https://github.com/kubernetes/kubernetes/pull/106906)

<details>

 - smb volume unmount logs when volume is deleted in the beginning
```
I1228 11:12:45.307558       1 utils.go:76] GRPC call: /csi.v1.Node/NodeUnpublishVolume
I1228 11:12:45.307578       1 utils.go:77] GRPC request: {"target_path":"/var/lib/kubelet/pods/da9f818f-913b-4b4a-9366-84340d66c7b2/volumes/kubernetes.io~csi/pvc-4337cd9a-a158-4ffe-834d-227d0079527d/mount","volume_id":"mc_andy-aks1252_andy-aks1252_eastus#f4d4861fa0e0b462d8ff3e8#pvc-4337cd9a-a158-4ffe-834d-227d0079527d###default"}
I1228 11:12:45.307671       1 nodeserver.go:132] NodeUnpublishVolume: unmounting volume mc_andy-aks1252_andy-aks1252_eastus#f4d4861fa0e0b462d8ff3e8#pvc-4337cd9a-a158-4ffe-834d-227d0079527d###default on /var/lib/kubelet/pods/da9f818f-913b-4b4a-9366-84340d66c7b2/volumes/kubernetes.io~csi/pvc-4337cd9a-a158-4ffe-834d-227d0079527d/mount
W1228 11:12:45.343145       1 mount_helper_unix.go:193] Potential stale file handle detected: /var/lib/kubelet/pods/da9f818f-913b-4b4a-9366-84340d66c7b2/volumes/kubernetes.io~csi/pvc-4337cd9a-a158-4ffe-834d-227d0079527d/mount
I1228 11:12:45.343176       1 mount_helper_common.go:93] unmounting "/var/lib/kubelet/pods/da9f818f-913b-4b4a-9366-84340d66c7b2/volumes/kubernetes.io~csi/pvc-4337cd9a-a158-4ffe-834d-227d0079527d/mount" (corruptedMount: true, mounterCanSkipMountPointChecks: true)
I1228 11:12:45.343189       1 mount_linux.go:362] Unmounting /var/lib/kubelet/pods/da9f818f-913b-4b4a-9366-84340d66c7b2/volumes/kubernetes.io~csi/pvc-4337cd9a-a158-4ffe-834d-227d0079527d/mount
I1228 11:12:45.398410       1 mount_helper_common.go:150] Warning: deleting path "/var/lib/kubelet/pods/da9f818f-913b-4b4a-9366-84340d66c7b2/volumes/kubernetes.io~csi/pvc-4337cd9a-a158-4ffe-834d-227d0079527d/mount"
```

 - nfs mount unmount logs  when volume is deleted in the beginning
```
I1228 06:13:06.244335       1 utils.go:76] GRPC call: /csi.v1.Node/NodeUnpublishVolume
I1228 06:13:06.244365       1 utils.go:77] GRPC request: {"target_path":"/var/lib/kubelet/pods/2e636d26-9427-4fd5-86b5-0692302fe7d8/volumes/kubernetes.io~csi/pvc-a110ff04-ea27-42d0-8a49-b0b763af0830/mount","volume_id":"capz-nfntic#f36cb0cda47f1477da90d60#pvcn-a110ff04-ea27-42d0-8a49-b0b763af0830###azurefile-3710"}
I1228 06:13:06.244450       1 nodeserver.go:132] NodeUnpublishVolume: unmounting volume capz-nfntic#f36cb0cda47f1477da90d60#pvcn-a110ff04-ea27-42d0-8a49-b0b763af0830###azurefile-3710 on /var/lib/kubelet/pods/2e636d26-9427-4fd5-86b5-0692302fe7d8/volumes/kubernetes.io~csi/pvc-a110ff04-ea27-42d0-8a49-b0b763af0830/mount
I1228 06:13:06.245682       1 mount_helper_common.go:93] unmounting "/var/lib/kubelet/pods/2e636d26-9427-4fd5-86b5-0692302fe7d8/volumes/kubernetes.io~csi/pvc-a110ff04-ea27-42d0-8a49-b0b763af0830/mount" (corruptedMount: true, mounterCanSkipMountPointChecks: true)
I1228 06:13:06.245708       1 mount_linux.go:362] Unmounting /var/lib/kubelet/pods/2e636d26-9427-4fd5-86b5-0692302fe7d8/volumes/kubernetes.io~csi/pvc-a110ff04-ea27-42d0-8a49-b0b763af0830/mount
I1228 06:13:06.257671       1 mount_helper_common.go:150] Warning: deleting path "/var/lib/kubelet/pods/2e636d26-9427-4fd5-86b5-0692302fe7d8/volumes/kubernetes.io~csi/pvc-a110ff04-ea27-42d0-8a49-b0b763af0830/mount"
I1228 06:13:06.257776       1 nodeserver.go:136] NodeUnpublishVolume: unmount volume capz-nfntic#f36cb0cda47f1477da90d60#pvcn-a110ff04-ea27-42d0-8a49-b0b763af0830###azurefile-3710 on /var/lib/kubelet/pods/2e636d26-9427-4fd5-86b5-0692302fe7d8/volumes/kubernetes.io~csi/pvc-a110ff04-ea27-42d0-8a49-b0b763af0830/mount successfully
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
