### PR TITLE
fix: use safe type assertion and fix path construction in createFolderIfNotExists

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -1472,11 +1472,15 @@ func isKataNode(ctx context.Context, nodeID, confidentialContainerLabel string, 
 // This function handles nested paths by creating each directory level recursively
 func (d *Driver) createFolderIfNotExists(ctx context.Context, accountName, accountKey, fileShareName, folderName, storageEndpointSuffix string) error {
 	fileClient, err := newAzureFileClient(accountName, accountKey, storageEndpointSuffix)
-	if err != nil || fileClient.(*azureFileDataplaneClient).Client == nil {
+	if err != nil {
 		return fmt.Errorf("create Azure File client(%s) failed: %v", accountName, err)
 	}
+	dc, ok := fileClient.(*azureFileDataplaneClient)
+	if !ok || dc.Client == nil {
+		return fmt.Errorf("create Azure File client(%s) failed: unexpected client type or nil client", accountName)
+	}
 
-	shareClient := fileClient.(*azureFileDataplaneClient).Client.NewShareClient(fileShareName)
+	shareClient := dc.Client.NewShareClient(fileShareName)
 
 	// Performance optimization: First check if the complete directory structure already exists
 	// This is the most common case and avoids unnecessary recursive checking
@@ -1501,12 +1505,12 @@ func (d *Driver) createFolderIfNotExists(ctx context.Context, accountName, accou
 
 	// Build path incrementally and create each directory level
 	currentPath := ""
-	for i, component := range pathComponents {
+	for _, component := range pathComponents {
 		if component == "" {
 			continue // Skip empty components
 		}
 
-		if i > 0 {
+		if currentPath != "" {
 			currentPath += "/"
 		}
 		currentPath += component

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -1473,11 +1473,14 @@ func isKataNode(ctx context.Context, nodeID, confidentialContainerLabel string, 
 func (d *Driver) createFolderIfNotExists(ctx context.Context, accountName, accountKey, fileShareName, folderName, storageEndpointSuffix string) error {
 	fileClient, err := newAzureFileClient(accountName, accountKey, storageEndpointSuffix)
 	if err != nil {
-		return fmt.Errorf("create Azure File client(%s) failed: %v", accountName, err)
+		return fmt.Errorf("create Azure File client(%s) failed: %w", accountName, err)
 	}
 	dc, ok := fileClient.(*azureFileDataplaneClient)
-	if !ok || dc.Client == nil {
-		return fmt.Errorf("create Azure File client(%s) failed: unexpected client type or nil client", accountName)
+	if !ok {
+		return fmt.Errorf("create Azure File client(%s) failed: expected *azureFileDataplaneClient but got %T", accountName, fileClient)
+	}
+	if dc.Client == nil {
+		return fmt.Errorf("create Azure File client(%s) failed: dataplane client is nil", accountName)
 	}
 
 	shareClient := dc.Client.NewShareClient(fileShareName)

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -1471,6 +1471,13 @@ func isKataNode(ctx context.Context, nodeID, confidentialContainerLabel string, 
 // createFolderIfNotExists creates a folder in Azure File Share if it doesn't already exist
 // This function handles nested paths by creating each directory level recursively
 func (d *Driver) createFolderIfNotExists(ctx context.Context, accountName, accountKey, fileShareName, folderName, storageEndpointSuffix string) error {
+	if accountName == "" {
+		return fmt.Errorf("accountName is empty")
+	}
+	if fileShareName == "" {
+		return fmt.Errorf("fileShareName is empty")
+	}
+
 	fileClient, err := newAzureFileClient(accountName, accountKey, storageEndpointSuffix)
 	if err != nil {
 		return fmt.Errorf("create Azure File client(%s) failed: %w", accountName, err)

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -1943,6 +1943,15 @@ func TestCreateFolderIfNotExists(t *testing.T) {
 		expectedError         string
 	}{
 		{
+			name:                  "Empty account name",
+			accountName:           "",
+			accountKey:            base64.StdEncoding.EncodeToString([]byte("testkey")),
+			fileShareName:         "testshare",
+			folderName:            "testfolder",
+			storageEndpointSuffix: "core.windows.net",
+			expectedError:         "create Azure File client",
+		},
+		{
 			name:                  "Invalid account key",
 			accountName:           "testaccount",
 			accountKey:            "invalid-base64-key",

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -1949,7 +1949,16 @@ func TestCreateFolderIfNotExists(t *testing.T) {
 			fileShareName:         "testshare",
 			folderName:            "testfolder",
 			storageEndpointSuffix: "core.windows.net",
-			expectedError:         "create Azure File client",
+			expectedError:         "accountName is empty",
+		},
+		{
+			name:                  "Empty file share name",
+			accountName:           "testaccount",
+			accountKey:            base64.StdEncoding.EncodeToString([]byte("testkey")),
+			fileShareName:         "",
+			folderName:            "testfolder",
+			storageEndpointSuffix: "core.windows.net",
+			expectedError:         "fileShareName is empty",
 		},
 		{
 			name:                  "Invalid account key",


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Fixes several issues in `createFolderIfNotExists`:

1. **Unsafe type assertion** — `fileClient.(*azureFileDataplaneClient)` is used without comma-ok pattern, which can panic if the type doesn't match. Changed to safe assertion with proper error handling.

2. **Nil dereference risk** — When `newAzureFileClient` returns an error, `fileClient` could be nil. The original code combined the nil-error check with the type assertion in a single `if` condition. While Go's short-circuit evaluation prevents this in practice, separating the checks is clearer and safer.

3. **Incorrect path construction with skipped components** — The loop used `i > 0` to decide whether to prepend "/" to the path. When empty components are skipped (e.g., input `"a//b"`), `i` still increments, causing a leading "/" even when `currentPath` is empty. Changed to check `currentPath != ""` instead.

4. **Repeated type assertions** — The same `fileClient.(*azureFileDataplaneClient)` assertion was done multiple times. Now stored in a local variable `dc`.

## Which issue(s) this PR fixes:
None

## Special notes for your reviewer:
Minimal, targeted fix. No behavioral change for the happy path.