### PR TITLE
fix: increase volume cloning timeout and reduce time cost

### DIFF
--- a/pkg/azurefile/azurefile_options.go
+++ b/pkg/azurefile/azurefile_options.go
@@ -45,6 +45,7 @@ type DriverOptions struct {
 	VolStatsCacheExpireInMinutes           int
 	PrintVolumeStatsCallLogs               bool
 	SasTokenExpirationMinutes              int
+	WaitForAzCopyTimeoutMinutes            int
 	KubeConfig                             string
 	Endpoint                               string
 	AzcopyUseSasToken                      bool
@@ -79,7 +80,8 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.IntVar(&o.SkipMatchingTagCacheExpireInMinutes, "skip-matching-tag-cache-expire-in-minutes", 30, "The cache expire time in minutes for skipMatchingTagCache")
 	fs.IntVar(&o.VolStatsCacheExpireInMinutes, "vol-stats-cache-expire-in-minutes", 10, "The cache expire time in minutes for volume stats cache")
 	fs.BoolVar(&o.PrintVolumeStatsCallLogs, "print-volume-stats-call-logs", false, "Whether to print volume statfs call logs with log level 2")
-	fs.IntVar(&o.SasTokenExpirationMinutes, "sas-token-expiration-minutes", 1440, "sas token expiration minutes during volume cloning")
+	fs.IntVar(&o.SasTokenExpirationMinutes, "sas-token-expiration-minutes", 1440, "sas token expiration minutes during volume cloning and snapshot restore")
+	fs.IntVar(&o.WaitForAzCopyTimeoutMinutes, "wait-for-azcopy-timeout-minutes", 18, "timeout in minutes for waiting for azcopy to finish")
 	fs.StringVar(&o.KubeConfig, "kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
 	fs.StringVar(&o.Endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	fs.BoolVar(&o.AzcopyUseSasToken, "azcopy-use-sas-token", true, "Whether SAS token should be used in azcopy based on volume clone and snapshot restore")

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -53,10 +53,11 @@ var (
 
 func NewFakeDriver() *Driver {
 	driverOptions := DriverOptions{
-		NodeID:     fakeNodeID,
-		DriverName: DefaultDriverName,
-		KubeConfig: "",
-		Endpoint:   "tcp://127.0.0.1:0",
+		NodeID:                      fakeNodeID,
+		DriverName:                  DefaultDriverName,
+		KubeConfig:                  "",
+		Endpoint:                    "tcp://127.0.0.1:0",
+		WaitForAzCopyTimeoutMinutes: 1,
 	}
 	driver := NewDriver(&driverOptions)
 	driver.Name = fakeDriverName


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: increase volume cloning timeout and reduce time cost
```
I0119 16:02:28.249983       1 controllerserver.go:558] begin to create file share(pvc-2be8db95-bfdd-40ea-af4e-6bec11a63c42) on account(f3f8a72cba75146cea68300) type(Standard_LRS) subID() rg(capz-q1e8te) location() size(10) protocol(SMB)
I0119 16:02:28.406155       1 controllerserver.go:1265] generate sas token for account(f3f8a72cba75146cea68300)
I0119 16:02:28.422141       1 azurefile.go:1019] azcopy job status: NotFound, copy percent: %, error: <nil>
I0119 16:02:28.422176       1 azurefile.go:1023] begin to copy fileshare pvc-08990f2c-6be3-4927-99ac-9256deb73c1a to pvc-2be8db95-bfdd-40ea-af4e-6bec11a63c42
I0119 16:02:30.423114       1 azurefile.go:1037] copy fileshare pvc-08990f2c-6be3-4927-99ac-9256deb73c1a to pvc-2be8db95-bfdd-40ea-af4e-6bec11a63c42
I0119 16:02:32.597637       1 azurefile.go:1058] copied fileshare pvc-08990f2c-6be3-4927-99ac-9256deb73c1a to pvc-2be8db95-bfdd-40ea-af4e-6bec11a63c42 successfully
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1676

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: increase volume cloning timeout and reduce time cost
```
