### PR TITLE
fix: don't use account search cache in RandomMatchingAccount mode

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -434,7 +434,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, err.Error())
 			}
-			if cache != nil {
+			if cache != nil && !selectRandomMatchingAccount {
 				accountName = cache.(string)
 			} else {
 				d.volLockMap.LockEntry(lockKey)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: don't use account search cache in RandomMatchingAccount mode
this PR together with https://github.com/kubernetes-sigs/cloud-provider-azure/pull/4203, would fix the RandomMatchingAccount issue.

```
I0630 11:53:05.980948       1 controllerserver.go:501] begin to create file share(pvc-1b33dba8-3c37-41f1-9e47-ce7e1a9b3139) on account(f0001cbc9dd7d4637a9e443) type(Standard_LRS) subID() rg(mc_andy-aks126_andy-aks126_eastus2) location() size(100) protocol(SMB)
I0630 11:53:06.009768       1 azure_storageaccount.go:254] randomly pick one matching account, index: 1, matching accounts: [{andyaccount Standard_LRS eastus2} {f0001cbc9dd7d4637a9e443 Standard_LRS eastus2}]
I0630 11:53:06.009784       1 azure_storageaccount.go:258] found a matching account f0001cbc9dd7d4637a9e443 type Standard_LRS location eastus2
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1308

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: don't use account search cache in RandomMatchingAccount mode
```
