### PR TITLE
fix: check storage account type if parameter is missing

### DIFF
--- a/deploy/example/azure.json
+++ b/deploy/example/azure.json
@@ -6,8 +6,8 @@
     "location": "eastus2",                         // mandatory
     "aadClientId": "xxxx-xxxx-xxxx-xxxx-xxxx",     // mandatory if using service principal
     "aadClientSecret": "xxxx-xxxx-xxxx-xxxx-xxxx", // mandatory if using service principal
-    "useManagedIdentityExtension": false,          // set true if using managed idenitty
-    "userAssignedIdentityID": "",                  // mandatory if using managed idenitty
+    "useManagedIdentityExtension": false,          // set true if using managed identity
+    "userAssignedIdentityID": "",                  // mandatory if using managed identity
     "useInstanceMetadata": true,                   // optional
     "vmType": "standard",                          // optional
     "subnetName": "k8s-subnet",                    // optional

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -173,7 +173,7 @@ Enable [large file shares](https://docs.microsoft.com/azure/storage/files/storag
 ##### Premium Files
 Azure premium files follows provisioned model where IOPS and throughput are associated to the quota. See this article that explains the co-relation between share size and IOPS and throughput - [link](https://docs.microsoft.com/azure/storage/files/understanding-billing#provisioned-model). Increase the share quota by following this guide - [link](https://github.com/kubernetes-sigs/azurefile-csi-driver/tree/master/deploy/example/resize).
 
-##### For more, refer to this doc for perforance troubleshooting tips - [Link to performance troubleshooting tips](https://docs.microsoft.com/en-us/azure/storage/files/storage-troubleshooting-files-performance)
+##### For more, refer to this doc for performance troubleshooting tips - [Link to performance troubleshooting tips](https://docs.microsoft.com/en-us/azure/storage/files/storage-troubleshooting-files-performance)
 
 ##### [Storage considerations for Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/storage)
 ##### [Compare access to Azure Files, Blob Storage, and Azure NetApp Files with NFS](https://learn.microsoft.com/en-us/azure/storage/common/nfs-comparison#comparison)

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -336,7 +336,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		shareProtocol = storage.EnabledProtocolsNFS
 		// NFS protocol does not need account key
 		storeAccountKey = false
-		// reset protocol field (compatble with "fsType: nfs")
+		// reset protocol field (compatible with "fsType: nfs")
 		setKeyValueInMap(parameters, protocolField, protocol)
 
 		if !pointer.BoolDeref(createPrivateEndpoint, false) {

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -359,6 +359,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 	}
 
+	if resourceGroup == "" {
+		resourceGroup = d.cloud.ResourceGroup
+	}
+
 	fileShareSize := int(requestGiB)
 	// account kind should be FileStorage for Premium File
 	accountKind := string(storage.KindStorageV2)
@@ -385,10 +389,6 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			}
 		}
 		validFileShareName = getValidFileShareName(name)
-	}
-
-	if resourceGroup == "" {
-		resourceGroup = d.cloud.ResourceGroup
 	}
 
 	tags, err := ConvertTagsToMap(customTags)

--- a/test/e2e/driver/azurefile_driver.go
+++ b/test/e2e/driver/azurefile_driver.go
@@ -39,7 +39,7 @@ type AzureFileDriver struct {
 	driverName string
 }
 
-// InitAzureFileDriver returns AzureFileDriver that implemnts DynamicPVTestDriver interface
+// InitAzureFileDriver returns AzureFileDriver that implements DynamicPVTestDriver interface
 func InitAzureFileDriver() PVTestDriver {
 	driverName := os.Getenv(AzureDriverNameVar)
 	if driverName == "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

While using StorageClass with samba protocol without explicitly specifying strorage account type users get a misleading message and volume creation fails:

`Status=400 Code="InvalidHeaderValue" Message="The value for one of the HTTP headers is not in the correct format.`

This happens in a scenario when creating a volume with size < 100Gi and storage account name (premium type) was provided as a parameter in `StorageClass` while `skuName` was omitted. Premium requirement is that a fileshare must have at least 100Gi in size.

Driver can lookup storage account type via storage account client and use that instead of relying on the`skuName` parameter that users otherwise need to set manually. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1390

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:
```
`skuName` storage class parameter is now optional when using premium storage account with volume sizes below 100Gi
```
