### PR TITLE
fix: upgrade base image to alpine 3.18 to fix DNS issue

### DIFF
--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.15.1
+FROM alpine:3.18.3
 
 ARG ARCH=amd64
 ARG binary=./_output/${ARCH}/azurefileplugin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: upgrade base image to alpine 3.18 to fix DNS issue

tricky thing is that nslookup works inside the driver with alpine 3.15 image, but cifs mount returns dns resolution error, return error msg:
```
Output: mount error: could not resolve address for xxx.file.core.windows.net: Unknown error
```

https://www.msn.com/en-us/news/technology/alpine-linux-318-fixes-dns-over-tcp-issue-now-ready-for-all-the-internets-problems/ar-AA1bfaqi#:~:text=For%20many%20years%2C%20and%20by%20design%2C%20Musl%20did,meaning%20that%20it%20also%20works%20in%20Alpine%203.18.

The latest update to the ultra-lightweight Alpine Linux distro, as widely used for hosting Docker containers, fixes an important issue.…

There are many relatively small new features in Alpine 3.18, but one of them, while niche, could prove significant. One of several unusual things about Alpine Linux is that it doesn't use glibc, the standard C library that is the basis of almost all other Linux distros. Instead, Alpine is based on the smaller, lighter Musl libc.

For many years, and by design, Musl did not support DNS over TCP, only over UDP.

This has caused some Alpine users much consternation, and that has led some people to turn against Alpine. Well, no more: DNS over TCP is now supported in Musl 1.2.4, meaning that it also works in Alpine 3.18.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: upgrade base image to alpine 3.18 to fix DNS issue
```
