### PR TITLE
fix: aznfs package install failure on arm64 node

### DIFF
--- a/pkg/azurefile-proxy/init.sh
+++ b/pkg/azurefile-proxy/init.sh
@@ -37,5 +37,10 @@ if [ "$DISTRIBUTION" != "azurelinux" ] && [ "$DISTRIBUTION" != "ubuntu" ];then
   exit 0
 fi
 
+if [ "$ARCH" = "aarch64" ];then
+  echo "aznfs-mount is not supported on architecture: $ARCH"
+  exit 0
+fi
+
 . ./azurefile-proxy/install-proxy.sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: aznfs package install failure on arm64 node

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
<details>

```
# k logs -n kube-system csi-azurefile-node-467lg -c install-azurefile-proxy
+ MIGRATE_K8S_REPO=false
+ KUBELET_PATH=/var/lib/kubelet
+ [ /var/lib/kubelet != /var/lib/kubelet ]
+ HOST_CMD=nsenter --mount=/proc/1/ns/mnt
+ nsenter --mount=/proc/1/ns/mnt cat /etc/os-release
+ grep ^ID=
+ tr -d "
+ cut -d= -f2
+ DISTRIBUTION=ubuntu
+ nsenter --mount=/proc/1/ns/mnt uname -m
+ ARCH=aarch64
+ echo Linux distribution: ubuntu, Arch: aarch64
+ [ ubuntu != azurelinux ]
+ [ ubuntu != ubuntu ]
+ . ./azurefile-proxy/install-proxy.sh
+ set -xe
+ [ false = true ]
+ [ true = true ]
+ [ ubuntu = ubuntu ]
+ AZNFS_VERSION=0.3.15
+ echo install aznfs v0.3.15....
Linux distribution: ubuntu, Arch: aarch64
install aznfs v0.3.15....
+ . /host/etc/os-release
+ PRETTY_NAME=Ubuntu 22.04.5 LTS
+ NAME=Ubuntu
+ VERSION_ID=22.04
+ VERSION=22.04.5 LTS (Jammy Jellyfish)
+ VERSION_CODENAME=jammy
+ ID=ubuntu
+ ID_LIKE=debian
+ HOME_URL=https://www.ubuntu.com/
+ SUPPORT_URL=https://help.ubuntu.com/
+ BUG_REPORT_URL=https://bugs.launchpad.net/ubuntu/
+ PRIVACY_POLICY_URL=https://www.ubuntu.com/legal/terms-and-policies/privacy-policy
+ UBUNTU_CODENAME=jammy
+ echo ubuntu/22.04
+ nsenter --mount=/proc/1/ns/mnt curl -sSL -O https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
+ nsenter --mount=/proc/1/ns/mnt dpkg -i packages-microsoft-prod.deb
+ yes
(Reading database ... 69834 files and directories currently installed.)
Preparing to unpack packages-microsoft-prod.deb ...
Unpacking packages-microsoft-prod (1.0-ubuntu22.04.1) over (1.0-ubuntu22.04.1) ...
Setting up packages-microsoft-prod (1.0-ubuntu22.04.1) ...
+ nsenter --mount=/proc/1/ns/mnt apt-get update
Hit:1 https://packages.microsoft.com/ubuntu/22.04/prod testing InRelease
Hit:2 https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease
Hit:3 http://ports.ubuntu.com/ubuntu-ports jammy InRelease
Hit:4 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease
Hit:5 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease
Hit:6 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease
Reading package lists...
+ nsenter --mount=/proc/1/ns/mnt rm packages-microsoft-prod.deb
+ nsenter --mount=/proc/1/ns/mnt apt-get install -y aznfs=0.3.15
Reading package lists...
Building dependency tree...
Reading state information...
Package aznfs is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Version '0.3.15' for 'aznfs' was not found
```
</details>

<details>
```
# k logs -n kube-system csi-azurefile-node-48qgl -c install-azurefile-proxy
+ MIGRATE_K8S_REPO=false
+ KUBELET_PATH=/var/lib/kubelet
+ [ /var/lib/kubelet != /var/lib/kubelet ]
+ HOST_CMD=nsenter --mount=/proc/1/ns/mnt
+ nsenter --mount=/proc/1/ns/mnt cat /etc/os-release
+ grep ^ID=
+ cut -d= -f2
+ tr -d "
+ DISTRIBUTION=ubuntu
+ nsenter --mount=/proc/1/ns/mnt uname -m
Linux distribution: ubuntu, Arch: aarch64
aznfs-mount is not supported on architecture: aarch64
+ ARCH=aarch64
+ echo Linux distribution: ubuntu, Arch: aarch64
+ [ ubuntu != azurelinux ]
+ [ ubuntu != ubuntu ]
+ [ aarch64 = aarch64 ]
+ echo aznfs-mount is not supported on architecture: aarch64
+ exit 0
```
</details>

**Release note**:
```
fix: aznfs package install failure on arm64 node
```
