### PR TITLE
fix: incorrect volume usage on Windows node with host process deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
 	github.com/jongio/azidext/go/azidext v0.5.0
 	github.com/onsi/ginkgo/v2 v2.11.0
+	golang.org/x/sys v0.11.0
 	k8s.io/pod-security-admission v0.27.4
 )
 
@@ -132,7 +133,6 @@ require (
 	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/term v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/pkg/azurefile/azure_common_darwin.go
+++ b/pkg/azurefile/azure_common_darwin.go
@@ -20,6 +20,10 @@ limitations under the License.
 package azurefile
 
 import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	mount "k8s.io/mount-utils"
 )
 
@@ -37,4 +41,9 @@ func preparePublishPath(path string, m *mount.SafeFormatAndMount) error {
 
 func prepareStagePath(path string, m *mount.SafeFormatAndMount) error {
 	return nil
+}
+
+// GetVolumeStats returns volume stats based on the given path.
+func GetVolumeStats(path string, enableWindowsHostProcess bool) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Errorf(codes.Internal, "GetVolumeStats is not supported on darwin")
 }

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -877,6 +877,9 @@ func TestNodeGetVolumeStats(t *testing.T) {
 	d := NewFakeDriver()
 
 	for _, test := range tests {
+		if runtime.GOOS == "darwin" {
+			continue
+		}
 		_, err := d.NodeGetVolumeStats(context.Background(), &test.req)
 		//t.Errorf("[debug] error: %v\n metrics: %v", err, metrics)
 		if !reflect.DeepEqual(err, test.expectedErr) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: incorrect volume usage on Windows node with host process deployment

<details>

 - get permission denied in non host process deployment
```
I0813 14:38:57.305188    7060 utils.go:76] GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0813 14:38:57.305188    7060 utils.go:77] GRPC request: {"volume_id":"csi-c67aa8fb6faecd9e38978fab46a3b86d1de33a34c810ea2c7a1250431092c4ad","volume_path":"c:\\var\\lib\\kubelet\\pods\\3fa8e1e7-f4af-4609-8527-33f4e4395941\\volumes\\kubernetes.io~csi\\test-volume-1\\mount"}
E0813 14:38:57.374862    7060 utils.go:81] GRPC error: rpc error: code = Internal desc = failed to get free space on path c:\var\lib\kubelet\pods\3fa8e1e7-f4af-4609-8527-33f4e4395941\volumes\kubernetes.io~csi\test-volume-1\mount: Access is denied.
```

 - works in host process deployment
 ```
I0813 15:05:12.981989    1188 utils.go:76] GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0813 15:05:12.981989    1188 utils.go:77] GRPC request: {"volume_id":"capz-b1ujhx#f2b755625a29b4c7e9804f4#pvc-6cc51713-bb44-4756-ad6b-35f5e504f963###azurefile-9188","volume_path":"c:\\var\\lib\\kubelet\\pods\\b4840a41-22dd-4adf-9266-05568bc51dea\\volumes\\kubernetes.io~csi\\pvc-6cc51713-bb44-4756-ad6b-35f5e504f963\\mount"}
I0813 15:05:12.998393    1188 utils.go:83] GRPC response: {"usage":[{"available":10737352704,"total":10737418240,"unit":1,"used":65536}]}
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: incorrect volume usage on Windows node
```
