### PR TITLE
fix: append nosharesock mount option on Linux node by default

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -201,6 +201,7 @@ type DriverOptions struct {
 	KubeAPIBurst                           int
 	EnableWindowsHostProcess               bool
 	AppendClosetimeoOption                 bool
+	AppendNoShareSockOption                bool
 }
 
 // Driver implements all interfaces of CSI drivers
@@ -223,6 +224,7 @@ type Driver struct {
 	kubeAPIBurst                           int
 	enableWindowsHostProcess               bool
 	appendClosetimeoOption                 bool
+	appendNoShareSockOption                bool
 	fileClient                             *azureFileClient
 	mounter                                *mount.SafeFormatAndMount
 	// lock per volume attach (only for vhd disk feature)
@@ -271,6 +273,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	driver.kubeAPIBurst = options.KubeAPIBurst
 	driver.enableWindowsHostProcess = options.EnableWindowsHostProcess
 	driver.appendClosetimeoOption = options.AppendClosetimeoOption
+	driver.appendNoShareSockOption = options.AppendNoShareSockOption
 	driver.volLockMap = newLockMap()
 	driver.subnetLockMap = newLockMap()
 	driver.volumeLocks = newVolumeLocks()
@@ -429,7 +432,7 @@ func GetFileShareInfo(id string) (string, string, string, string, string, string
 }
 
 // check whether mountOptions contains file_mode, dir_mode, vers, if not, append default mode
-func appendDefaultMountOptions(mountOptions []string, appendClosetimeoOption bool) []string {
+func appendDefaultMountOptions(mountOptions []string, appendNoShareSockOption, appendClosetimeoOption bool) []string {
 	var defaultMountOptions = map[string]string{
 		fileMode:   defaultFileMode,
 		dirMode:    defaultDirMode,
@@ -439,6 +442,9 @@ func appendDefaultMountOptions(mountOptions []string, appendClosetimeoOption boo
 
 	if appendClosetimeoOption {
 		defaultMountOptions["sloppy,closetimeo=0"] = ""
+	}
+	if appendNoShareSockOption {
+		defaultMountOptions["nosharesock"] = ""
 	}
 
 	// stores the mount options already included in mountOptions

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -92,9 +92,10 @@ func TestNewFakeDriver(t *testing.T) {
 
 func TestAppendDefaultMountOptions(t *testing.T) {
 	tests := []struct {
-		options                []string
-		appendClosetimeoOption bool
-		expected               []string
+		options                 []string
+		appendClosetimeoOption  bool
+		appendNoShareSockOption bool
+		expected                []string
 	}{
 		{
 			options: []string{"dir_mode=0777"},
@@ -194,10 +195,32 @@ func TestAppendDefaultMountOptions(t *testing.T) {
 				"sloppy,closetimeo=0",
 			},
 		},
+		{
+			options:                 []string{""},
+			appendNoShareSockOption: true,
+			expected: []string{"", fmt.Sprintf("%s=%s",
+				fileMode, defaultFileMode),
+				fmt.Sprintf("%s=%s", dirMode, defaultDirMode),
+				fmt.Sprintf("%s=%s", actimeo, defaultActimeo),
+				mfsymlinks,
+				"nosharesock",
+			},
+		},
+		{
+			options:                 []string{"nosharesock"},
+			appendNoShareSockOption: true,
+			expected: []string{fmt.Sprintf("%s=%s",
+				fileMode, defaultFileMode),
+				fmt.Sprintf("%s=%s", dirMode, defaultDirMode),
+				fmt.Sprintf("%s=%s", actimeo, defaultActimeo),
+				mfsymlinks,
+				"nosharesock",
+			},
+		},
 	}
 
 	for _, test := range tests {
-		result := appendDefaultMountOptions(test.options, test.appendClosetimeoOption)
+		result := appendDefaultMountOptions(test.options, test.appendNoShareSockOption, test.appendClosetimeoOption)
 		sort.Strings(result)
 		sort.Strings(test.expected)
 

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -294,7 +294,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			if ephemeralVol {
 				cifsMountFlags = util.JoinMountOptions(cifsMountFlags, strings.Split(ephemeralVolMountOptions, ","))
 			}
-			mountOptions = appendDefaultMountOptions(cifsMountFlags, d.appendClosetimeoOption)
+			mountOptions = appendDefaultMountOptions(cifsMountFlags, d.appendNoShareSockOption, d.appendClosetimeoOption)
 		}
 	}
 

--- a/pkg/azurefileplugin/main.go
+++ b/pkg/azurefileplugin/main.go
@@ -58,6 +58,7 @@ var (
 	appendMountErrorHelpLink               = flag.Bool("append-mount-error-help-link", true, "Whether to include a link for help with mount errors when a mount error occurs.")
 	enableWindowsHostProcess               = flag.Bool("enable-windows-host-process", false, "enable windows host process")
 	appendClosetimeoOption                 = flag.Bool("append-closetimeo-option", false, "Whether appending closetimeo=0 option to smb mount command")
+	appendNoShareSockOption                = flag.Bool("append-nosharesock-option", true, "Whether appending nosharesock option to smb mount command")
 )
 
 func main() {
@@ -101,6 +102,7 @@ func handle() {
 		KubeAPIBurst:                           *kubeAPIBurst,
 		EnableWindowsHostProcess:               *enableWindowsHostProcess,
 		AppendClosetimeoOption:                 *appendClosetimeoOption,
+		AppendNoShareSockOption:                *appendNoShareSockOption,
 	}
 	driver := azurefile.NewDriver(&driverOptions)
 	if driver == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: append nosharesock mount option on Linux node by default

`nosharesock` mount option should be the default mount option, it could avoid sharing same file share mount when there are multiple PVs pointing to the same file share.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: append nosharesock mount option on Linux node by default
```
