### PR TITLE
feat: append help link when there is mount error

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -192,6 +192,7 @@ type DriverOptions struct {
 	AllowInlineVolumeKeyAccessWithIdentity bool
 	EnableVHDDiskFeature                   bool
 	EnableGetVolumeStats                   bool
+	AppendMountErrorHelpLink               bool
 	MountPermissions                       uint64
 	FSGroupChangePolicy                    string
 	KubeAPIQPS                             float64
@@ -211,6 +212,7 @@ type Driver struct {
 	allowInlineVolumeKeyAccessWithIdentity bool
 	enableVHDDiskFeature                   bool
 	enableGetVolumeStats                   bool
+	appendMountErrorHelpLink               bool
 	mountPermissions                       uint64
 	kubeAPIQPS                             float64
 	kubeAPIBurst                           int
@@ -254,6 +256,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	driver.allowInlineVolumeKeyAccessWithIdentity = options.AllowInlineVolumeKeyAccessWithIdentity
 	driver.enableVHDDiskFeature = options.EnableVHDDiskFeature
 	driver.enableGetVolumeStats = options.EnableGetVolumeStats
+	driver.appendMountErrorHelpLink = options.AppendMountErrorHelpLink
 	driver.mountPermissions = options.MountPermissions
 	driver.fsGroupChangePolicy = options.FSGroupChangePolicy
 	driver.kubeAPIQPS = options.KubeAPIQPS

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -318,7 +318,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		if err := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
 			return true, SMBMount(d.mounter, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions)
 		}); err != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %s on %s failed with %v", volumeID, source, cifsMountPath, err))
+			var helpLinkMsg string
+			if d.appendMountErrorHelpLink {
+				helpLinkMsg = fmt.Sprintf("\nPlease refer to http://aka.ms/filemounterror for possible causes and solutions for mount errors.")
+			}
+			return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %s on %s failed with %v%s", volumeID, source, cifsMountPath, err, helpLinkMsg))
 		}
 		if protocol == nfs {
 			if performChmodOp {

--- a/pkg/azurefileplugin/main.go
+++ b/pkg/azurefileplugin/main.go
@@ -54,6 +54,7 @@ var (
 	enableVHDDiskFeature                   = flag.Bool("enable-vhd", true, "enable VHD disk feature (experimental)")
 	kubeAPIQPS                             = flag.Float64("kube-api-qps", 25.0, "QPS to use while communicating with the kubernetes apiserver.")
 	kubeAPIBurst                           = flag.Int("kube-api-burst", 50, "Burst to use while communicating with the kubernetes apiserver.")
+	appendMountErrorHelpLink               = flag.Bool("append-mount-error-help-link", true, "Whether to include a link for help with mount errors when a mount error occurs.")
 )
 
 func main() {
@@ -91,6 +92,7 @@ func handle() {
 		AllowInlineVolumeKeyAccessWithIdentity: *allowInlineVolumeKeyAccessWithIdentity,
 		FSGroupChangePolicy:                    *fsGroupChangePolicy,
 		EnableVHDDiskFeature:                   *enableVHDDiskFeature,
+		AppendMountErrorHelpLink:               *appendMountErrorHelpLink,
 		KubeAPIQPS:                             *kubeAPIQPS,
 		KubeAPIBurst:                           *kubeAPIBurst,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: append help link when there is mount error

example error output:
```
mount //f6036fda6458647d0a93152.file.core.windows.net/pvc-0fb82cac-c7ef-4a3b-919f-e38df1b8161d on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/dd0682c0f2d9d6d85b5bbad86a5014e8d7bc54b19144c454cbde25cb309724c5/globalmount failed with mount failed: exit status 32
Mounting command: mount
Mounting arguments: -t cifs -o file_mode=0777,dir_mode=0777,actimeo=30,mfsymlinks,<masked> // xxx.file.core.windows.net/pvc-0fb82cac-c7ef-4a3b-919f-e38df1b8161d /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/dd0682c0f2d9d6d85b5bbad86a5014e8d7bc54b19144c454cbde25cb309724c5/globalmount
Output: mount error(2): No such file or directory
Refer to the mount.cifs(8) manual page (e.g. man mount.cifs) and kernel log messages (dmesg)

Please refer to http://aka.ms/filemounterror for possible causes and solutions for mount errors.
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
feat: append help link when there is mount error
```
