### PR TITLE
 fix: support mulltiple subnet when creating private endpoints

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -344,9 +344,6 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	shareProtocol := storage.EnabledProtocolsSMB
 	var createPrivateEndpoint *bool
 	if strings.EqualFold(networkEndpointType, privateEndpoint) {
-		if strings.Contains(subnetName, ",") {
-			return nil, status.Errorf(codes.InvalidArgument, "subnetName(%s) can only contain one subnet for private endpoint", subnetName)
-		}
 		createPrivateEndpoint = pointer.BoolPtr(true)
 	}
 	var vnetResourceIDs []string

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -609,33 +609,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid privateEndpoint and subnetName combination",
-			testFunc: func(t *testing.T) {
-				allParam := map[string]string{
-					networkEndpointTypeField: "privateendpoint",
-					subnetNameField:          "subnet1,subnet2",
-				}
-
-				req := &csi.CreateVolumeRequest{
-					Name:               "invalid-privateEndpoint-and-subnetName-combination",
-					CapacityRange:      stdCapRange,
-					VolumeCapabilities: stdVolCap,
-					Parameters:         allParam,
-				}
-
-				d := NewFakeDriver()
-				d.cloud = &azure.Cloud{
-					Config: azure.Config{},
-				}
-
-				expectedErr := status.Errorf(codes.InvalidArgument, "subnetName(subnet1,subnet2) can only contain one subnet for private endpoint")
-				_, err := d.CreateVolume(ctx, req)
-				if !reflect.DeepEqual(err, expectedErr) {
-					t.Errorf("Unexpected error: %v, expected error: %v", err, expectedErr)
-				}
-			},
-		},
-		{
 			name: "Failed to update subnet service endpoints",
 			testFunc: func(t *testing.T) {
 				allParam := map[string]string{

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_storageaccount.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_storageaccount.go
@@ -282,9 +282,6 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 	}
 
 	subnetName := accountOptions.SubnetName
-	if subnetName == "" {
-		subnetName = az.SubnetName
-	}
 
 	if accountOptions.SubscriptionID != "" && !strings.EqualFold(accountOptions.SubscriptionID, az.Config.SubscriptionID) && accountOptions.ResourceGroup == "" {
 		return "", "", fmt.Errorf("resourceGroup must be specified when subscriptionID(%s) is not empty", accountOptions.SubscriptionID)
@@ -578,17 +575,22 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 		if accountOptions.StorageType == StorageTypeBlob {
 			privateEndpointName = privateEndpointName + blobNameSuffix
 		}
-		if err := az.createPrivateEndpoint(ctx, accountName, storageAccount.ID, privateEndpointName, vnetResourceGroup, vnetName, subnetName, location, accountOptions.StorageType); err != nil {
-			return "", "", fmt.Errorf("create private endpoint for storage account(%s), resourceGroup(%s): %w", accountName, vnetResourceGroup, err)
+		var privateEndpointNames []string
+		var rerr error
+		if privateEndpointNames, rerr = az.createPrivateEndpoint(ctx, accountName, storageAccount.ID, privateEndpointName, vnetResourceGroup, vnetName, subnetName, location, accountOptions.StorageType); rerr != nil {
+			return "", "", fmt.Errorf("create private endpoint for storage account(%s), resourceGroup(%s): %w", accountName, vnetResourceGroup, rerr)
 		}
 
-		// Create dns zone group
+		// Create one dns zone group associated with one virtual network
 		dnsZoneGroupName := accountName + "-dnszonegroup"
 		if accountOptions.StorageType == StorageTypeBlob {
 			dnsZoneGroupName = dnsZoneGroupName + blobNameSuffix
 		}
-		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, vnetName, privateDNSZoneName); err != nil {
-			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointName, vnetName, vnetResourceGroup, err)
+		// Create or update private DNS zone group associated with each private endpoint which associated with one subnet
+		for _, privateEndpointNameOnSubnet := range privateEndpointNames {
+			if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointNameOnSubnet, vnetResourceGroup, vnetName, privateDNSZoneName); err != nil {
+				return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointNameOnSubnet, vnetName, vnetResourceGroup, err)
+			}
 		}
 	}
 
@@ -601,43 +603,74 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 	return accountName, accountKey, nil
 }
 
-func (az *Cloud) createPrivateEndpoint(ctx context.Context, accountName string, accountID *string, privateEndpointName, vnetResourceGroup, vnetName, subnetName, location string, storageType StorageType) error {
+func (az *Cloud) createPrivateEndpoint(ctx context.Context, accountName string, accountID *string, privateEndpointName, vnetResourceGroup, vnetName, subnetName, location string, storageType StorageType) ([]string, error) {
 	klog.V(2).Infof("Creating private endpoint(%s) for account (%s)", privateEndpointName, accountName)
-
-	subnet, _, err := az.getSubnet(vnetResourceGroup, vnetName, subnetName)
-	if err != nil {
-		return err
-	}
-	if subnet.SubnetPropertiesFormat == nil {
-		klog.Errorf("SubnetPropertiesFormat of (%s, %s) is nil", vnetName, subnetName)
+	var subnets []network.Subnet
+	var privateEndpointNames []string
+	if subnetName != "" {
+		// list multiple subnets separated by comma
+		subnetNames := strings.Split(subnetName, ",")
+		for _, sn := range subnetNames {
+			sn = strings.TrimSpace(sn)
+			subnet, _, err := az.getSubnet(vnetResourceGroup, vnetName, sn)
+			if err != nil {
+				return privateEndpointNames, err
+			}
+			subnets = append(subnets, subnet)
+		}
 	} else {
-		// Disable the private endpoint network policies before creating private endpoint
-		subnet.SubnetPropertiesFormat.PrivateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled
+		var err error
+		subnets, err = az.listSubnet(vnetResourceGroup, vnetName)
+		if err != nil {
+			return privateEndpointNames, fmt.Errorf("failed to list subnets under rg %s vnet %s: %w", vnetResourceGroup, vnetName, err)
+		}
 	}
 
-	if rerr := az.SubnetsClient.CreateOrUpdate(ctx, vnetResourceGroup, vnetName, subnetName, subnet); rerr != nil {
-		return rerr.Error()
-	}
+	for idx, subnet := range subnets {
+		if subnet.Name == nil {
+			return privateEndpointNames, fmt.Errorf("subnet name is nil")
+		}
+		sn := *subnet.Name
+		if subnet.SubnetPropertiesFormat == nil {
+			klog.Errorf("SubnetPropertiesFormat of (%s, %s) is nil", vnetName, sn)
+		} else {
+			// Disable the private endpoint network policies before creating private endpoint
+			subnet.SubnetPropertiesFormat.PrivateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled
+		}
 
-	//Create private endpoint
-	privateLinkServiceConnectionName := accountName + "-pvtsvcconn"
-	if storageType == StorageTypeBlob {
-		privateLinkServiceConnectionName = privateLinkServiceConnectionName + blobNameSuffix
-	}
-	privateLinkServiceConnection := network.PrivateLinkServiceConnection{
-		Name: &privateLinkServiceConnectionName,
-		PrivateLinkServiceConnectionProperties: &network.PrivateLinkServiceConnectionProperties{
-			GroupIds:             &[]string{string(storageType)},
-			PrivateLinkServiceID: accountID,
-		},
-	}
-	privateLinkServiceConnections := []network.PrivateLinkServiceConnection{privateLinkServiceConnection}
-	privateEndpoint := network.PrivateEndpoint{
-		Location:                  &location,
-		PrivateEndpointProperties: &network.PrivateEndpointProperties{Subnet: &subnet, PrivateLinkServiceConnections: &privateLinkServiceConnections},
-	}
+		if rerr := az.SubnetsClient.CreateOrUpdate(ctx, vnetResourceGroup, vnetName, sn, subnet); rerr != nil {
+			return privateEndpointNames, rerr.Error()
+		}
 
-	return az.privateendpointclient.CreateOrUpdate(ctx, vnetResourceGroup, privateEndpointName, privateEndpoint, "", true).Error()
+		//Create private endpoint
+		privateLinkServiceConnectionName := accountName + "-pvtsvcconn"
+		if storageType == StorageTypeBlob {
+			privateLinkServiceConnectionName = privateLinkServiceConnectionName + blobNameSuffix
+		}
+		privateLinkServiceConnection := network.PrivateLinkServiceConnection{
+			Name: &privateLinkServiceConnectionName,
+			PrivateLinkServiceConnectionProperties: &network.PrivateLinkServiceConnectionProperties{
+				GroupIds:             &[]string{string(storageType)},
+				PrivateLinkServiceID: accountID,
+			},
+		}
+		privateLinkServiceConnections := []network.PrivateLinkServiceConnection{privateLinkServiceConnection}
+		privateEndpoint := network.PrivateEndpoint{
+			Location:                  &location,
+			PrivateEndpointProperties: &network.PrivateEndpointProperties{Subnet: &subnets[idx], PrivateLinkServiceConnections: &privateLinkServiceConnections},
+		}
+
+		privateEndpointNameOnSubnet := privateEndpointName
+		if len(subnets) > 1 {
+			privateEndpointNameOnSubnet = fmt.Sprintf("%s-%d", privateEndpointName, idx)
+		}
+		privateEndpointNames = append(privateEndpointNames, privateEndpointNameOnSubnet)
+		klog.V(2).Infof("begin to create private endpoint(%s) on subnet(%s) under vnet(%s) in rg(%s)", privateEndpointNameOnSubnet, sn, vnetName, vnetResourceGroup)
+		if err := az.privateendpointclient.CreateOrUpdate(ctx, vnetResourceGroup, privateEndpointNameOnSubnet, privateEndpoint, "", true).Error(); err != nil {
+			return privateEndpointNames, fmt.Errorf("failed to create private endpoint(%s) on subnet(%s) under vnet(%s) in rg(%s): %w", privateEndpointNameOnSubnet, sn, vnetName, vnetResourceGroup, err)
+		}
+	}
+	return privateEndpointNames, nil
 }
 
 func (az *Cloud) createPrivateDNSZone(ctx context.Context, vnetResourceGroup, privateDNSZoneName string) error {

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_subnet_repo.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_subnet_repo.go
@@ -67,3 +67,22 @@ func (az *Cloud) getSubnet(vnetResourceGroup, virtualNetworkName, subnetName str
 	}
 	return subnet, exists, nil
 }
+
+func (az *Cloud) listSubnet(vnetResourceGroup, virtualNetworkName string) ([]network.Subnet, error) {
+	if vnetResourceGroup == "" {
+		if len(az.VnetResourceGroup) > 0 {
+			vnetResourceGroup = az.VnetResourceGroup
+		} else {
+			vnetResourceGroup = az.ResourceGroup
+		}
+	}
+
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+	subnets, rerr := az.SubnetsClient.List(ctx, vnetResourceGroup, virtualNetworkName)
+	if rerr != nil {
+		return subnets, rerr.Error()
+	}
+
+	return subnets, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**What this PR does / why we need it**:

fix: support mulltiple subnet when creating private endpoints
when specifying "networkEndpointType: privateEndpoint" in storage class, only first subnet is associated with a new private endpoint, this does not work when there are multiple subnets. Ideally when there are multiple subnets, multiple private endpoints should be created, every private endpoint is associated with one subnet, and only one dns zone will be created mapping to vnet and multiple private endpoints
For example, in csi logs below, there are two subnets(aks-subnet, subnet2), two private endpoint(f0240127bc91d4905903342-pvtendpoint-0, f0240127bc91d4905903342-pvtendpoint-1) will be created and one private DNS zone group(f0240127bc91d4905903342-dnszonegroup) will be created. 
cloud-provider-azure pr: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/6783
csi logs:
```
I0809 10:44:20.264799       1 utils.go:101] GRPC call: /csi.v1.Controller/CreateVolume
I0809 10:44:20.264829       1 utils.go:102] GRPC request: {"capacity_range":{"required_bytes":107374182400},"name":"pvc-a449228d-7696-48a9-b082-a98530a9401d","parameters":{"csi.storage.k8s.io/pv/name":"pvc-a449228d-7696-48a9-b082-a98530a9401d","csi.storage.k8s.io/pvc/name":"pvc-azurefile","csi.storage.k8s.io/pvc/namespace":"default","networkEndpointType":"privateEndpoint","skuName":"Premium_LRS","subnetName":"aks-subnet,subnet2"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["dir_mode=0777","file_mode=0777","mfsymlinks","cache=strict","nosharesock","actimeo=30","nobrl"]}},"access_mode":{"mode":5}}]}
I0809 10:44:20.508800       1 azure_storageaccount.go:344] found a matching account f0240127bc91d4905903342 type Premium_LRS location eastus
I0809 10:44:21.135082       1 azure_storageaccount.go:609] Creating private endpoint(f0240127bc91d4905903342-pvtendpoint) for account (f0240127bc91d4905903342)
I0809 10:44:21.707160       1 azure_storageaccount.go:670] begin to create private endpoint(f0240127bc91d4905903342-pvtendpoint-0) on subnet(aks-subnet) under vnet(aks-vnet-27574481) in rg(MC_aks-yxytest_group_aks-yxytest_eastus)
I0809 10:44:27.370234       1 azure_storageaccount.go:670] begin to create private endpoint(f0240127bc91d4905903342-pvtendpoint-1) on subnet(subnet2) under vnet(aks-vnet-27574481) in rg(MC_aks-yxytest_group_aks-yxytest_eastus)
I0809 10:44:33.498485       1 azure_storageaccount.go:721] Creating private DNS zone group(f0240127bc91d4905903342-dnszonegroup) with privateEndpoint(f0240127bc91d4905903342-pvtendpoint-0), vNetName(aks-vnet-27574481), resourceGroup(MC_aks-yxytest_group_aks-yxytest_eastus)
I0809 10:44:34.687096       1 azure_storageaccount.go:721] Creating private DNS zone group(f0240127bc91d4905903342-dnszonegroup) with privateEndpoint(f0240127bc91d4905903342-pvtendpoint-1), vNetName(aks-vnet-27574481), resourceGroup(MC_aks-yxytest_group_aks-yxytest_eastus)
I0809 10:44:35.663168       1 controllerserver.go:568] begin to create file share(pvc-a449228d-7696-48a9-b082-a98530a9401d) on account(f0240127bc91d4905903342) type(Premium_LRS) subID() rg(MC_aks-yxytest_group_aks-yxytest_eastus) location() size(100) protocol(SMB)
I0809 10:44:35.925792       1 controllerserver.go:600] create file share pvc-a449228d-7696-48a9-b082-a98530a9401d on storage account f0240127bc91d4905903342 successfully
I0809 10:44:35.935106       1 controllerserver.go:646] store account key to k8s secret(azure-storage-account-f0240127bc91d4905903342-secret) in default namespace
I0809 10:44:35.935406       1 azure_metrics.go:118] "Observed Request Latency" latency_seconds=15.670012553 request="azurefile_csi_driver_controller_create_volume" resource_group="mc_aks-yxytest_group_aks-yxytest_eastus" subscription_id="" source="file.csi.azure.com" volumeid="MC_aks-yxytest_group_aks-yxytest_eastus#f0240127bc91d4905903342#pvc-a449228d-7696-48a9-b082-a98530a9401d###default" result_code="succeeded"
I0809 10:44:35.935528       1 utils.go:108] GRPC response: {"volume":{"capacity_bytes":107374182400,"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-a449228d-7696-48a9-b082-a98530a9401d","csi.storage.k8s.io/pvc/name":"pvc-azurefile","csi.storage.k8s.io/pvc/namespace":"default","networkEndpointType":"privateEndpoint","secretnamespace":"default","server":"f0240127bc91d4905903342.privatelink.file.core.windows.net","skuName":"Premium_LRS","subnetName":"aks-subnet,subnet2"},"volume_id":"MC_aks-yxytest_group_aks-yxytest_eastus#f0240127bc91d4905903342#pvc-a449228d-7696-48a9-b082-a98530a9401d###default"}}


```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/2047

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
