### PR TITLE
fix: stop resize file share when account limit is exceeded

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -250,6 +250,8 @@ type Driver struct {
 	accountSearchCache azcache.Resource
 	// a timed cache storing tag removing history (solve account update throttling issue)
 	removeTagCache azcache.Resource
+	// a timed cache when resize file share failed due to account limit exceeded
+	resizeFileShareFailureCache azcache.Resource
 }
 
 // NewDriver Creates a NewCSIDriver object. Assumes vendor version is equal to driver version &
@@ -300,6 +302,10 @@ func NewDriver(options *DriverOptions) *Driver {
 	}
 
 	if driver.dataPlaneAPIAccountCache, err = azcache.NewTimedCache(10*time.Minute, getter, false); err != nil {
+		klog.Fatalf("%v", err)
+	}
+
+	if driver.resizeFileShareFailureCache, err = azcache.NewTimedCache(3*time.Minute, getter, false); err != nil {
 		klog.Fatalf("%v", err)
 	}
 

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -1039,6 +1039,16 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 		subsID = d.cloud.SubscriptionID
 	}
 
+	if accountName != "" {
+		cache, err := d.resizeFileShareFailureCache.Get(accountName, azcache.CacheReadTypeDefault)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "resizeFileShareFailureCache(%s) failed with error: %v", accountName, err)
+		}
+		if cache != nil {
+			return nil, status.Errorf(codes.Internal, "account(%s) is in %s, wait for a few minutes to retry", accountName, accountLimitExceedManagementAPI)
+		}
+	}
+
 	mc := metrics.NewMetricContext(azureFileCSIDriverName, "controller_expand_volume", resourceGroupName, subsID, d.Name)
 	isOperationSucceeded := false
 	defer func() {
@@ -1060,6 +1070,11 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 	}
 
 	if err = d.ResizeFileShare(ctx, subsID, resourceGroupName, accountName, fileShareName, int(requestGiB), secrets); err != nil {
+		if strings.Contains(err.Error(), accountLimitExceedManagementAPI) || strings.Contains(err.Error(), accountLimitExceedDataPlaneAPI) {
+			if accountName != "" {
+				d.resizeFileShareFailureCache.Set(accountName, "")
+			}
+		}
 		return nil, status.Errorf(codes.Internal, "expand volume error: %v", err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: stop resize file share when account limit is exceeded

<details>

```
W0807 02:36:49.123547       1 azurefile.go:835] ResizeFileShare(pvc-cfc300e0-0045-401f-8f8c-757910acd8b4) on account(xxx) with new size(419) failed with error(failed to update quota on file share(pvc-cfc300e0-0045-401f-8f8c-757910acd8b4), err: storage.FileSharesClient#Update: Failure responding to request: StatusCode=429 -- Original Error: autorest/azure: Service returned an error. Status=429 Code="TooManyRequests" Message="The request is being throttled as the limit has been reached for operation type - Write_ObservationWindow_00:00:01. For more information, see - https://aka.ms/srpthrottlinglimits"), waiting for retrying

W0807 02:36:49.123579       1 utils.go:139] sleep 180 more seconds, waiting for throttling complete

E0807 02:40:56.098924       1 utils.go:81] GRPC error: rpc error: code = Internal desc = expand volume error: failed to update quota on file share(pvc-cfc300e0-0045-401f-8f8c-757910acd8b4), err: storage.FileSharesClient#Update: Failure sending request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="TotalSharesProvisionedCapacityExceedsAccountLimit" Message="The total provisioned capacity of the shares cannot exceed the account maximum size limit.\nRequestId:93685d91-701a-0039-16d8-c83a72000000\nTime:2023-08-07T02:40:56.0668135Z"
```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: stop resize file share when account limit is exceeded
```
