### PR TITLE
fix: nfs mount failure when there are multiple subnets in the cluster

### DIFF
--- a/pkg/azurefile/azure_test.go
+++ b/pkg/azurefile/azure_test.go
@@ -267,8 +267,6 @@ func TestUpdateSubnetServiceEndpoints(t *testing.T) {
 				}
 
 				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeSubnet, nil).Times(1)
-				mockSubnetClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-
 				_, err := d.updateSubnetServiceEndpoints(ctx, "", "", "subnetname")
 				if !reflect.DeepEqual(err, nil) {
 					t.Errorf("Unexpected error: %v", err)
@@ -285,7 +283,7 @@ func TestUpdateSubnetServiceEndpoints(t *testing.T) {
 					Name: pointer.String("subnetName"),
 				}
 
-				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeSubnet, nil).Times(1)
+				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeSubnet, nil).AnyTimes()
 
 				_, err := d.updateSubnetServiceEndpoints(ctx, "", "", "subnetname")
 				if !reflect.DeepEqual(err, nil) {
@@ -307,7 +305,7 @@ func TestUpdateSubnetServiceEndpoints(t *testing.T) {
 					Name: pointer.String("subnetName"),
 				}
 
-				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeSubnet, nil).Times(1)
+				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeSubnet, nil).AnyTimes()
 
 				_, err := d.updateSubnetServiceEndpoints(ctx, "", "", "subnetname")
 				if !reflect.DeepEqual(err, nil) {

--- a/pkg/azurefile/azure_test.go
+++ b/pkg/azurefile/azure_test.go
@@ -28,10 +28,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/azurefile-csi-driver/test/utils/testutil"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/subnetclient/mocksubnetclient"
-	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 
 	azureprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 )
@@ -246,25 +246,14 @@ func TestUpdateSubnetServiceEndpoints(t *testing.T) {
 		testFunc func(t *testing.T)
 	}{
 		{
-			name: "[fail] no subnet",
-			testFunc: func(t *testing.T) {
-				retErr := retry.NewError(false, fmt.Errorf("the subnet does not exist"))
-				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(network.Subnet{}, retErr).Times(1)
-				expectedErr := fmt.Errorf("failed to get the subnet %s under vnet %s: %v", config.SubnetName, config.VnetName, retErr)
-				err := d.updateSubnetServiceEndpoints(ctx, "", "", "")
-				if !reflect.DeepEqual(err, expectedErr) {
-					t.Errorf("Unexpected error: %v", err)
-				}
-			},
-		},
-		{
-			name: "[success] subnetPropertiesFormat is nil",
+			name: "[fail] subnet name is nil",
 			testFunc: func(t *testing.T) {
 				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(network.Subnet{}, nil).Times(1)
 				mockSubnetClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-				err := d.updateSubnetServiceEndpoints(ctx, "", "", "")
-				if !reflect.DeepEqual(err, nil) {
+				_, err := d.updateSubnetServiceEndpoints(ctx, "", "", "subnetname")
+				expectedErr := fmt.Errorf("subnet name is nil")
+				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 			},
@@ -274,12 +263,13 @@ func TestUpdateSubnetServiceEndpoints(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				fakeSubnet := network.Subnet{
 					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{},
+					Name:                   pointer.String("subnetName"),
 				}
 
 				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeSubnet, nil).Times(1)
 				mockSubnetClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-				err := d.updateSubnetServiceEndpoints(ctx, "", "", "")
+				_, err := d.updateSubnetServiceEndpoints(ctx, "", "", "subnetname")
 				if !reflect.DeepEqual(err, nil) {
 					t.Errorf("Unexpected error: %v", err)
 				}
@@ -292,12 +282,12 @@ func TestUpdateSubnetServiceEndpoints(t *testing.T) {
 					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 						ServiceEndpoints: &[]network.ServiceEndpointPropertiesFormat{},
 					},
+					Name: pointer.String("subnetName"),
 				}
 
 				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeSubnet, nil).Times(1)
-				mockSubnetClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-				err := d.updateSubnetServiceEndpoints(ctx, "", "", "")
+				_, err := d.updateSubnetServiceEndpoints(ctx, "", "", "subnetname")
 				if !reflect.DeepEqual(err, nil) {
 					t.Errorf("Unexpected error: %v", err)
 				}
@@ -314,11 +304,12 @@ func TestUpdateSubnetServiceEndpoints(t *testing.T) {
 							},
 						},
 					},
+					Name: pointer.String("subnetName"),
 				}
 
 				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeSubnet, nil).Times(1)
 
-				err := d.updateSubnetServiceEndpoints(ctx, "", "", "")
+				_, err := d.updateSubnetServiceEndpoints(ctx, "", "", "subnetname")
 				if !reflect.DeepEqual(err, nil) {
 					t.Errorf("Unexpected error: %v", err)
 				}
@@ -329,7 +320,7 @@ func TestUpdateSubnetServiceEndpoints(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				d.cloud.SubnetsClient = nil
 				expectedErr := fmt.Errorf("SubnetsClient is nil")
-				err := d.updateSubnetServiceEndpoints(ctx, "", "", "")
+				_, err := d.updateSubnetServiceEndpoints(ctx, "", "", "")
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)
 				}

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -259,6 +259,8 @@ type Driver struct {
 	volStatsCache azcache.Resource
 	// a timed cache storing account which should use sastoken for azcopy based volume cloning
 	azcopySasTokenCache azcache.Resource
+	// a timed cache storing subnet operations
+	subnetCache azcache.Resource
 	// sas expiry time for azcopy in volume clone and snapshot restore
 	sasTokenExpirationMinutes int
 	// azcopy timeout for volume clone and snapshot restore
@@ -345,6 +347,10 @@ func NewDriver(options *DriverOptions) *Driver {
 		options.VolStatsCacheExpireInMinutes = 10 // default expire in 10 minutes
 	}
 	if driver.volStatsCache, err = azcache.NewTimedCache(time.Duration(options.VolStatsCacheExpireInMinutes)*time.Minute, getter, false); err != nil {
+		klog.Fatalf("%v", err)
+	}
+
+	if driver.subnetCache, err = azcache.NewTimedCache(10*time.Minute, getter, false); err != nil {
 		klog.Fatalf("%v", err)
 	}
 

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -368,15 +368,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 		if !pointer.BoolDeref(createPrivateEndpoint, false) {
 			// set VirtualNetworkResourceIDs for storage account firewall setting
-			subnets := strings.Split(subnetName, ",")
-			for _, subnet := range subnets {
-				subnet = strings.TrimSpace(subnet)
-				vnetResourceID := d.getSubnetResourceID(vnetResourceGroup, vnetName, subnet)
-				klog.V(2).Infof("set vnetResourceID(%s) for NFS protocol", vnetResourceID)
-				vnetResourceIDs = append(vnetResourceIDs, vnetResourceID)
-				if err := d.updateSubnetServiceEndpoints(ctx, vnetResourceGroup, vnetName, subnet); err != nil {
-					return nil, status.Errorf(codes.Internal, "update service endpoints failed with error: %v", err)
-				}
+			var err error
+			if vnetResourceIDs, err = d.updateSubnetServiceEndpoints(ctx, vnetResourceGroup, vnetName, subnetName); err != nil {
+				return nil, status.Errorf(codes.Internal, "update service endpoints failed with error: %v", err)
 			}
 		}
 	}

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -666,9 +666,9 @@ func TestCreateVolume(t *testing.T) {
 				mockSubnetClient := mocksubnetclient.NewMockInterface(ctrl)
 				fakeCloud.SubnetsClient = mockSubnetClient
 
-				mockSubnetClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(network.Subnet{}, retErr).Times(1)
+				mockSubnetClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return([]network.Subnet{}, retErr).Times(1)
 
-				expectedErr := status.Errorf(codes.Internal, "update service endpoints failed with error: failed to get the subnet fake-subnet under vnet fake-vnet: &{false 0 0001-01-01 00:00:00 +0000 UTC the subnet does not exist}")
+				expectedErr := status.Errorf(codes.Internal, "update service endpoints failed with error: failed to list the subnets under rg rg vnet fake-vnet: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: the subnet does not exist")
 				_, err := d.CreateVolume(ctx, req)
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: nfs mount failure when there are multiple subnets in the cluster

When there are multiple node pools (with multiple subnets) in the cluster, this driver would only set the first node pool to storage account ACL, which makes nfs mount fails with "access denied" error when pods with nfs volume are scheduled to other node pool, this PR adds multiple subnets into the account ACL.

```
I0803 02:52:00.813091       1 utils.go:101] GRPC call: /csi.v1.Controller/CreateVolume
I0803 02:52:00.813116       1 utils.go:102] GRPC request: {"capacity_range":{"required_bytes":107374182400},"name":"pvc-290b8eb8-8d36-4566-81e7-054bba14160b","parameters":{"csi.storage.k8s.io/pv/name":"pvc-290b8eb8-8d36-4566-81e7-054bba14160b","csi.storage.k8s.io/pvc/name":"pvc-njfwt","csi.storage.k8s.io/pvc/namespace":"azurefile-799","protocol":"nfs","selectRandomMatchingAccount":"true","skuName":"Premium_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{}},"access_mode":{"mode":7}}]}
I0803 02:52:00.813580       1 azure.go:192] updateSubnetServiceEndpoints on vnetName: capz-vc119e-vnet, subnetName: , location: canadacentral
I0803 02:52:00.912435       1 azure.go:227] set vnetResourceID /subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/capz-vc119e/providers/Microsoft.Network/virtualNetworks/capz-vc119e-vnet/subnets/control-plane-subnet
I0803 02:52:00.912483       1 azure.go:255] begin to update the subnet control-plane-subnet under vnet capz-vc119e-vnet in rg capz-vc119e
I0803 02:52:34.485387       1 azure.go:227] set vnetResourceID /subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/capz-vc119e/providers/Microsoft.Network/virtualNetworks/capz-vc119e-vnet/subnets/node-subnet
I0803 02:52:34.485418       1 azure.go:255] begin to update the subnet node-subnet under vnet capz-vc119e-vnet in rg capz-vc119e
I0803 02:53:08.176359       1 azure_storageaccount.go:409] subnetID(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/capz-vc119e/providers/Microsoft.Network/virtualNetworks/capz-vc119e-vnet/subnets/control-plane-subnet) has been set
I0803 02:53:08.176404       1 azure_storageaccount.go:409] subnetID(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/capz-vc119e/providers/Microsoft.Network/virtualNetworks/capz-vc119e-vnet/subnets/node-subnet) has been set
```

<details>

```
I0803 07:42:49.152917       1 azure.go:255] begin to update the subnet control-plane-subnet under vnet capz-wkuzxj-vnet in rg capz-wkuzxj
I0803 07:48:16.648251       1 azure.go:255] begin to update the subnet control-plane-subnet under vnet capz-wkuzxj-vnet in rg capz-wkuzxj
I0803 07:48:16.833393       1 azure_armclient.go:302] Received error in sendAsync.send: resourceID: https://management.azure.com/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/capz-wkuzxj/providers/Microsoft.Network/virtualNetworks/capz-wkuzxj-vnet/subnets/control-plane-subnet?api-version=2022-07-01, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: {
  "error": {
    "code": "AnotherOperationInProgress",
    "message": "Another operation on this or dependent resource is in progress. To retrieve status of the operation use uri: https://management.azure.com/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/providers/Microsoft.Network/locations/uksouth/operations/8f83a19b-48e4-47b6-8bf0-30e21085fdef?api-version=2020-11-01.",
    "details": []
  }
}
```

</details>


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: nfs mount failure when there are multiple subnets in the cluster
```
