### PR TITLE
feat: support nfs volume clone and snapshot restore

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -1115,9 +1115,6 @@ func (d *Driver) ResizeFileShare(ctx context.Context, subsID, resourceGroup, acc
 
 // copyFileShare copies a fileshare, if dstAccountName is empty, then copy in the same account
 func (d *Driver) copyFileShare(ctx context.Context, req *csi.CreateVolumeRequest, dstAccountName string, dstAccountSasToken string, authAzcopyEnv []string, secretNamespace string, shareOptions *ShareOptions, accountOptions *storage.AccountOptions, storageEndpointSuffix string) error {
-	if shareOptions.Protocol == armstorage.EnabledProtocolsNFS {
-		return fmt.Errorf("protocol nfs is not supported for volume cloning")
-	}
 	var sourceVolumeID string
 	if req.GetVolumeContentSource() != nil && req.GetVolumeContentSource().GetVolume() != nil {
 		sourceVolumeID = req.GetVolumeContentSource().GetVolume().GetVolumeId()
@@ -1149,7 +1146,7 @@ func (d *Driver) copyFileShare(ctx context.Context, req *csi.CreateVolumeRequest
 	srcPath := fmt.Sprintf("https://%s.file.%s/%s%s", srcAccountName, storageEndpointSuffix, srcFileShareName, srcAccountSasToken)
 	dstPath := fmt.Sprintf("https://%s.file.%s/%s%s", dstAccountName, storageEndpointSuffix, dstFileShareName, dstAccountSasToken)
 
-	return d.copyFileShareByAzcopy(ctx, srcFileShareName, dstFileShareName, srcPath, dstPath, "", srcAccountName, dstAccountName, srcAccountSasToken, authAzcopyEnv, accountOptions)
+	return d.copyFileShareByAzcopy(ctx, srcFileShareName, dstFileShareName, srcPath, dstPath, "", srcAccountName, dstAccountName, srcAccountSasToken, authAzcopyEnv, shareOptions, accountOptions)
 }
 
 // GetTotalAccountQuota returns the total quota in GB of all file shares in the storage account and the number of file shares

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -1430,33 +1430,6 @@ var _ = ginkgo.Describe("TestCopyVolume", func() {
 	ginkgo.AfterEach(func() {
 		ctrl.Finish()
 	})
-	ginkgo.When("restore volume from volumeSnapshot nfs is not supported", func() {
-		ginkgo.It("should fail", func(ctx context.Context) {
-			allParam := map[string]string{}
-
-			volumeSnapshotSource := &csi.VolumeContentSource_SnapshotSource{
-				SnapshotId: "unit-test",
-			}
-			volumeContentSourceSnapshotSource := &csi.VolumeContentSource_Snapshot{
-				Snapshot: volumeSnapshotSource,
-			}
-			volumecontensource := csi.VolumeContentSource{
-				Type: volumeContentSourceSnapshotSource,
-			}
-
-			req := &csi.CreateVolumeRequest{
-				Name:                "random-vol-name-valid-request",
-				VolumeCapabilities:  stdVolCap,
-				CapacityRange:       lessThanPremCapRange,
-				Parameters:          allParam,
-				VolumeContentSource: &volumecontensource,
-			}
-
-			expectedErr := fmt.Errorf("protocol nfs is not supported for snapshot restore")
-			err := d.copyVolume(ctx, req, "", "", []string{}, "", &ShareOptions{Protocol: armstorage.EnabledProtocolsNFS}, nil, "core.windows.net")
-			gomega.Expect(err).To(gomega.Equal(expectedErr))
-		})
-	})
 	ginkgo.When("restore volume from volumeSnapshot not found", func() {
 		ginkgo.It("should fail", func(ctx context.Context) {
 			allParam := map[string]string{}
@@ -1508,33 +1481,6 @@ var _ = ginkgo.Describe("TestCopyVolume", func() {
 
 			expectedErr := fmt.Errorf("one or more of srcAccountName(unit-test), srcFileShareName(), dstFileShareName(dstFileshare) are empty")
 			err := d.copyVolume(ctx, req, "", "", []string{}, "", &ShareOptions{Name: "dstFileshare"}, nil, "core.windows.net")
-			gomega.Expect(err).To(gomega.Equal(expectedErr))
-		})
-	})
-	ginkgo.When("copy volume nfs is not supported", func() {
-		ginkgo.It("should fail", func(ctx context.Context) {
-			allParam := map[string]string{}
-
-			volumeSource := &csi.VolumeContentSource_VolumeSource{
-				VolumeId: "unit-test",
-			}
-			volumeContentSourceVolumeSource := &csi.VolumeContentSource_Volume{
-				Volume: volumeSource,
-			}
-			volumecontensource := csi.VolumeContentSource{
-				Type: volumeContentSourceVolumeSource,
-			}
-
-			req := &csi.CreateVolumeRequest{
-				Name:                "random-vol-name-valid-request",
-				VolumeCapabilities:  stdVolCap,
-				CapacityRange:       lessThanPremCapRange,
-				Parameters:          allParam,
-				VolumeContentSource: &volumecontensource,
-			}
-
-			expectedErr := fmt.Errorf("protocol nfs is not supported for volume cloning")
-			err := d.copyVolume(ctx, req, "", "", []string{}, "", &ShareOptions{Protocol: armstorage.EnabledProtocolsNFS}, nil, "core.windows.net")
 			gomega.Expect(err).To(gomega.Equal(expectedErr))
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: support nfs volume clone and snapshot restore

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

<details>

```
I0706 15:15:32.397069       1 utils.go:105] GRPC call: /csi.v1.Controller/CreateVolume
I0706 15:15:32.397092       1 utils.go:106] GRPC request: {"capacity_range":{"required_bytes":107374182400},"name":"pvc-0d58dc6a-84b9-4bcc-b4aa-4cc3ff2543bd","parameters":{"csi.storage.k8s.io/pv/name":"pvc-0d58dc6a-84b9-4bcc-b4aa-4cc3ff2543bd","csi.storage.k8s.io/pvc/name":"pvc-azurefile-snapshot-restored2","csi.storage.k8s.io/pvc/namespace":"default","protocol":"nfs","resourceGroup":"andy-dev","storageAccount":"andynfs"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["nconnect=4","noresvport","actimeo=30"]}},"access_mode":{"mode":5}}],"volume_content_source":{"Type":{"Snapshot":{"snapshot_id":"MC_andy-aks133_andy-aks133_eastus2euap#fe96b913cf7ba475692f8b7#pvcn-c876738d-62ab-47b5-89c7-68f21cc6d181###default#2025-07-06T07:52:19.0000000Z"}}}}
I0706 15:15:32.397496       1 azure.go:224] updateSubnetServiceEndpoints on vnetName: aks-vnet-16027573, subnetName: , location: eastus2euap
I0706 15:15:32.397521       1 azure.go:236] subnet  under vnet aks-vnet-16027573 in rg MC_andy-aks133_andy-aks133_eastus2euap is already updated, vnetResourceIDs: [/subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/MC_andy-aks133_andy-aks133_eastus2euap/providers/Microsoft.Network/virtualNetworks/aks-vnet-16027573/subnets/aks-subnet]
I0706 15:15:32.397662       1 controllerserver.go:482] source volume account name: fe96b913cf7ba475692f8b7, sourceID: MC_andy-aks133_andy-aks133_eastus2euap#fe96b913cf7ba475692f8b7#pvcn-c876738d-62ab-47b5-89c7-68f21cc6d181###default#2025-07-06T07:52:19.0000000Z
I0706 15:15:32.669137       1 controllerserver.go:607] begin to create file share(pvcn-0d58dc6a-84b9-4bcc-b4aa-4cc3ff2543bd) on account(andynfs) type(Premium_LRS) subID() rg(andy-dev) location() size(100) protocol(NFS)
I0706 15:15:33.312934       1 azurefile_mgmt_client.go:87] created share pvcn-0d58dc6a-84b9-4bcc-b4aa-4cc3ff2543bd in account andynfs
I0706 15:15:33.312957       1 controllerserver.go:1447] use user assigned managed identity to authorize azcopy
I0706 15:15:33.326315       1 controllerserver.go:1170] azcopy job status: NotFound, copy percent: %, error: <nil>
I0706 15:15:33.326332       1 controllerserver.go:1188] copy fileshare fe96b913cf7ba475692f8b7:pvcn-c876738d-62ab-47b5-89c7-68f21cc6d181(snapshot: 2025-07-06T07:52:19.0000000Z) to andynfs:pvcn-0d58dc6a-84b9-4bcc-b4aa-4cc3ff2543bd
I0706 15:15:36.891766       1 controllerserver.go:1205] copied fileshare pvcn-c876738d-62ab-47b5-89c7-68f21cc6d181(snapshot: 2025-07-06T07:52:19.0000000Z) to pvcn-0d58dc6a-84b9-4bcc-b4aa-4cc3ff2543bd successfully
```

</details>

**Release note**:
```
feat: support nfs volume clone and snapshot restore
```
