### PR TITLE
test: add UT for filewatcher

### DIFF
--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filewatcher
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWatchFileForChanges(t *testing.T) {
+	// Set mock exit once.
+	exit = func(_ int) {
+		// Mock, do nothing
+	}
+
+	t.Run("ExistingFile", func(t *testing.T) {
+		// Create a temporary file to watch
+		tmpfile, err := os.CreateTemp("", "testfile")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(tmpfile.Name())
+
+		// Now call the watcher
+		if err = WatchFileForChanges(tmpfile.Name()); err != nil {
+			t.Errorf("Failed to watch file: %v", err)
+		}
+
+		// Trigger the watcher
+		if err = os.WriteFile(tmpfile.Name(), []byte("new content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Let the watcher see the change
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	t.Run("NonExistentFile", func(t *testing.T) {
+		// Reset the watcher once before the test
+		resetWatchCertificateFileOnce()
+
+		err := WatchFileForChanges("nonexistentfile")
+		if err == nil || (!strings.Contains(err.Error(), "no such file or directory") &&
+			!strings.Contains(err.Error(), "The system cannot find the file specified")) {
+			t.Errorf("expected error to contain 'no such file or directory' or 'The system cannot find the file specified', got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This pull request introduces several changes to the `pkg/filewatcher` package to improve the handling of file watching and add tests. The most important changes include the addition of a mockable exit function, the introduction of a reset function for testing purposes, and the creation of new tests for the file watcher functionality.

Changes to `pkg/filewatcher/filewatcher.go`:

* Added a mockable `exit` function to handle program termination, replacing direct calls to `os.Exit` with `exit` in the `checkForFileChanges` function. [[1]](diffhunk://#diff-5d8d60fa78da8b711b2e021fa0643a9e8d880a4ed6eca069019dd76d9a37677eR28-R39) [[2]](diffhunk://#diff-5d8d60fa78da8b711b2e021fa0643a9e8d880a4ed6eca069019dd76d9a37677eL67-R75)
* Introduced a `resetWatchCertificateFileOnce` function to reset the `watchCertificateFileOnce` variable for testing purposes.
* Removed an unnecessary goroutine in the `WatchFileForChanges` function to simplify the code.

Changes to `pkg/filewatcher/filewatcher_test.go`:

* Added a new test file with tests for the `WatchFileForChanges` function, including tests for existing and non-existent files.<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
