### PR TITLE
docs: improve managed identity mount documentation

### DIFF
--- a/docs/managed-identity-mount.md
+++ b/docs/managed-identity-mount.md
@@ -1,112 +1,150 @@
-# Mount Azure SMB file share with managed identity
- - Feature status: Preview
- - supported from CSI driver v1.34.0 on Linux node
+# Mount Azure SMB File Share with Managed Identity
 
-This article demonstrates the process of mounting smb file share with user-assigned managed identity authentication only, without relying on account key authentication.
-> by default you could leverage the built-in user assigned managed identity(kubelet identity) bound to the AKS agent node pool(with naming rule [`AKS Cluster Name-agentpool`](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#summary-of-managed-identities))
+- **Feature status:** Preview
+- **Supported from:** CSI driver v1.34.0 on Linux nodes
 
-> if you have created your own managed identity, make sure the managed identity is associated with the agent node pool. You could use following command to bind the managed identity to the VMSS node pool:
+This article demonstrates how to mount an SMB file share using user-assigned managed identity authentication, without relying on account key authentication.
 
-    > `az vmss identity assign --name <vmss-name> --resource-group <resource-group-name> --identities <managed-identity-resource-id>`
+> [!NOTE]
+> By default, you can leverage the built-in user-assigned managed identity (kubelet identity) bound to the AKS agent node pool (with the naming convention [`<AKS Cluster Name>-agentpool`](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#summary-of-managed-identities)).
 
-## Before you begin
- - Make sure the managed identity is granted the `Storage File Data SMB MI Admin` role on the storage account.
- > here is an example that uses Azure CLI commands to assign the `Storage File Data SMB MI Admin` role to the managed identity for the storage account. If the storage account is created by the driver(dynamic provisioning), you need to grant `Storage File Data SMB MI Admin` role on the resource group where the storage account is located
+> [!IMPORTANT]
+> If you have created your own managed identity, make sure it is associated with the agent node pool. Use the following command to bind the managed identity to the VMSS node pool:
+>
+> ```bash
+> az vmss identity assign \
+>   --name <vmss-name> \
+>   --resource-group <resource-group-name> \
+>   --identities <managed-identity-resource-id>
+> ```
+
+## Prerequisites
+
+### 1. Grant the required role to the managed identity
+
+Make sure the managed identity is granted the **`Storage File Data SMB MI Admin`** role on the storage account.
+
+> [!NOTE]
+> If the storage account is created by the driver (dynamic provisioning), you need to grant the `Storage File Data SMB MI Admin` role on the **resource group** where the storage account is located.
 
 ```bash
-mid="$(az identity list -g "$resourcegroup" --query "[?name == 'managedIdentityName'].principalId" -o tsv)"
-said="$(az storage account list -g "$resourcegroup" --query "[?name == '$storageaccountname'].id" -o tsv)"
-az role assignment create --assignee-object-id "$mid" --role "Storage File Data SMB MI Admin" --scope "$said"
+# Get the principal ID of the managed identity
+mid="$(az identity list -g "$resourcegroup" \
+  --query "[?name == 'managedIdentityName'].principalId" -o tsv)"
+
+# Get the storage account resource ID
+said="$(az storage account list -g "$resourcegroup" \
+  --query "[?name == '$storageaccountname'].id" -o tsv)"
+
+# Assign the role
+az role assignment create \
+  --assignee-object-id "$mid" \
+  --role "Storage File Data SMB MI Admin" \
+  --scope "$said"
 ```
 
- - Retrieve the clientID of managed identity
- > skip this step if you are going to use kubelet identity since CSI driver will default to using the kubelet identity if `clientID` parameter is not provided in storage class or persisent volume.
+### 2. Retrieve the client ID of the managed identity
+
+> [!TIP]
+> Skip this step if you plan to use the kubelet identity. The CSI driver defaults to the kubelet identity when the `clientID` parameter is not provided in the StorageClass or PersistentVolume.
+
 ```bash
-clientID=`az identity list -g "$resourcegroup" --query "[?name == '$identityname'].clientId" -o tsv`
+clientID=$(az identity list -g "$resourcegroup" \
+  --query "[?name == '$identityname'].clientId" -o tsv)
 ```
-    
+
 ## Dynamic Provisioning
-- Ensure that the identity of your CSI driver control plane is assigned the `Storage Account Contributor role` for the storage account.
- > if the storage account is created by the driver, then you need to grant `Storage Account Contributor` role to the resource group where the storage account is located.
- > 
- > AKS cluster control plane identity is assigned the `Storage Account Contributor role` on the node resource group for the storage account by default.
 
-1. Create a storage class
-    ```yml
-    apiVersion: storage.k8s.io/v1
-    kind: StorageClass
-    metadata:
-      name: azurefile-csi
-    provisioner: file.csi.azure.com
-    parameters:
-      resourceGroup: EXISTING_RESOURCE_GROUP_NAME   # optional, node resource group by default if it's not provided
-      storageAccount: EXISTING_STORAGE_ACCOUNT_NAME # optional, a new account will be created if it's not provided
-      mountWithManagedIdentity: "true"
-      # optional, clientID of the managed identity, kubelet identity would be used by default if it's not provided
-      clientID: "xxxxx-xxxx-xxx-xxx-xxxxxxx"
-    reclaimPolicy: Delete
-    volumeBindingMode: Immediate
-    allowVolumeExpansion: true
-    mountOptions:
-      - dir_mode=0777  # modify this permission if you want to enhance the security
-      - file_mode=0777
-      - uid=0
-      - gid=0
-      - mfsymlinks
-      - cache=strict  # https://linux.die.net/man/8/mount.cifs
-      - nosharesock  # reduce probability of reconnect race
-      - actimeo=30  # reduce latency for metadata-heavy workload
-      - nobrl  # disable sending byte range lock requests to the server
-    ```
+Ensure that the CSI driver control plane identity is assigned the **`Storage Account Contributor`** role for the storage account.
 
-1. create a statefulset with volume mount
+> [!NOTE]
+> - If the storage account is created by the driver, grant the `Storage Account Contributor` role on the **resource group** where the storage account is located.
+> - AKS cluster control plane identity is assigned the `Storage Account Contributor` role on the node resource group by default.
+
+### Step 1: Create a StorageClass
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: azurefile-csi
+provisioner: file.csi.azure.com
+parameters:
+  resourceGroup: EXISTING_RESOURCE_GROUP_NAME   # optional, defaults to node resource group
+  storageAccount: EXISTING_STORAGE_ACCOUNT_NAME # optional, a new account will be created if not provided
+  mountWithManagedIdentity: "true"
+  clientID: "xxxxx-xxxx-xxx-xxx-xxxxxxx"        # optional, defaults to kubelet identity
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+mountOptions:
+  - dir_mode=0777    # modify for enhanced security
+  - file_mode=0777
+  - uid=0
+  - gid=0
+  - mfsymlinks
+  - cache=strict     # https://linux.die.net/man/8/mount.cifs
+  - nosharesock      # reduce probability of reconnect race
+  - actimeo=30       # reduce latency for metadata-heavy workloads
+  - nobrl            # disable sending byte range lock requests to the server
+```
+
+### Step 2: Create a StatefulSet with volume mount
+
 ```bash
 kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/deploy/example/statefulset.yaml
 ```
 
 ## Static Provisioning
 
-> If you are using your own storage account, please ensure that the `SMBOauth` property is enabled for that account by running following command:
+> [!IMPORTANT]
+> If you are using your own storage account, ensure that the **SMBOauth** property is enabled:
 >
-> `az storage account update --name <account-name> --resource-group <resource-group-name> --enable-smb-oauth true`
+> ```bash
+> az storage account update \
+>   --name <account-name> \
+>   --resource-group <resource-group-name> \
+>   --enable-smb-oauth true
+> ```
 
-1. create PV with your own account
-    ```yml
-    apiVersion: v1
-    kind: PersistentVolume
-    metadata:
-      name: pv-azurefile
-    spec:
-      capacity:
-        storage: 100Gi
-      accessModes:
-        - ReadWriteMany
-      persistentVolumeReclaimPolicy: Retain
-      storageClassName: azurefile-csi
-      mountOptions:
-        - dir_mode=0777  # modify this permission if you want to enhance the security
-        - file_mode=0777
-        - uid=0
-        - gid=0
-        - mfsymlinks
-        - cache=strict  # https://linux.die.net/man/8/mount.cifs
-        - nosharesock  # reduce probability of reconnect race
-        - actimeo=30  # reduce latency for metadata-heavy workload
-        - nobrl  # disable sending byte range lock requests to the server
-      csi:
-        driver: file.csi.azure.com
-        # make sure volumeHandle is unique for every identical share in the cluster
-        volumeHandle: "{resource-group-name}#{account-name}#{file-share-name}"
-        volumeAttributes:
-          resourceGroup: EXISTING_RESOURCE_GROUP_NAME   # optional, node resource group by default if it's not provided
-          storageAccount: EXISTING_STORAGE_ACCOUNT_NAME # ensure that the `SMBOauth` property is enabled on this account
-          shareName: EXISTING_FILE_SHARE_NAME
-          mountWithManagedIdentity: "true"
-          # optional, clientID of the managed identity, kubelet identity would be used by default if it's empty
-          clientID: "xxxxx-xxxx-xxx-xxx-xxxxxxx"
-    ```
+### Step 1: Create a PersistentVolume
 
-1. create a pvc and a deployment with volume mount
-    ```console
-    kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/deploy/example/deployment.yaml
-    ```
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-azurefile
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: azurefile-csi
+  mountOptions:
+    - dir_mode=0777    # modify for enhanced security
+    - file_mode=0777
+    - uid=0
+    - gid=0
+    - mfsymlinks
+    - cache=strict     # https://linux.die.net/man/8/mount.cifs
+    - nosharesock      # reduce probability of reconnect race
+    - actimeo=30       # reduce latency for metadata-heavy workloads
+    - nobrl            # disable sending byte range lock requests to the server
+  csi:
+    driver: file.csi.azure.com
+    # make sure volumeHandle is unique for every identical share in the cluster
+    volumeHandle: "{resource-group-name}#{account-name}#{file-share-name}"
+    volumeAttributes:
+      resourceGroup: EXISTING_RESOURCE_GROUP_NAME   # optional, defaults to node resource group
+      storageAccount: EXISTING_STORAGE_ACCOUNT_NAME # ensure SMBOauth is enabled on this account
+      shareName: EXISTING_FILE_SHARE_NAME
+      mountWithManagedIdentity: "true"
+      clientID: "xxxxx-xxxx-xxx-xxx-xxxxxxx"        # optional, defaults to kubelet identity
+```
+
+### Step 2: Create a PVC and Deployment with volume mount
+
+```bash
+kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/deploy/example/deployment.yaml
+```


### PR DESCRIPTION
## What this PR does

Improves the readability and formatting of `docs/managed-identity-mount.md`.

### Changes

- **Restructured** the document with clearer hierarchy — renamed "Before you begin" to "Prerequisites" with numbered sub-steps
- **Added GitHub-flavored admonitions** (`NOTE`, `TIP`, `IMPORTANT`) replacing inconsistent blockquote usage
- **Fixed formatting issues:**
  - Inconsistent indentation and blockquote nesting
  - Mixed code block language tags (`yml` → `yaml`, `console` → `bash`)
  - Inline code within blockquotes was hard to read
- **Fixed typo:** `persisent` → `persistent` (in the tip about kubelet identity)
- **Improved CLI commands** with line continuation (`\\`) for better readability
- **Aligned inline comments** in YAML examples for visual consistency
- **Added explicit step labels** ("Step 1", "Step 2") for Dynamic and Static provisioning sections

### Why

The current page has several formatting inconsistencies that make it harder to follow, especially for new users. This PR makes the document easier to scan and more consistent with modern GitHub Markdown best practices.

No functional/content changes — purely documentation improvements.