### PR TITLE
fix: upgrade to aznfs 3.0.10 on Ubuntu node

### DIFF
--- a/pkg/azurefile-proxy/install-proxy.sh
+++ b/pkg/azurefile-proxy/install-proxy.sh
@@ -27,18 +27,22 @@ fi
 if [ "${INSTALL_AZNFS_MOUNT}" = "true" ];then
   # install aznfs-mount on ubuntu
   if [ "$DISTRIBUTION" = "ubuntu" ];then
-    AZNFS_VERSION="0.3.15"
-    echo "install aznfs v$AZNFS_VERSION...."
+    if [ -z "${AZNFS_UBUNTU_VERSION}" ]; then
+      AZNFS_UBUNTU_VERSION="3.0.10"
+    fi
+    echo "install aznfs v$AZNFS_UBUNTU_VERSION...."
     # shellcheck disable=SC1091
     $HOST_CMD curl -sSL -O "https://packages.microsoft.com/config/$(. /host/etc/os-release && echo "$ID/$VERSION_ID")/packages-microsoft-prod.deb"
     yes | $HOST_CMD dpkg -i packages-microsoft-prod.deb && $HOST_CMD apt-get update
     $HOST_CMD rm packages-microsoft-prod.deb
-    $HOST_CMD apt-get install -y aznfs="$AZNFS_VERSION"
+    $HOST_CMD apt-get install -y aznfs="$AZNFS_UBUNTU_VERSION" --allow-downgrades
     echo "aznfs-mount installed"
   elif [ "$DISTRIBUTION" = "azurelinux" ];then # install aznfs-mount on azure linux 3.0
-    AZNFS_VERSION="0.1.548"
-    echo "install aznfs v$AZNFS_VERSION...."
-    $HOST_CMD curl -fsSL https://github.com/Azure/AZNFS-mount/releases/download/$AZNFS_VERSION/aznfs_install.sh | $HOST_CMD bash
+    if [ -z "${AZNFS_AZURELINUX_VERSION}" ]; then
+      AZNFS_AZURELINUX_VERSION="0.1.548"
+    fi
+    echo "install aznfs v$AZNFS_AZURELINUX_VERSION...."
+    $HOST_CMD curl -fsSL https://github.com/Azure/AZNFS-mount/releases/download/$AZNFS_AZURELINUX_VERSION/aznfs_install.sh | $HOST_CMD bash
   else
     echo "aznfs-mount is not supported on Linux distribution: $DISTRIBUTION"
     exit 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: upgrade to aznfs 3.0.10 on Ubuntu node

Potential Reason:
•	The per node EiT (aznfs) mount subsystem becomes inconsistent after repeated mount/unmount cycles. This might be due to mount map corruption or a race inside aznfs. This is a known issue and has been fixed in the aznfs mount package of version 3.0.10. Please details in the email attached above.
•	After a node reboot, the local mountmap, watchdog state and stunnel processes are reset. Hence, the mount succeeds again.
•	After enough pod churn, stale state reappears. Hence, the mount fails again.
 
According to my understanding, we can ask the user to deploy the latest version of aznfs mount package of 3.0.10, to mitigate the issue. 


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: upgrade to aznfs 3.0.10 on Ubuntu node
```
