### PR TITLE
docs: update storage class definition for optional cross-subscription config

### DIFF
--- a/deploy/example/storageclass-azurefile-existing-share.yaml
+++ b/deploy/example/storageclass-azurefile-existing-share.yaml
@@ -5,6 +5,7 @@ metadata:
   name: azurefile-csi
 provisioner: file.csi.azure.com
 parameters:
+  subscriptionID: STORAGE_ACCOUNT_SUBSCRIPTION_ID  # optional, only set this when storage account is not in the same subscription as agent node
   resourceGroup: EXISTING_RESOURCE_GROUP_NAME  # optional, only set this when storage account is not in the same resource group as agent node
   storageAccount: EXISTING_STORAGE_ACCOUNT_NAME
   shareName: SHARE_NAME


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adding subscriptionID parameter for use case when Azure Files storage account and cluster worker nodes are in different subscriptions (optional)

**Which issue(s) this PR fixes**:

N/A

**Requirements**:
- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

Please note there are no unit tests here as this is a simple manifest example update (documentation).

**Release note**:
```
none
```
