### PR TITLE
feat: support allowCrossTenantReplication storage class parameter

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -126,6 +126,7 @@ const (
 	allowBlobPublicAccessField        = "allowblobpublicaccess"
 	publicNetworkAccessField          = "publicnetworkaccess"
 	allowSharedKeyAccessField         = "allowsharedkeyaccess"
+	allowCrossTenantReplicationField  = "allowcrosstenantreplication"
 	storageEndpointSuffixField        = "storageendpointsuffix"
 	fsGroupChangePolicyField          = "fsgroupchangepolicy"
 	ephemeralField                    = "csi.storage.k8s.io/ephemeral"

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -592,9 +592,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey = fmt.Sprintf("%s%s%s%s%s%s%s%v%v%v%v%v", sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier,
+			lockKey = fmt.Sprintf("%s%s%s%s%s%s%s%v%v%v%v%v%v%v", sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false), ptr.Deref(requireInfraEncryption, false),
-				ptr.Deref(enableLFS, false), ptr.Deref(disableDeleteRetentionPolicy, false))
+				ptr.Deref(enableLFS, false), ptr.Deref(disableDeleteRetentionPolicy, false),
+				ptr.Deref(allowCrossTenantReplication, false), ptr.Deref(allowSharedKeyAccess, false))
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -595,7 +595,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			lockKey = fmt.Sprintf("%s%s%s%s%s%s%s%v%v%v%v%v%v%v", sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false), ptr.Deref(requireInfraEncryption, false),
 				ptr.Deref(enableLFS, false), ptr.Deref(disableDeleteRetentionPolicy, false),
-				ptr.Deref(allowCrossTenantReplication, false), ptr.Deref(allowSharedKeyAccess, false))
+				ptr.Deref(allowCrossTenantReplication, true), ptr.Deref(allowSharedKeyAccess, true))
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -122,7 +122,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	var secretNamespace, pvcNamespace, protocol, customTags, storageEndpointSuffix, networkEndpointType, shareAccessTier, accountAccessTier, rootSquashType, tagValueDelimiter string
 	var createAccount, useSeretCache, matchTags, selectRandomMatchingAccount, getLatestAccountKey, encryptInTransit, mountWithManagedIdentity, mountWithWIToken bool
 	var vnetResourceGroup, vnetName, vnetLinkName, publicNetworkAccess, subnetName, shareNamePrefix, fsGroupChangePolicy, useDataPlaneAPI string
-	var requireInfraEncryption, disableDeleteRetentionPolicy, enableLFS, isMultichannelEnabled, allowSharedKeyAccess *bool
+	var requireInfraEncryption, disableDeleteRetentionPolicy, enableLFS, isMultichannelEnabled, allowSharedKeyAccess, allowCrossTenantReplication *bool
 	var provisionedBandwidthMibps, provisionedIops *int32
 	// set allowBlobPublicAccess as false by default
 	allowBlobPublicAccess := ptr.To(false)
@@ -225,6 +225,12 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %s in storage class", allowSharedKeyAccessField, v)
 			}
 			allowSharedKeyAccess = &value
+		case allowCrossTenantReplicationField:
+			value, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %s in storage class", allowCrossTenantReplicationField, v)
+			}
+			allowCrossTenantReplication = &value
 		case pvcNameKey:
 			fileShareNameReplaceMap[pvcNameMetadata] = v
 		case pvNameKey:
@@ -557,6 +563,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		DisableFileServiceDeleteRetentionPolicy: disableDeleteRetentionPolicy,
 		AllowBlobPublicAccess:                   allowBlobPublicAccess,
 		AllowSharedKeyAccess:                    allowSharedKeyAccess,
+		AllowCrossTenantReplication:             allowCrossTenantReplication,
 		PublicNetworkAccess:                     publicNetworkAccess,
 		VNetResourceGroup:                       vnetResourceGroup,
 		VNetName:                                vnetName,

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -639,6 +639,68 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 			gomega.Expect(err).To(gomega.Equal(expectedErr))
 		})
 	})
+	ginkgo.When("invalid allowCrossTenantReplication value", func() {
+		ginkgo.It("should fail", func(ctx context.Context) {
+			allParam := map[string]string{
+				allowCrossTenantReplicationField: "invalid",
+			}
+
+			req := &csi.CreateVolumeRequest{
+				Name:               "random-vol-name-allowCrossTenantReplication-invalid",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         allParam,
+			}
+			d.cloud = &storage.AccountRepo{
+				Config: config.Config{},
+			}
+
+			expectedErr := status.Errorf(codes.InvalidArgument, "invalid %s: %s in storage class", allowCrossTenantReplicationField, "invalid")
+			_, err := d.CreateVolume(ctx, req)
+			gomega.Expect(err).To(gomega.Equal(expectedErr))
+		})
+	})
+	ginkgo.When("valid allowCrossTenantReplication value set to false", func() {
+		ginkgo.It("should fail with storeAccountKey not supported when shared access key disabled", func(ctx context.Context) {
+			allParam := map[string]string{
+				skuNameField:                     "premium",
+				storageAccountTypeField:          "stoacctype",
+				locationField:                    "loc",
+				storageAccountField:              "stoacc",
+				resourceGroupField:               "rg",
+				shareNameField:                   "",
+				diskNameField:                    "diskname.vhd",
+				fsTypeField:                      "",
+				storeAccountKeyField:             "storeaccountkey",
+				secretNamespaceField:             "default",
+				mountPermissionsField:            "0755",
+				accountQuotaField:                "1000",
+				allowCrossTenantReplicationField: "false",
+				allowSharedKeyAccessField:        "false",
+			}
+
+			fakeCloud := &storage.AccountRepo{
+				Config: config.Config{
+					ResourceGroup: "rg",
+					Location:      "loc",
+					VnetName:      "fake-vnet",
+					SubnetName:    "fake-subnet",
+				},
+			}
+
+			req := &csi.CreateVolumeRequest{
+				Name:               "random-vol-name-vol-cap-cross-tenant",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         allParam,
+			}
+			d.cloud = fakeCloud
+
+			expectedErr := status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
+			_, err := d.CreateVolume(ctx, req)
+			gomega.Expect(err).To(gomega.Equal(expectedErr))
+		})
+	})
 	ginkgo.When("No valid key, check all params, with less than min premium volume", func() {
 		ginkgo.It("should fail", func(ctx context.Context) {
 			name := "baz"

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -202,11 +202,12 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 				"skuName": "Premium_LRS",
 				"tags":    tags,
 				// make sure this is the first test case due to storeAccountKey is set as false
-				"storeAccountKey":        "false",
-				"getLatestAccountKey":    "true",
-				"shareAccessTier":        "Premium",
-				"requireInfraEncryption": "true",
-				"enableMultichannel":     "true",
+				"storeAccountKey":             "false",
+				"getLatestAccountKey":         "true",
+				"shareAccessTier":             "Premium",
+				"requireInfraEncryption":      "true",
+				"enableMultichannel":          "true",
+				"allowCrossTenantReplication": "false",
 			},
 			Tags: tags,
 		}


### PR DESCRIPTION
## What
Add `allowcrosstenantreplication` parameter to StorageClass to control cross-tenant object replication on the storage account.

## Why
Users may want to disable cross-tenant object replication for security compliance (least-privilege). Currently there is no way to configure this via the CSI driver.

## Usage
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: azurefile-no-cross-tenant
provisioner: file.csi.azure.com
parameters:
  allowcrosstenantreplication: "false"
```

## Changes
- Add `allowcrosstenantreplication` field constant in `azurefile.go`
- Parse the parameter in `controllerserver.go` and pass to `AccountOptions`
- Include `allowCrossTenantReplication` and `allowSharedKeyAccess` in the account cache key (`lockKey`)
- Add unit tests for valid/invalid parameter parsing