### PR TITLE
[release-1.24] fix: append nosharesock mount option on Linux node by default

### DIFF
--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -93,8 +93,9 @@ func TestNewFakeDriver(t *testing.T) {
 
 func TestAppendDefaultMountOptions(t *testing.T) {
 	tests := []struct {
-		options  []string
-		expected []string
+		options                 []string
+		appendNoShareSockOption bool
+		expected                []string
 	}{
 		{
 			options: []string{"dir_mode=0777"},
@@ -183,10 +184,32 @@ func TestAppendDefaultMountOptions(t *testing.T) {
 				mfsymlinks,
 			},
 		},
+		{
+			options:                 []string{""},
+			appendNoShareSockOption: true,
+			expected: []string{"", fmt.Sprintf("%s=%s",
+				fileMode, defaultFileMode),
+				fmt.Sprintf("%s=%s", dirMode, defaultDirMode),
+				fmt.Sprintf("%s=%s", actimeo, defaultActimeo),
+				mfsymlinks,
+				"nosharesock",
+			},
+		},
+		{
+			options:                 []string{"nosharesock"},
+			appendNoShareSockOption: true,
+			expected: []string{fmt.Sprintf("%s=%s",
+				fileMode, defaultFileMode),
+				fmt.Sprintf("%s=%s", dirMode, defaultDirMode),
+				fmt.Sprintf("%s=%s", actimeo, defaultActimeo),
+				mfsymlinks,
+				"nosharesock",
+			},
+		},
 	}
 
 	for _, test := range tests {
-		result := appendDefaultMountOptions(test.options)
+		result := appendDefaultMountOptions(test.options, test.appendNoShareSockOption)
 		sort.Strings(result)
 		sort.Strings(test.expected)
 

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -295,7 +295,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			if ephemeralVol {
 				cifsMountFlags = util.JoinMountOptions(cifsMountFlags, strings.Split(ephemeralVolMountOptions, ","))
 			}
-			mountOptions = appendDefaultMountOptions(cifsMountFlags)
+			mountOptions = appendDefaultMountOptions(cifsMountFlags, d.appendNoShareSockOption)
 		}
 	}
 

--- a/pkg/azurefileplugin/main.go
+++ b/pkg/azurefileplugin/main.go
@@ -54,6 +54,7 @@ var (
 	enableVHDDiskFeature                   = flag.Bool("enable-vhd", true, "enable VHD disk feature (experimental)")
 	kubeAPIQPS                             = flag.Float64("kube-api-qps", 25.0, "QPS to use while communicating with the kubernetes apiserver.")
 	kubeAPIBurst                           = flag.Int("kube-api-burst", 50, "Burst to use while communicating with the kubernetes apiserver.")
+	appendNoShareSockOption                = flag.Bool("append-nosharesock-option", true, "Whether appending nosharesock option to smb mount command")
 )
 
 func main() {
@@ -93,6 +94,7 @@ func handle() {
 		EnableVHDDiskFeature:                   *enableVHDDiskFeature,
 		KubeAPIQPS:                             *kubeAPIQPS,
 		KubeAPIBurst:                           *kubeAPIBurst,
+		AppendNoShareSockOption:                *appendNoShareSockOption,
 	}
 	driver := azurefile.NewDriver(&driverOptions)
 	if driver == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: append nosharesock mount option on Linux node by default
cherry pick of https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/1267

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: append nosharesock mount option on Linux node by default
```
