### PR TITLE
cleanup: refine extensiveMountCheck usage in unmount

### DIFF
--- a/pkg/azurefile/azure_common_linux.go
+++ b/pkg/azurefile/azure_common_linux.go
@@ -33,12 +33,12 @@ func SMBMount(m *mount.SafeFormatAndMount, source, target, fsType string, option
 	return m.MountSensitive(source, target, fsType, options, sensitiveMountOptions)
 }
 
-func SMBUnmount(m *mount.SafeFormatAndMount, target string, _, _ bool) error {
-	return mount.CleanupMountPoint(target, m.Interface, true /*extensiveMountPointCheck*/)
+func SMBUnmount(m *mount.SafeFormatAndMount, target string, extensiveMountCheck, _ bool) error {
+	return mount.CleanupMountPoint(target, m.Interface, extensiveMountCheck)
 }
 
-func CleanupMountPoint(m *mount.SafeFormatAndMount, target string, _ bool) error {
-	return mount.CleanupMountPoint(target, m.Interface, true /*extensiveMountPointCheck*/)
+func CleanupMountPoint(m *mount.SafeFormatAndMount, target string, extensiveMountCheck bool) error {
+	return mount.CleanupMountPoint(target, m.Interface, extensiveMountCheck)
 }
 
 func preparePublishPath(_ string, _ *mount.SafeFormatAndMount) error {

--- a/pkg/mounter/safe_mounter_host_process_windows.go
+++ b/pkg/mounter/safe_mounter_host_process_windows.go
@@ -134,8 +134,7 @@ func (mounter *winMounter) Unmount(target string) error {
 	remoteServer, err := smb.GetRemoteServerFromTarget(target)
 	if err == nil {
 		klog.V(2).Infof("remote server path: %s, local path: %s", remoteServer, target)
-		hasDupSMBMount, err := smb.CheckForDuplicateSMBMounts(driverGlobalMountPath, target, remoteServer)
-		if err == nil {
+		if hasDupSMBMount, err := smb.CheckForDuplicateSMBMounts(driverGlobalMountPath, target, remoteServer); err == nil {
 			if !hasDupSMBMount {
 				remoteServer = strings.Replace(remoteServer, "UNC\\", "\\\\", 1)
 				if err := smb.RemoveSmbGlobalMapping(remoteServer); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
cleanup: refine extensiveMountCheck usage in unmount

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
