### PR TITLE
security: Update trivy-action to use sha for v0.35.0

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -27,7 +27,7 @@ jobs:
           make container
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         env:
           TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db:2"
         with:


### PR DESCRIPTION
## Description

This PR updates `aquasecurity/trivy-action` to address security vulnerabilities.

## Changes

- Updates from mutable reference (`@master`/`@main`/old tags) to SHA-pinned version
- Now using: `aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0)

## References

- Issue: https://github.com/aquasecurity/trivy/discussions/10425
- Release: https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0