### PR TITLE
fix: wait for azcopy job running in snapshot restore and clone

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/fileclient"
@@ -1068,30 +1069,41 @@ func (d *Driver) copyFileShareByAzcopy(srcFileShareName, dstFileShareName, srcPa
 
 	jobState, percent, err := d.azcopy.GetAzcopyJob(dstFileShareName, authAzcopyEnv)
 	klog.V(2).Infof("azcopy job status: %s, copy percent: %s%%, error: %v", jobState, percent, err)
+
 	switch jobState {
 	case volumehelper.AzcopyJobError, volumehelper.AzcopyJobCompleted:
 		return err
 	case volumehelper.AzcopyJobRunning:
-		return fmt.Errorf("wait for the existing AzCopy job to complete, current copy percentage is %s%%", percent)
+		err = wait.PollImmediate(20*time.Second, time.Duration(d.waitForAzCopyTimeoutMinutes)*time.Minute, func() (bool, error) {
+			jobState, percent, err := d.azcopy.GetAzcopyJob(dstFileShareName, authAzcopyEnv)
+			klog.V(2).Infof("azcopy job status: %s, copy percent: %s%%, error: %v", jobState, percent, err)
+			if err != nil {
+				return false, err
+			}
+			if jobState == volumehelper.AzcopyJobRunning {
+				return false, nil
+			}
+			return true, nil
+		})
 	case volumehelper.AzcopyJobNotFound:
 		klog.V(2).Infof("copy fileshare %s:%s to %s:%s", srcAccountName, srcFileShareName, dstAccountName, dstFileShareName)
-		execFuncWithAuth := func() error {
+		execAzcopyJob := func() error {
 			if out, err := d.execAzcopyCopy(srcPathAuth, dstPath, azcopyCopyOptions, authAzcopyEnv); err != nil {
 				return fmt.Errorf("exec error: %v, output: %v", err, string(out))
 			}
 			return nil
 		}
 		timeoutFunc := func() error {
-			_, percent, _ := d.azcopy.GetAzcopyJob(dstFileShareName, authAzcopyEnv)
-			return fmt.Errorf("timeout waiting for copy fileshare %s:%s to %s:%s complete, current copy percent: %s%%", srcAccountName, srcFileShareName, dstAccountName, dstFileShareName, percent)
+			jobState, percent, _ := d.azcopy.GetAzcopyJob(dstFileShareName, authAzcopyEnv)
+			return fmt.Errorf("azcopy job status: %s, timeout waiting for copy fileshare %s:%s to %s:%s complete, current copy percent: %s%%", jobState, srcAccountName, srcFileShareName, dstAccountName, dstFileShareName, percent)
 		}
-		copyErr := volumehelper.WaitUntilTimeout(time.Duration(d.waitForAzCopyTimeoutMinutes)*time.Minute, execFuncWithAuth, timeoutFunc)
-		if copyErr != nil {
-			klog.Warningf("CopyFileShare(%s, %s, %s) failed with error: %v", accountOptions.ResourceGroup, dstAccountName, dstFileShareName, copyErr)
-		} else {
-			klog.V(2).Infof("copied fileshare %s to %s successfully", srcFileShareName, dstFileShareName)
-		}
-		return copyErr
+		err = volumehelper.WaitUntilTimeout(time.Duration(d.waitForAzCopyTimeoutMinutes)*time.Minute, execAzcopyJob, timeoutFunc)
+	}
+
+	if err != nil {
+		klog.Warningf("CopyFileShare(%s, %s, %s) failed with error: %v", accountOptions.ResourceGroup, dstAccountName, dstFileShareName, err)
+	} else {
+		klog.V(2).Infof("copied fileshare %s to %s successfully", srcFileShareName, dstFileShareName)
 	}
 	return err
 }

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/azurefile-csi-driver/pkg/util"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/fileshareclient/mock_fileshareclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/mock_azclient"
@@ -1643,41 +1642,6 @@ var _ = ginkgo.Describe("TestCopyVolume", func() {
 			gomega.Expect(err).To(gomega.Equal(expectedErr))
 		})
 	})
-	ginkgo.When("azcopy job is in progress", func() {
-		ginkgo.It("should fail", func(ctx context.Context) {
-
-			mp := map[string]string{}
-
-			volumeSource := &csi.VolumeContentSource_VolumeSource{
-				VolumeId: "vol_1#f5713de20cde511e8ba4900#fileshare#",
-			}
-			volumeContentSourceVolumeSource := &csi.VolumeContentSource_Volume{
-				Volume: volumeSource,
-			}
-			volumecontensource := csi.VolumeContentSource{
-				Type: volumeContentSourceVolumeSource,
-			}
-
-			req := &csi.CreateVolumeRequest{
-				Name:                "unit-test",
-				VolumeCapabilities:  stdVolCap,
-				Parameters:          mp,
-				VolumeContentSource: &volumecontensource,
-			}
-
-			m := util.NewMockEXEC(ctrl)
-			listStr1 := "JobId: ed1c3833-eaff-fe42-71d7-513fb065a9d9\nStart Time: Monday, 07-Aug-23 03:29:54 UTC\nStatus: InProgress\nCommand: copy https://{accountName}.file.core.windows.net/{srcFileshare}{SAStoken} https://{accountName}.file.core.windows.net/{dstFileshare}{SAStoken} --recursive --check-length=false"
-			m.EXPECT().RunCommand(gomock.Eq("azcopy jobs list | grep dstFileshare -B 3"), gomock.Any()).Return(listStr1, nil).Times(1)
-			m.EXPECT().RunCommand(gomock.Not("azcopy jobs list | grep dstFileshare -B 3"), gomock.Any()).Return("Percent Complete (approx): 50.0", nil)
-
-			d.azcopy.ExecCmd = m
-
-			expectedErr := fmt.Errorf("wait for the existing AzCopy job to complete, current copy percentage is 50.0%%")
-			err := d.copyVolume(ctx, req, "", "sastoken", []string{}, "", &ShareOptions{Name: "dstFileshare"}, nil, "core.windows.net")
-			gomega.Expect(err).To(gomega.Equal(expectedErr))
-		})
-	})
-
 })
 
 var _ = ginkgo.Describe("ControllerGetVolume", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: wait for azcopy job running in snapshot restore and clone

 - original behavior
```
I1130 09:00:23.572985       1 utils.go:102] GRPC request: {"capacity_range":{"required_bytes":1073741824000},"name":"pvc-9a891963-4d08-4642-860d-52b313a34599","parameters":{"csi.storage.k8s.io/pv/name":"pvc-9a891963-4d08-4642-860d-52b313a34599","csi.storage.k8s.io/pvc/name":"pvc-azurefilesrestore-100gb-33","csi.storage.k8s.io/pvc/namespace":"churntest","skuName":"Premium_ZRS","useDataPlaneAPI":"true"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["mfsymlinks","actimeo=30","nosharesock"]}},"access_mode":{"mode":7}}],"volume_content_source":{"Type":{"Snapshot":{"snapshot_id":"MC_mayaggarea_mayankscrubber_eastasia#f9c8e62184bb34a229251e1#pvc-a6a88fbf-8b57-4652-9634-6995c6a39b05###churntest#2024-11-27T08:49:15.0000000Z"}}}}
I1130 09:00:23.572962       1 utils.go:101] GRPC call: /csi.v1.Controller/CreateVolume
I1130 06:00:10.554098       1 controllerserver.go:1388] generate sas token for account(f5536663891bc4178a86cce)
I1130 06:00:10.554131       1 controllerserver.go:1403] use sas token for account(f5536663891bc4178a86cce) since this account is found in azcopySasTokenCache
I1130 06:00:10.554166       1 controllerserver.go:1388] generate sas token for account(f9c8e62184bb34a229251e1)
I1130 06:00:10.554178       1 controllerserver.go:1403] use sas token for account(f9c8e62184bb34a229251e1) since this account is found in azcopySasTokenCache
I1130 06:00:10.623513       1 controllerserver.go:1085] azcopy job status: Running, copy percent: 0.0%, error: <nil>
I1130 06:00:10.623608       1 azure_metrics.go:118] "Observed Request Latency" latency_seconds=0.5001277 request="azurefile_csi_driver_controller_create_volume_from_snapshot" resource_group="mc_mayaggarea_mayankscrubber_eastasia" subscription_id="" source="file.csi.azure.com" volumeid="" result_code="failed_csi_driver_controller_create_volume_from_snapshot"
E1130 06:00:10.623639       1 utils.go:106] GRPC error: wait for the existing AzCopy job to complete, current copy percentage is 0.0%
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: wait for azcopy job running in snapshot restore and clone
```
