### PR TITLE
test: fix external test failure

### DIFF
--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -32,6 +32,8 @@ setup_e2e_binaries() {
     export EXTRA_HELM_OPTIONS=" --set driver.name=$DRIVER.csi.azure.com --set controller.name=csi-$DRIVER-controller --set linux.dsName=csi-$DRIVER-node --set windows.dsName=csi-$DRIVER-node-win"
     sed -i "s/file.csi.azure.com/$DRIVER.csi.azure.com/g" deploy/example/storageclass-azurefile-csi.yaml
     sed -i "s/file.csi.azure.com/$DRIVER.csi.azure.com/g" deploy/example/storageclass-azurefile-nfs.yaml
+    # run e2e test on standard storage class since premium file share only supports volume size >= 100GiB
+    sed -i "s/Premium/Standard/g" deploy/example/storageclass-azurefile-csi.yaml
     make e2e-bootstrap
     sed -i "s/csi-azurefile-controller/csi-$DRIVER-controller/g" deploy/example/metrics/csi-azurefile-controller-svc.yaml
     make create-metrics-svc

--- a/test/external-e2e/testdriver-nfs.yaml
+++ b/test/external-e2e/testdriver-nfs.yaml
@@ -22,3 +22,5 @@ DriverInfo:
   StressTestOptions:
     NumPods: 10
     NumRestarts: 10
+  SupportedSizeRange:
+    Min: 100Gi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
test: fix external test failure

original external test is trying to expand premium file share with 6GB size, and failed with following error:
```
I1120 12:37:47.522673       1 utils.go:76] GRPC call: /csi.v1.Controller/ControllerExpandVolume
I1120 12:37:47.522688       1 utils.go:77] GRPC request: {"capacity_range":{"required_bytes":6442450944},"volume_capability":{"AccessType":{"Mount":{"mount_flags":["dir_mode=0777","file_mode=0777","mfsymlinks","cache=strict","nosharesock","actimeo=30"]}},"access_mode":{"mode":7}},"volume_id":"capz-yh200k#f6f8bd190baf14f198b41b5#pvc-af526e92-c040-4ab5-9b31-a4ba1ab60ef3###volume-expand-6158"}
I1120 12:37:47.522896       1 azurefile.go:550] got storage account(f6f8bd190baf14f198b41b5) from secret
I1120 12:37:47.525989       1 azure_metrics.go:115] "Observed Request Latency" latency_seconds=0.003096173 request="azurefile_csi_driver_controller_expand_volume" resource_group="capz-yh200k" subscription_id="0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e" source="test.csi.azure.com" volumeid="capz-yh200k#f6f8bd190baf14f198b41b5#pvc-af526e92-c040-4ab5-9b31-a4ba1ab60ef3###volume-expand-6158" result_code="failed_csi_driver_controller_expand_volume"
E1120 12:37:47.526007       1 utils.go:81] GRPC error: rpc error: code = Internal desc = expand volume error: failed to set quota on file share pvc-af526e92-c040-4ab5-9b31-a4ba1ab60ef3, err: storage: service returned error: StatusCode=400, ErrorCode=InvalidHeaderValue, ErrorMessage=The value for one of the HTTP headers is not in the correct format.
RequestId:87359983-d01a-0099-5aae-1b8f8b000000
Time:2023-11-20T12:37:47.5277155Z, Req
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
