### PR TITLE
[release-1.24] fix: debian image CVEs

### DIFF
--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
+FROM registry.k8s.io/build-image/debian-base:bullseye-v1.4.3
 
 ARG ARCH=amd64
 ARG binary=./_output/${ARCH}/azurefileplugin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: debian image CVEs

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

<details>

```
mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.24.0 (debian 11.5)

Total: 12 (UNKNOWN: 0, LOW: 0, MEDIUM: 4, HIGH: 7, CRITICAL: 1)

âââââââââââââââ¬âââââââââââââââââ¬âââââââââââ¬ââââââââââââââââââââ¬âââââââââââââââââââ¬âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
â   Library   â Vulnerability  â Severity â Installed Version â  Fixed Version   â                            Title                             â
âââââââââââââââ¼âââââââââââââââââ¼âââââââââââ¼ââââââââââââââââââââ¼âââââââââââââââââââ¼âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â libgnutls30 â CVE-2023-0361  â HIGH     â 3.7.1-5+deb11u2   â 3.7.1-5+deb11u3  â gnutls: timing side-channel in the TLS RSA key exchange code â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2023-0361                    â
âââââââââââââââ¼âââââââââââââââââ¤          âââââââââââââââââââââ¼âââââââââââââââââââ¼âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â libssl1.1   â CVE-2022-4450  â          â 1.1.1n-0+deb11u3  â 1.1.1n-0+deb11u4 â double free after calling PEM_read_bio_ex                    â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2022-4450                    â
â             ââââââââââââââââââ¤          â                   â                  ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â             â CVE-2023-0215  â          â                   â                  â use-after-free following BIO_new_NDEF                        â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2023-0215                    â
â             ââââââââââââââââââ¤          â                   â                  ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â             â CVE-2023-0286  â          â                   â                  â X.400 address type confusion in X.509 GeneralName            â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2023-0286                    â
â             ââââââââââââââââââ¼âââââââââââ¤                   â                  ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â             â CVE-2022-2097  â MEDIUM   â                   â                  â openssl: AES OCB fails to encrypt some bytes                 â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2022-2097                    â
â             ââââââââââââââââââ¤          â                   â                  ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â             â CVE-2022-4304  â          â                   â                  â timing attack in RSA Decryption implementation               â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2022-4304                    â
âââââââââââââââ¼âââââââââââââââââ¼âââââââââââ¼ââââââââââââââââââââ¼âââââââââââââââââââ¼âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â libtasn1-6  â CVE-2021-46848 â CRITICAL â 4.16.0-2          â 4.16.0-2+deb11u1 â libtasn1: Out-of-bound access in ETYPE_OK                    â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2021-46848                   â
âââââââââââââââ¼âââââââââââââââââ¼âââââââââââ¼ââââââââââââââââââââ¼âââââââââââââââââââ¼âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â openssl     â CVE-2022-4450  â HIGH     â 1.1.1n-0+deb11u3  â 1.1.1n-0+deb11u4 â double free after calling PEM_read_bio_ex                    â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2022-4450                    â
â             ââââââââââââââââââ¤          â                   â                  ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â             â CVE-2023-0215  â          â                   â                  â use-after-free following BIO_new_NDEF                        â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2023-0215                    â
â             ââââââââââââââââââ¤          â                   â                  ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â             â CVE-2023-0286  â          â                   â                  â X.400 address type confusion in X.509 GeneralName            â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2023-0286                    â
â             ââââââââââââââââââ¼âââââââââââ¤                   â                  ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â             â CVE-2022-2097  â MEDIUM   â                   â                  â openssl: AES OCB fails to encrypt some bytes                 â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2022-2097                    â
â             ââââââââââââââââââ¤          â                   â                  ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ¤
â             â CVE-2022-4304  â          â                   â                  â timing attack in RSA Decryption implementation               â
â             â                â          â                   â                  â https://avd.aquasec.com/nvd/cve-2022-4304                    â
âââââââââââââââ´âââââââââââââââââ´âââââââââââ´ââââââââââââââââââââ´âââââââââââââââââââ´âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
```
</details>

**Release note**:
```
fix: debian image CVEs
```
