### PR TITLE
[release-1.30] fix: trim slash in RemoveSmbGlobalMapping

### DIFF
--- a/pkg/os/smb/smb.go
+++ b/pkg/os/smb/smb.go
@@ -57,6 +57,7 @@ func NewSmbGlobalMapping(remotePath, username, password string) error {
 }
 
 func RemoveSmbGlobalMapping(remotePath string) error {
+	remotePath = strings.TrimSuffix(remotePath, `\`)
 	cmd := `Remove-SmbGlobalMapping -RemotePath $Env:smbremotepath -Force`
 	klog.V(2).Infof("begin to run RemoveSmbGlobalMapping with %s", remotePath)
 	if output, err := util.RunPowershellCmd(cmd, fmt.Sprintf("smbremotepath=%s", remotePath)); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: trim slash in RemoveSmbGlobalMapping

```
I0419 05:10:41.566746    5668 safe_mounter_host_process_windows.go:145] remote server path: UNC\f95c76592b2ac4bcb957ad4.file.core.windows.net\pre-provisioned-multiple-pods\, local path: c:\var\lib\kubelet\plugins\kubernetes.io\csi\file.csi.azure.com\ff618e8b87f48350191c3ebae8902d9c38e17ee1b1913422f168f2865355330c\globalmount
I0419 05:10:41.567453    5668 smb.go:110] checking file ff618e8b87f48350191c3ebae8902d9c38e17ee1b1913422f168f2865355330c
I0419 05:10:41.567529    5668 smb.go:114] skip current mount path c:\var\lib\kubelet\plugins\kubernetes.io\csi\file.csi.azure.com\ff618e8b87f48350191c3ebae8902d9c38e17ee1b1913422f168f2865355330c\globalmount
I0419 05:10:41.567560    5668 smb.go:85] begin to run RemoveSmbGlobalMapping with \\f95c76592b2ac4bcb957ad4.file.core.windows.net\pre-provisioned-multiple-pods\
I0419 05:10:41.569358    5668 util.go:76] Executing command: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -Mta -NoProfile -Command Remove-SmbGlobalMapping -RemotePath $Env:smbremotepath -Force"
E0419 05:10:42.663584    5668 safe_mounter_host_process_windows.go:151] RemoveSmbGlobalMapping(c:\var\lib\kubelet\plugins\kubernetes.io\csi\file.csi.azure.com\ff618e8b87f48350191c3ebae8902d9c38e17ee1b1913422f168f2865355330c\globalmount) failed with UnmountSmbShare failed. output: "Remove-SmbGlobalMapping : No MSFT_SmbGlobalMapping objects found with property 'RemotePath' equal to \r\n'\\\\f95c76592b2ac4bcb957ad4.file.core.windows.net\\pre-provisioned-multiple-pods\\'.  Verify the value of the property \r\nand retry.\r\nAt line:1 char:1\r\n+ Remove-SmbGlobalMapping -RemotePath $Env:smbremotepath -Force\r\n+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n    + CategoryInfo          : ObjectNotFound: (\\\\f95c76592b2ac...-multiple-pods\\:String) [Remove-SmbGlobalMapping], Ci \r\n   mJobException\r\n    + FullyQualifiedErrorId : CmdletizationQuery_NotFound_RemotePath,Remove-SmbGlobalMapping\r\n \r\n", err: exit status 1
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: trim slash in RemoveSmbGlobalMapping
```
