### PR TITLE
cleanup: add folderName validation to reject invalid characters

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -231,6 +231,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			fileShareNameReplaceMap[pvNameMetadata] = v
 		case serverNameField:
 		case folderNameField:
+			if v != "" {
+				if err := isValidFolderName(v); err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "invalid folderName in storage class: %v", err)
+				}
+			}
 		case clientIDField:
 		case tenantIDField:
 		case confidentialContainerLabelField:

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -265,6 +265,23 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 			gomega.Expect(err).To(gomega.Equal(expectedErr))
 		})
 	})
+	ginkgo.When("Invalid folderName", func() {
+		ginkgo.It("should fail", func(ctx context.Context) {
+			allParam := map[string]string{
+				folderNameField: "my|folder",
+			}
+
+			req := &csi.CreateVolumeRequest{
+				Name:               "folderName-invalid",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         allParam,
+			}
+			expectedErr := status.Errorf(codes.InvalidArgument, "invalid folderName in storage class: folderName(\"my|folder\") contains invalid character in segment \"my|folder\", characters \\:*?\"<>| are not allowed")
+			_, err := d.CreateVolume(ctx, req)
+			gomega.Expect(err).To(gomega.Equal(expectedErr))
+		})
+	})
 	ginkgo.When("Invalid PublicNetworkAccess", func() {
 		ginkgo.It("should fail", func(ctx context.Context) {
 			allParam := map[string]string{

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -303,6 +303,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			diskName = v
 		case folderNameField:
 			folderName = v
+			if folderName != "" {
+				if err := isValidFolderName(folderName); err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "invalid folderName: %v", err)
+				}
+			}
 		case createFolderIfNotExistField:
 			createFolderIfNotExist = strings.EqualFold(v, trueValue)
 		case serverNameField:

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -544,6 +544,19 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			desc: "[Error] Invalid folderName",
+			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1", StagingTargetPath: sourceTest,
+				VolumeCapability: &stdVolCap,
+				VolumeContext: map[string]string{
+					folderNameField: "my*folder",
+					shareNameField:  "test_sharename",
+					serverNameField: "test_servername",
+				}},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Errorf(codes.InvalidArgument, "invalid folderName: folderName(\"my*folder\") contains invalid character in segment \"my*folder\", characters \\:*?\"<>| are not allowed"),
+			},
+		},
+		{
 			desc: "[Error] Invalid fsGroupChangePolicy",
 			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1", StagingTargetPath: sourceTest,
 				VolumeCapability: &stdVolCap,

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -461,26 +461,26 @@ func isValidFolderName(folderName string) error {
 			return fmt.Errorf("folderName contains empty path segment")
 		}
 
-		// ".." is not allowed as a path segment (directory traversal)
-		if seg == ".." {
-			return fmt.Errorf("folderName(%s) contains disallowed path segment %q", folderName, seg)
+		// ".." and "." are not allowed as path segments (directory traversal)
+		if seg == ".." || seg == "." {
+			return fmt.Errorf("folderName(%q) contains disallowed path segment %q", folderName, seg)
 		}
 
 		// check for invalid characters
 		if invalidFolderNameChars.MatchString(seg) {
-			return fmt.Errorf("folderName(%s) contains invalid character in segment %q, characters \\:*?\"<>| are not allowed", folderName, seg)
+			return fmt.Errorf("folderName(%q) contains invalid character in segment %q, characters \\:*?\"<>| are not allowed", folderName, seg)
 		}
 
 		// check for control characters (0x00-0x1F)
 		for _, c := range seg {
 			if c >= 0x00 && c <= 0x1F {
-				return fmt.Errorf("folderName(%s) contains control character in segment %q", folderName, seg)
+				return fmt.Errorf("folderName(%q) contains control character in segment %q", folderName, seg)
 			}
 		}
 
 		// must not end with period or space
 		if strings.HasSuffix(seg, ".") || strings.HasSuffix(seg, " ") {
-			return fmt.Errorf("folderName(%s) segment %q must not end with a period or space", folderName, seg)
+			return fmt.Errorf("folderName(%q) segment %q must not end with a period or space", folderName, seg)
 		}
 	}
 	return nil

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -443,6 +443,49 @@ func setCredentialCache(server, clientID, tenantID, tokenFile string) ([]byte, e
 	return cmd.CombinedOutput()
 }
 
+// invalidFolderNameChars contains characters not allowed in Azure file share folder names
+var invalidFolderNameChars = regexp.MustCompile(`[\\:*?"<>|]`)
+
+// isValidFolderName checks if a folder name is valid for Azure file share.
+// Empty folderName is allowed. Folder name may contain "/" as path separator for nested folders.
+// Each path segment must not contain \:*?"<>| or control characters,
+// must not be ".." (directory traversal), and must not end with a period or space.
+func isValidFolderName(folderName string) error {
+	if folderName == "" {
+		return nil
+	}
+
+	segments := strings.Split(strings.Trim(folderName, "/"), "/")
+	for _, seg := range segments {
+		if seg == "" {
+			return fmt.Errorf("folderName contains empty path segment")
+		}
+
+		// ".." is not allowed as a path segment (directory traversal)
+		if seg == ".." {
+			return fmt.Errorf("folderName(%s) contains disallowed path segment %q", folderName, seg)
+		}
+
+		// check for invalid characters
+		if invalidFolderNameChars.MatchString(seg) {
+			return fmt.Errorf("folderName(%s) contains invalid character in segment %q, characters \\:*?\"<>| are not allowed", folderName, seg)
+		}
+
+		// check for control characters (0x00-0x1F)
+		for _, c := range seg {
+			if c >= 0x00 && c <= 0x1F {
+				return fmt.Errorf("folderName(%s) contains control character in segment %q", folderName, seg)
+			}
+		}
+
+		// must not end with period or space
+		if strings.HasSuffix(seg, ".") || strings.HasSuffix(seg, " ") {
+			return fmt.Errorf("folderName(%s) segment %q must not end with a period or space", folderName, seg)
+		}
+	}
+	return nil
+}
+
 // isValidTokenFileName checks if the token file name is valid
 // fileName should only contain alphanumeric characters, hyphens
 func isValidTokenFileName(fileName string) bool {

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -455,6 +455,11 @@ func isValidFolderName(folderName string) error {
 		return nil
 	}
 
+	// reject null bytes early — they truncate C strings and are a path injection risk
+	if strings.ContainsRune(folderName, 0) {
+		return fmt.Errorf("folderName(%q) contains null byte which is not allowed", folderName)
+	}
+
 	segments := strings.Split(strings.Trim(folderName, "/"), "/")
 	for _, seg := range segments {
 		if seg == "" {

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -1523,6 +1523,7 @@ func TestIsValidFolderName(t *testing.T) {
 		{name: "greater than", folder: "my>folder", expectErr: true},
 		{name: "pipe", folder: "my|folder", expectErr: true},
 		{name: "control char", folder: "my\x01folder", expectErr: true},
+		{name: "null byte", folder: "my\x00folder", expectErr: true},
 		{name: "dot dot segment", folder: "..", expectErr: true},
 		{name: "dot dot in path", folder: "a/../b", expectErr: true},
 		{name: "ends with period", folder: "folder.", expectErr: true},

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -1501,3 +1501,49 @@ func TestIsValidTokenFileName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidFolderName(t *testing.T) {
+	tests := []struct {
+		name      string
+		folder    string
+		expectErr bool
+	}{
+		{name: "valid simple", folder: "myfolder", expectErr: false},
+		{name: "valid nested", folder: "a/b/c", expectErr: false},
+		{name: "valid with leading slash", folder: "/myfolder", expectErr: false},
+		{name: "valid with trailing slash", folder: "myfolder/", expectErr: false},
+		{name: "valid with pvc placeholder", folder: "${pvc.metadata.name}", expectErr: false},
+		{name: "empty string is allowed", folder: "", expectErr: false},
+		{name: "backslash", folder: "my\\folder", expectErr: true},
+		{name: "colon", folder: "my:folder", expectErr: true},
+		{name: "asterisk", folder: "my*folder", expectErr: true},
+		{name: "question mark", folder: "my?folder", expectErr: true},
+		{name: "double quote", folder: `my"folder`, expectErr: true},
+		{name: "less than", folder: "my<folder", expectErr: true},
+		{name: "greater than", folder: "my>folder", expectErr: true},
+		{name: "pipe", folder: "my|folder", expectErr: true},
+		{name: "control char", folder: "my\x01folder", expectErr: true},
+		{name: "dot dot segment", folder: "..", expectErr: true},
+		{name: "dot dot in path", folder: "a/../b", expectErr: true},
+		{name: "ends with period", folder: "folder.", expectErr: true},
+		{name: "ends with space", folder: "folder ", expectErr: true},
+		{name: "empty segment", folder: "a//b", expectErr: true},
+		{name: "nested segment ends with period", folder: "a/b./c", expectErr: true},
+		{name: "valid hyphen and underscore", folder: "my-folder_name", expectErr: false},
+		{name: "valid dots in middle", folder: "my.folder.name", expectErr: false},
+		{name: "valid single dot segment", folder: ".", expectErr: true},
+		{name: "reserved name CON is allowed", folder: "CON", expectErr: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidFolderName(tc.folder)
+			if tc.expectErr && err == nil {
+				t.Fatalf("isValidFolderName(%q) expected error but got nil", tc.folder)
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("isValidFolderName(%q) unexpected error: %v", tc.folder, err)
+			}
+		})
+	}
+}

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -1524,6 +1524,8 @@ func TestIsValidFolderName(t *testing.T) {
 		{name: "pipe", folder: "my|folder", expectErr: true},
 		{name: "control char", folder: "my\x01folder", expectErr: true},
 		{name: "null byte", folder: "my\x00folder", expectErr: true},
+		{name: "whitespace only", folder: "   ", expectErr: true},
+		{name: "whitespace only segment in path", folder: "a/   /b", expectErr: true},
 		{name: "dot dot segment", folder: "..", expectErr: true},
 		{name: "dot dot in path", folder: "a/../b", expectErr: true},
 		{name: "ends with period", folder: "folder.", expectErr: true},

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -1531,7 +1531,7 @@ func TestIsValidFolderName(t *testing.T) {
 		{name: "nested segment ends with period", folder: "a/b./c", expectErr: true},
 		{name: "valid hyphen and underscore", folder: "my-folder_name", expectErr: false},
 		{name: "valid dots in middle", folder: "my.folder.name", expectErr: false},
-		{name: "valid single dot segment", folder: ".", expectErr: true},
+		{name: "invalid single dot segment", folder: ".", expectErr: true},
 		{name: "reserved name CON is allowed", folder: "CON", expectErr: false},
 	}
 


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it
Add `folderName` parameter validation in both `CreateVolume` and `NodeStageVolume` to reject invalid characters early, before they reach the mount layer and produce cryptic errors.

### Validation rules
Each path segment of `folderName` is checked for:
- Invalid characters: `\ : * ? " < > |`
- Control characters (0x00-0x1F), including null bytes
- Disallowed path segments: `..` and `.` (directory traversal prevention)
- Segments ending with period or space
- Empty path segments (e.g. `a//b`)

`/` is allowed as a path separator for nested folders (e.g. `a/b/c`).
Leading and trailing `/` are trimmed before validation.

### Changes
- `controllerserver.go`: validate `folderName` in `CreateVolume` parameter parsing
- `nodeserver.go`: validate `folderName` in `NodeStageVolume` parameter parsing
- `utils.go`: add `isValidFolderName()` with regex + per-segment checks
- `controllerserver_test.go`, `nodeserver_test.go`, `utils_test.go`: add unit tests

## Which issue(s) this PR fixes
Previously, invalid folder names would silently pass through and fail at mount time with cryptic errors. This provides early, clear validation.

## Does this PR introduce a user-facing change?
```release-note
Add folderName parameter validation to reject invalid characters (\:*?"<>|, control chars, directory traversal) before mount
```