### PR TITLE
fix: revert alpine base image change to fix DNS issue

### DIFF
--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.3
+FROM registry.k8s.io/build-image/debian-base:bullseye-v1.4.3
 
 ARG ARCH=amd64
 ARG binary=./_output/${ARCH}/azurefileplugin
 COPY ${binary} /azurefileplugin
 
-RUN apk upgrade --available --no-cache && \
-    apk add --no-cache ca-certificates cifs-utils util-linux e2fsprogs-extra udev xfsprogs-extra nfs-utils
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates cifs-utils util-linux e2fsprogs mount udev xfsprogs nfs-common netbase
 
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: revert alpine base image change to fix DNS issue

revert of https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/1175

On some k8s clusters with customer vnet setting, cifs mount cannot resolve DNS while nslookup works well, and switch to debian-base image works.

 - Root cause: 
cifs mount is using [getaddrinfo](https://github.com/piastry/cifs-utils/blob/316522036133d44ed02cd39ed2748e2b59c85b30/resolve_host.c#L48) invoked by [resolve_host](https://github.com/piastry/cifs-utils/blob/316522036133d44ed02cd39ed2748e2b59c85b30/mount.cifs.c#L1897) which finally depends on glibc implementation on debian based image, while on alpine image, it's using musl, getaddrinfo may not handle DNS well in lots of cases: https://github.com/alpinelinux/docker-alpine/issues/155, so we decided to using debian base image which are using glibc lib.

other reference: https://github.com/nodejs/docker-node/issues/1030#issuecomment-956122581

btw, though alpine is updating musl lib which could solve dns-over-tcp (on alpine 3.18), while it's still not suggested to use alpine image since we don't know whether there is other potential dns issue: https://news.ycombinator.com/item?id=35056594

```
E0901 04:03:22.810456       1 utils.go:81] GRPC error: rpc error: code = Internal desc = volume(rg-aue-dev-mex-api-005#xxx#pvc-832fd08c-9c26-445c-89cf-27be3d21f200###aks-aue-dev-mex-02-apigateway-int) mount //xxx.file.core.windows.net/pvc-832fd08c-9c26-445c-89cf-27be3d21f200 on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/ab9b06cbec2b8378408965f5085bdd6debe6f12289c8f1549fe17bd96d104fe3/globalmount failed with mount failed: exit status 1
Mounting command: mount
Mounting arguments: -t cifs -o mfsymlinks,actimeo=30,nosharesock,gid=1000,file_mode=0777,dir_mode=0777,<masked> //xxx.file.core.windows.net/pvc-832fd08c-9c26-445c-89cf-27be3d21f200 /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/ab9b06cbec2b8378408965f5085bdd6debe6f12289c8f1549fe17bd96d104fe3/globalmount
Output: mount error: could not resolve address for xxx.file.core.windows.net: Unknown error
E0901 04:03:22.811614       1 mount_linux.go:195] Mount failed: exit status 1
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: revert alpine base image change to fix DNS issue
```
