### PR TITLE
chore: append subsid in snapshot id

### DIFF
--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -340,3 +340,17 @@ func isConfidentialRuntimeClass(ctx context.Context, kubeClient clientset.Interf
 	klog.Infof("runtimeClass %s handler: %s", runtimeClassName, runtimeClass.Handler)
 	return runtimeClass.Handler == confidentialRuntimeClassHandler, nil
 }
+
+// getSnapshotID returns snapshotID based on srcVolSubsID, srcVolumeID, itemSnapshot and subsID
+func getSnapshotID(srcVolSubsID, srcVolumeID, itemSnapshot, subsID string) string {
+	snapshotID := srcVolumeID + "#" + itemSnapshot
+	if srcVolSubsID == "" {
+		// if srcVolumeID does not contain subscription id, append it to snapshotID
+		if strings.HasSuffix(srcVolumeID, "#") {
+			snapshotID = srcVolumeID + subsID + "#" + itemSnapshot
+		} else {
+			snapshotID = srcVolumeID + "#" + subsID + "#" + itemSnapshot
+		}
+	}
+	return snapshotID
+}

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -814,3 +814,45 @@ func TestIsConfidentialRuntimeClass(t *testing.T) {
 		t.Fatalf("expected an error, got nil")
 	}
 }
+
+func TestGetSnapshotID(t *testing.T) {
+	tests := []struct {
+		desc            string
+		srcVolumeSubsID string
+		srcVolumeID     string
+		itemSnapshot    string
+		subsID          string
+		expected        string
+	}{
+		{
+			desc:            "srcVolumeSubsID contains subsID",
+			srcVolumeSubsID: "subsID",
+			srcVolumeID:     "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#subsID",
+			itemSnapshot:    "snapshot",
+			expected:        "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#subsID#snapshot",
+		},
+		{
+			desc:            "srcVolumeSubsID is empty",
+			srcVolumeSubsID: "",
+			srcVolumeID:     "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace",
+			itemSnapshot:    "snapshot",
+			subsID:          "subsID",
+			expected:        "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#subsID#snapshot",
+		},
+		{
+			desc:            "srcVolumeSubsID is empty but contains # at the end",
+			srcVolumeSubsID: "",
+			srcVolumeID:     "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#",
+			itemSnapshot:    "snapshot",
+			subsID:          "subsID",
+			expected:        "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#subsID#snapshot",
+		},
+	}
+
+	for _, test := range tests {
+		result := getSnapshotID(test.srcVolumeSubsID, test.srcVolumeID, test.itemSnapshot, test.subsID)
+		if result != test.expected {
+			t.Errorf("test[%s]: unexpected output: %v, expected result: %v", test.desc, result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
chore: append subsid in snapshot id, this could make snapshot copy across different subs work

<details>

```
 - before the change

I1208 10:28:01.445822       1 utils.go:101] GRPC call: /csi.v1.Controller/CreateSnapshot
I1208 10:28:01.445904       1 utils.go:102] GRPC request: {"name":"snapshot-d5ba2ca6-a632-4de2-9da6-fed6fb7b8a66","source_volume_id":"capz-0srnt6#f5181a7da05654559a366ab#pvc-1f27c75b-5c53-47f5-b87a-30edfad0ce84###azurefile-7082"}
I1208 10:28:01.555096       1 controllerserver.go:1291] list snapshot of share(pvc-1f27c75b-5c53-47f5-b87a-30edfad0ce84) under account(f5181a7da05654559a366ab) rg(capz-0srnt6) subsID() with total number(1)
I1208 10:28:01.894431       1 controllerserver.go:940] created share snapshot: 2024-12-08T10:28:01.0000000Z, time: 2024-12-08 10:28:01 +0000 UTC, quota: 0GiB
I1208 10:28:01.894625       1 controllerserver.go:951] get file share(pvc-1f27c75b-5c53-47f5-b87a-30edfad0ce84) account(f5181a7da05654559a366ab) quota from cloud
I1208 10:28:01.997267       1 azure_metrics.go:118] "Observed Request Latency" latency_seconds=0.551169793 request="azurefile_csi_driver_controller_create_snapshot" resource_group="capz-0srnt6" subscription_id="46678f10-4bbb-447e-98e8-d2829589f2d8" source="file.csi.azure.com" source_resource_id="capz-0srnt6#f5181a7da05654559a366ab#pvc-1f27c75b-5c53-47f5-b87a-30edfad0ce84###azurefile-7082" snapshot_name="snapshot-d5ba2ca6-a632-4de2-9da6-fed6fb7b8a66" result_code="succeeded"
I1208 10:28:01.997310       1 utils.go:108] GRPC response: {"snapshot":{"creation_time":{"seconds":1733653681},"ready_to_use":true,"size_bytes":107374182400,"snapshot_id":"capz-0srnt6#f5181a7da05654559a366ab#pvc-1f27c75b-5c53-47f5-b87a-30edfad0ce84###azurefile-7082#2024-12-08T10:28:01.0000000Z","source_volume_id":"capz-0srnt6#f5181a7da05654559a366ab#pvc-1f27c75b-5c53-47f5-b87a-30edfad0ce84###azurefile-7082"}}

 - after the change
I1210 09:42:47.989221       1 utils.go:101] GRPC call: /csi.v1.Controller/CreateSnapshot
I1210 09:42:47.989243       1 utils.go:102] GRPC request: {"name":"snapshot-ce98bb28-c14a-4b4d-9371-60fa26dc6ccb","source_volume_id":"capz-xohk8b#f2d175f12bd584cf08c2d19#pvc-7848ce54-f5d1-493c-b728-f88a90249c6c###azurefile-1707"}
I1210 09:42:48.212875       1 controllerserver.go:1301] list snapshot of share(pvc-7848ce54-f5d1-493c-b728-f88a90249c6c) under account(f2d175f12bd584cf08c2d19) rg(capz-xohk8b) subsID() with total number(1)
I1210 09:42:48.713356       1 controllerserver.go:949] created share snapshot: 2024-12-10T09:42:48.0000000Z, time: 2024-12-10 09:42:48 +0000 UTC, quota: 0GiB
I1210 09:42:48.713410       1 controllerserver.go:960] get file share(pvc-7848ce54-f5d1-493c-b728-f88a90249c6c) account(f2d175f12bd584cf08c2d19) quota from cloud
I1210 09:42:48.803541       1 azure_metrics.go:118] "Observed Request Latency" latency_seconds=0.813851783 request="azurefile_csi_driver_controller_create_snapshot" resource_group="capz-xohk8b" subscription_id="46678f10-4bbb-447e-98e8-d2829589f2d8" source="file.csi.azure.com" source_resource_id="capz-xohk8b#f2d175f12bd584cf08c2d19#pvc-7848ce54-f5d1-493c-b728-f88a90249c6c###azurefile-1707" snapshot_name="snapshot-ce98bb28-c14a-4b4d-9371-60fa26dc6ccb" result_code="succeeded"
I1210 09:42:48.803868       1 utils.go:108] GRPC response: {"snapshot":{"creation_time":{"seconds":1733823768},"ready_to_use":true,"size_bytes":107374182400,"snapshot_id":"capz-xohk8b#f2d175f12bd584cf08c2d19#pvc-7848ce54-f5d1-493c-b728-f88a90249c6c###azurefile-1707#46678f10-4bbb-447e-98e8-d2829589f2d8#2024-12-10T09:42:48.0000000Z","source_volume_id":"capz-xohk8b#f2d175f12bd584cf08c2d19#pvc-7848ce54-f5d1-493c-b728-f88a90249c6c###azurefile-1707"}}

```

</details>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
chore: append subsid in snapshot id
```
