### PR TITLE
fix: only unmount kata volume if it's kata node

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -114,14 +114,13 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		}
 
 		if d.enableKataCCMount && context[podNameField] != "" && context[podNamespaceField] != "" {
-			enableKataCCMount := d.isKataNode
 			confidentialContainerLabel := getValueInMap(context, confidentialContainerLabelField)
-			if !enableKataCCMount && confidentialContainerLabel != "" {
+			if !d.isKataNode && confidentialContainerLabel != "" {
 				klog.V(2).Infof("NodePublishVolume: checking if node %s is a kata node with confidential container label %s", d.NodeID, confidentialContainerLabel)
-				enableKataCCMount = isKataNode(ctx, d.NodeID, confidentialContainerLabel, d.kubeClient)
+				d.isKataNode = isKataNode(ctx, d.NodeID, confidentialContainerLabel, d.kubeClient)
 			}
 
-			if enableKataCCMount {
+			if d.isKataNode {
 				runtimeClass, err := getRuntimeClassForPodFunc(ctx, d.kubeClient, context[podNameField], context[podNamespaceField])
 				if err != nil {
 					return nil, status.Errorf(codes.Internal, "failed to get runtime class for pod %s/%s: %v", context[podNamespaceField], context[podNameField], err)
@@ -214,7 +213,7 @@ func (d *Driver) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVo
 		return nil, status.Errorf(codes.Internal, "failed to unmount target %s: %v", targetPath, err)
 	}
 
-	if d.enableKataCCMount {
+	if d.enableKataCCMount && d.isKataNode {
 		klog.V(2).Infof("NodeUnpublishVolume: remove direct volume mount info %s from %s", volumeID, targetPath)
 		// Remove deletes the direct volume path including all the files inside it.
 		// if there is no kata-cc mountinfo present on this path, it will return nil.
@@ -468,9 +467,9 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		}
 		klog.V(2).Infof("volume(%s) mount %s on %s succeeded", volumeID, source, cifsMountPath)
 	}
-	enableKataCCMount := d.isKataNode && d.enableKataCCMount
+
 	// If runtime OS is not windows and protocol is not nfs, save mountInfo.json
-	if enableKataCCMount {
+	if d.enableKataCCMount && d.isKataNode {
 		if runtime.GOOS != "windows" && protocol != nfs {
 			// Check if mountInfo.json is already present at the targetPath
 			isMountInfoPresent, err := d.directVolume.VolumeMountInfo(cifsMountPath)
@@ -581,7 +580,7 @@ func (d *Driver) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolume
 		}
 	}
 
-	if d.enableKataCCMount {
+	if d.enableKataCCMount && d.isKataNode {
 		klog.V(2).Infof("NodeUnstageVolume: remove direct volume mount info %s from %s", volumeID, stagingTargetPath)
 		if err := d.directVolume.Remove(stagingTargetPath); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to remove mount info %s: %v", stagingTargetPath, err)

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -355,6 +355,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			desc: "[Success] Valid request",
 			req:  &csi.NodeUnpublishVolumeRequest{TargetPath: targetFile, VolumeId: "vol_1"},
 			setup: func() {
+				d.isKataNode = true
 				mockDirectVolume.EXPECT().Remove(targetFile).Return(nil)
 			},
 			expectedErr: testutil.TestError{},
@@ -906,6 +907,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 			desc: "[Success] Valid request",
 			req:  &csi.NodeUnstageVolumeRequest{StagingTargetPath: targetFile, VolumeId: "vol_1"},
 			setup: func() {
+				d.isKataNode = true
 				mockDirectVolume.EXPECT().Remove(targetFile).Return(nil)
 			},
 			expectedErr: testutil.TestError{},

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -347,6 +347,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			},
 			setup: func() {
 				if runtime.GOOS == "windows" {
+					d.isKataNode = true
 					mockDirectVolume.EXPECT().Remove(errorTarget).Return(nil)
 				}
 			},
@@ -899,6 +900,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 			},
 			setup: func() {
 				if runtime.GOOS == "windows" {
+					d.isKataNode = true
 					mockDirectVolume.EXPECT().Remove(errorTarget).Return(nil)
 				}
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: only unmount kata volume if it's kata node

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: only unmount kata volume if it's kata node
```
