### PR TITLE
test: refine UT for ListenEndpoint in utils.go

### DIFF
--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -42,14 +42,10 @@ func parseEndpoint(ep string) (string, string, error) {
 	return "", "", fmt.Errorf("Invalid endpoint: %v", ep)
 }
 
-var klogFatalf = func(format string, args ...interface{}) {
-	klog.Fatalf(format, args...)
-}
-
 func ListenEndpoint(endpoint string) (net.Listener, error) {
 	proto, addr, err := parseEndpoint(endpoint)
 	if err != nil {
-		klogFatalf("Invalid endpoint: %v", err)
+		klog.Errorf("%v", err)
 		return nil, err
 	}
 
@@ -58,14 +54,14 @@ func ListenEndpoint(endpoint string) (net.Listener, error) {
 			addr = "/" + addr
 		}
 		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
-			klogFatalf("Failed to remove %s, error: %s", addr, err.Error())
+			klog.Errorf("Failed to remove %s, error: %v", addr, err)
 			return nil, err
 		}
 	}
 
 	listener, err := net.Listen(proto, addr)
 	if err != nil {
-		klogFatalf("Failed to listen: %v", err)
+		klog.Errorf("Failed to listen: %v", err)
 		return nil, err
 	}
 	return listener, err

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -310,10 +310,6 @@ func TestListenEndpoint(t *testing.T) {
 		t.Skip("Skip test on Windows")
 	}
 
-	originalKlogFatalf := klogFatalf
-	klogFatalf = func(_ string, _ ...interface{}) {}
-	defer func() { klogFatalf = originalKlogFatalf }()
-
 	tests := []struct {
 		name     string
 		endpoint string
@@ -344,14 +340,6 @@ func TestListenEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r != nil {
-					if !tt.wantErr {
-						t.Errorf("ListenEndpoint() panicked unexpectedly: %v", r)
-					}
-				}
-			}()
-
 			got, err := ListenEndpoint(tt.endpoint)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Listen() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
This pull request focuses on improving error handling in the `pkg/csi-common/utils.go` file by replacing calls to `klog.Fatalf` with `klog.Errorf`, and updating the associated test cases accordingly. The most important changes include the removal of the `klogFatalf` function, the modification of error logging in the `ListenEndpoint` function, and the simplification of the `TestListenEndpoint` test cases.

Improvements to error handling:

* [`pkg/csi-common/utils.go`](diffhunk://#diff-0d556f293c81880b06d6591091b951a2114fa383010513710c843f1d1b6a3e7aL45-R48): Removed the `klogFatalf` function and replaced calls to it with `klog.Errorf` in the `ListenEndpoint` function to avoid terminating the program on errors. [[1]](diffhunk://#diff-0d556f293c81880b06d6591091b951a2114fa383010513710c843f1d1b6a3e7aL45-R48) [[2]](diffhunk://#diff-0d556f293c81880b06d6591091b951a2114fa383010513710c843f1d1b6a3e7aL61-R64)

Updates to test cases:

* [`pkg/csi-common/utils_test.go`](diffhunk://#diff-ea2bc4fd189dd43f448b1da4dc719a1c8287f8850cafed8c4fd6f0595a1d28c1L313-L316): Simplified the `TestListenEndpoint` function by removing the override of `klogFatalf` and the associated deferred function for recovering from panics, as the program no longer terminates on errors. [[1]](diffhunk://#diff-ea2bc4fd189dd43f448b1da4dc719a1c8287f8850cafed8c4fd6f0595a1d28c1L313-L316) [[2]](diffhunk://#diff-ea2bc4fd189dd43f448b1da4dc719a1c8287f8850cafed8c4fd6f0595a1d28c1L347-L354)<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
