### PR TITLE
feat: add privateDNSZoneResourceGroup parameter support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	k8s.io/mount-utils v0.35.0
 	k8s.io/pod-security-admission v0.35.0
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-	sigs.k8s.io/cloud-provider-azure v1.29.1-0.20260405034709-416612e9ec01
+	sigs.k8s.io/cloud-provider-azure v1.29.1-0.20260416034754-970bd8e5f635
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.14.3
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.11.0
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -952,8 +952,8 @@ k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzk
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 h1:qPrZsv1cwQiFeieFlRqT627fVZ+tyfou/+S5S0H5ua0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cloud-provider-azure v1.29.1-0.20260405034709-416612e9ec01 h1:kvBW0Fi1r1LtCezlSfNpwfxYERuMOhQySqAVkwrGZNI=
-sigs.k8s.io/cloud-provider-azure v1.29.1-0.20260405034709-416612e9ec01/go.mod h1:17yBiLRMBxqUxGqWU07Wuj22/OuRIeibH8J5iP1AZiI=
+sigs.k8s.io/cloud-provider-azure v1.29.1-0.20260416034754-970bd8e5f635 h1:AByrwN9tRGMIbJ5zknBEPN7KSnNNjApPxJFs1E6bytc=
+sigs.k8s.io/cloud-provider-azure v1.29.1-0.20260416034754-970bd8e5f635/go.mod h1:17yBiLRMBxqUxGqWU07Wuj22/OuRIeibH8J5iP1AZiI=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.14.3 h1:FZ8lmJycB7+hGSQo4Qn8DT5M6oRN1mP/bCwRWdBThuQ=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.14.3/go.mod h1:BgHrVkRmx7iWCumslrUpxE6BX474IrMXc+7R0RpV+E8=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/cache v0.10.0 h1:KBGDanmK8awNR733CDwHfKO8b1Voac/kPdbIsvVTjSU=

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -156,7 +156,7 @@ const (
 	vhdSuffix                         = ".vhd"
 	metaDataNode                      = "node"
 	networkEndpointTypeField          = "networkendpointtype"
-	privateDNSResourceGroupField      = "privatednsresourcegroup"
+	privateDNSZoneResourceGroupField  = "privatednszoneresourcegroup"
 	vnetResourceGroupField            = "vnetresourcegroup"
 	vnetNameField                     = "vnetname"
 	vnetLinkNameField                 = "vnetlinkname"

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -156,6 +156,7 @@ const (
 	vhdSuffix                         = ".vhd"
 	metaDataNode                      = "node"
 	networkEndpointTypeField          = "networkendpointtype"
+	privateDNSResourceGroupField      = "privatednsresourcegroup"
 	vnetResourceGroupField            = "vnetresourcegroup"
 	vnetNameField                     = "vnetname"
 	vnetLinkNameField                 = "vnetlinkname"

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -612,7 +612,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey = fmt.Sprintf("%s%s%s%s%s%s%s%v%v%v%v%v%v%v", sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier,
+			lockKey = fmt.Sprintf("%s%s%s%s%s%s%s%s%v%v%v%v%v%v%v", sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier, privateDNSZoneResourceGroup,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false), ptr.Deref(requireInfraEncryption, false),
 				ptr.Deref(enableLFS, false), ptr.Deref(disableDeleteRetentionPolicy, false),
 				ptr.Deref(allowCrossTenantReplication, true), ptr.Deref(allowSharedKeyAccess, true))

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -121,7 +121,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	var sku, subsID, resourceGroup, location, account, fileShareName, diskName, fsType, secretName string
 	var secretNamespace, pvcNamespace, protocol, customTags, storageEndpointSuffix, networkEndpointType, shareAccessTier, accountAccessTier, rootSquashType, tagValueDelimiter string
 	var createAccount, useSeretCache, matchTags, selectRandomMatchingAccount, getLatestAccountKey, encryptInTransit, mountWithManagedIdentity, mountWithWIToken bool
-	var vnetResourceGroup, vnetName, vnetLinkName, publicNetworkAccess, subnetName, shareNamePrefix, fsGroupChangePolicy, useDataPlaneAPI string
+	var vnetResourceGroup, vnetName, vnetLinkName, publicNetworkAccess, subnetName, shareNamePrefix, fsGroupChangePolicy, useDataPlaneAPI, privateDNSResourceGroup string
 	var requireInfraEncryption, disableDeleteRetentionPolicy, enableLFS, isMultichannelEnabled, allowSharedKeyAccess, allowCrossTenantReplication *bool
 	var provisionedBandwidthMibps, provisionedIops *int32
 	// set allowBlobPublicAccess as false by default
@@ -203,6 +203,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			storageEndpointSuffix = v
 		case networkEndpointTypeField:
 			networkEndpointType = v
+		case privateDNSResourceGroupField:
+			privateDNSResourceGroup = v
 		case accessTierField:
 			shareAccessTier = v
 		case shareAccessTierField:
@@ -394,6 +396,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			return nil, status.Errorf(codes.InvalidArgument, "subnetName(%s) can only contain one subnet for private endpoint", subnetName)
 		}
 		createPrivateEndpoint = ptr.To(true)
+	} else {
+		if privateDNSResourceGroup != "" {
+			return nil, status.Errorf(codes.InvalidArgument, "privateDNSResourceGroup(%s) is only supported with private endpoint", privateDNSResourceGroup)
+		}
 	}
 	var vnetResourceIDs []string
 	if fsType == nfs || protocol == nfs {
@@ -572,6 +578,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		VirtualNetworkResourceIDs:               vnetResourceIDs,
 		CreateAccount:                           createAccount,
 		CreatePrivateEndpoint:                   createPrivateEndpoint,
+		PrivateDNSZoneResourceGroup:             privateDNSResourceGroup,
 		EnableLargeFileShare:                    enableLFS,
 		DisableFileServiceDeleteRetentionPolicy: disableDeleteRetentionPolicy,
 		AllowBlobPublicAccess:                   allowBlobPublicAccess,

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -121,7 +121,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	var sku, subsID, resourceGroup, location, account, fileShareName, diskName, fsType, secretName string
 	var secretNamespace, pvcNamespace, protocol, customTags, storageEndpointSuffix, networkEndpointType, shareAccessTier, accountAccessTier, rootSquashType, tagValueDelimiter string
 	var createAccount, useSeretCache, matchTags, selectRandomMatchingAccount, getLatestAccountKey, encryptInTransit, mountWithManagedIdentity, mountWithWIToken bool
-	var vnetResourceGroup, vnetName, vnetLinkName, publicNetworkAccess, subnetName, shareNamePrefix, fsGroupChangePolicy, useDataPlaneAPI, privateDNSResourceGroup string
+	var vnetResourceGroup, vnetName, vnetLinkName, publicNetworkAccess, subnetName, shareNamePrefix, fsGroupChangePolicy, useDataPlaneAPI, privateDNSZoneResourceGroup string
 	var requireInfraEncryption, disableDeleteRetentionPolicy, enableLFS, isMultichannelEnabled, allowSharedKeyAccess, allowCrossTenantReplication *bool
 	var provisionedBandwidthMibps, provisionedIops *int32
 	// set allowBlobPublicAccess as false by default
@@ -203,8 +203,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			storageEndpointSuffix = v
 		case networkEndpointTypeField:
 			networkEndpointType = v
-		case privateDNSResourceGroupField:
-			privateDNSResourceGroup = v
+		case privateDNSZoneResourceGroupField:
+			privateDNSZoneResourceGroup = v
 		case accessTierField:
 			shareAccessTier = v
 		case shareAccessTierField:
@@ -397,8 +397,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 		createPrivateEndpoint = ptr.To(true)
 	} else {
-		if privateDNSResourceGroup != "" {
-			return nil, status.Errorf(codes.InvalidArgument, "privateDNSResourceGroup(%s) is only supported with private endpoint", privateDNSResourceGroup)
+		if privateDNSZoneResourceGroup != "" {
+			return nil, status.Errorf(codes.InvalidArgument, "%s(%s) is only supported with private endpoint", privateDNSZoneResourceGroupField, privateDNSZoneResourceGroup)
 		}
 	}
 	var vnetResourceIDs []string
@@ -578,7 +578,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		VirtualNetworkResourceIDs:               vnetResourceIDs,
 		CreateAccount:                           createAccount,
 		CreatePrivateEndpoint:                   createPrivateEndpoint,
-		PrivateDNSZoneResourceGroup:             privateDNSResourceGroup,
+		PrivateDNSZoneResourceGroup:             privateDNSZoneResourceGroup,
 		EnableLargeFileShare:                    enableLFS,
 		DisableFileServiceDeleteRetentionPolicy: disableDeleteRetentionPolicy,
 		AllowBlobPublicAccess:                   allowBlobPublicAccess,

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -623,6 +623,27 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 			gomega.Expect(err).To(gomega.Equal(expectedErr))
 		})
 	})
+	ginkgo.When("privateDNSZoneResourceGroup without private endpoint", func() {
+		ginkgo.It("should fail", func(ctx context.Context) {
+			allParam := map[string]string{
+				privateDNSZoneResourceGroupField: "dns-rg",
+			}
+
+			req := &csi.CreateVolumeRequest{
+				Name:               "invalid-privateDNSZoneResourceGroup-without-private-endpoint",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         allParam,
+			}
+			d.cloud = &storage.AccountRepo{
+				Config: config.Config{},
+			}
+
+			expectedErr := status.Errorf(codes.InvalidArgument, "%s(%s) is only supported with private endpoint", privateDNSZoneResourceGroupField, "dns-rg")
+			_, err := d.CreateVolume(ctx, req)
+			gomega.Expect(err).To(gomega.Equal(expectedErr))
+		})
+	})
 	ginkgo.When("Failed to update subnet service endpoints", func() {
 		ginkgo.It("should fail", func(ctx context.Context) {
 			allParam := map[string]string{

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -644,6 +644,37 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 			gomega.Expect(err).To(gomega.Equal(expectedErr))
 		})
 	})
+	ginkgo.When("privateDNSZoneResourceGroup with private endpoint", func() {
+		ginkgo.It("should propagate into cloud-provider calls", func(ctx context.Context) {
+			allParam := map[string]string{
+				networkEndpointTypeField:          "privateendpoint",
+				privateDNSZoneResourceGroupField: "dns-rg",
+			}
+
+			fakeCloud := &storage.AccountRepo{
+				Config: config.Config{
+					ResourceGroup: "rg",
+					Location:      "loc",
+					VnetName:      "fake-vnet",
+					SubnetName:    "fake-subnet",
+				},
+			}
+
+			req := &csi.CreateVolumeRequest{
+				Name:               "valid-privateDNSZoneResourceGroup-with-private-endpoint",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         allParam,
+			}
+			d.cloud = fakeCloud
+
+			// The request should get past parameter validation (no InvalidArgument error)
+			// and fail later in EnsureStorageAccount due to nil clientFactory
+			_, err := d.CreateVolume(ctx, req)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to ensure storage account"))
+		})
+	})
 	ginkgo.When("Failed to update subnet service endpoints", func() {
 		ginkgo.It("should fail", func(ctx context.Context) {
 			allParam := map[string]string{

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -647,7 +647,7 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 	ginkgo.When("privateDNSZoneResourceGroup with private endpoint", func() {
 		ginkgo.It("should propagate into cloud-provider calls", func(ctx context.Context) {
 			allParam := map[string]string{
-				networkEndpointTypeField:          "privateendpoint",
+				networkEndpointTypeField:         "privateendpoint",
 				privateDNSZoneResourceGroupField: "dns-rg",
 			}
 

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -645,7 +645,7 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 		})
 	})
 	ginkgo.When("privateDNSZoneResourceGroup with private endpoint", func() {
-		ginkgo.It("should propagate into cloud-provider calls", func(ctx context.Context) {
+		ginkgo.It("should pass parameter validation", func(ctx context.Context) {
 			allParam := map[string]string{
 				networkEndpointTypeField:         "privateendpoint",
 				privateDNSZoneResourceGroupField: "dns-rg",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1492,7 +1492,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/cloud-provider-azure v1.29.1-0.20260405034709-416612e9ec01
+# sigs.k8s.io/cloud-provider-azure v1.29.1-0.20260416034754-970bd8e5f635
 ## explicit; go 1.25.0
 sigs.k8s.io/cloud-provider-azure/pkg/cache
 sigs.k8s.io/cloud-provider-azure/pkg/consts

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/storage/azure_storageaccount.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/storage/azure_storageaccount.go
@@ -100,6 +100,8 @@ type AccountOptions struct {
 	SourceAccountName string
 	// default is "privatelink"
 	PrivateDNSZoneName string
+	// resource group for private DNS zone, default is vnetResourceGroup
+	PrivateDNSZoneResourceGroup string
 	// default is vnetName + "-vnetlink"
 	VNetLinkName        string
 	PublicNetworkAccess string
@@ -461,20 +463,27 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		}
 	}
 
+	// Use a separate resource group for private DNS zone if specified,
+	// otherwise default to vnetResourceGroup for backward compatibility.
+	privateDNSResourceGroup := vnetResourceGroup
+	if accountOptions.PrivateDNSZoneResourceGroup != "" {
+		privateDNSResourceGroup = accountOptions.PrivateDNSZoneResourceGroup
+	}
+
 	if ptr.Deref(accountOptions.CreatePrivateEndpoint, false) {
 		clientFactory := az.NetworkClientFactory
 		if clientFactory == nil {
 			// multi-tenant support
 			clientFactory = az.ComputeClientFactory
 		}
-		if _, err := clientFactory.GetPrivateZoneClient().Get(ctx, vnetResourceGroup, privateDNSZoneName); err != nil {
+		if _, err := clientFactory.GetPrivateZoneClient().Get(ctx, privateDNSResourceGroup, privateDNSZoneName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				// Create DNS zone first, this could make sure driver has write permission on vnetResourceGroup
-				if err := az.createPrivateDNSZone(ctx, vnetResourceGroup, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create private DNS zone(%s) in resourceGroup(%s): %w", privateDNSZoneName, vnetResourceGroup, err)
+				// Create DNS zone first, this could make sure driver has write permission on privateDNSResourceGroup
+				if err := az.createPrivateDNSZone(ctx, privateDNSResourceGroup, privateDNSZoneName); err != nil {
+					return "", "", fmt.Errorf("create private DNS zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get private dns zone %s returned with %v", privateDNSZoneName, err.Error())
+				return "", "", fmt.Errorf("get private DNS zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 			}
 		}
 
@@ -483,13 +492,13 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.VNetLinkName != "" {
 			vNetLinkName = accountOptions.VNetLinkName
 		}
-		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, vnetResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
+		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, privateDNSResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				if err := az.createVNetLink(ctx, vNetLinkName, vnetResourceGroup, vnetName, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s): %w", vnetName, privateDNSZoneName, vnetResourceGroup, err)
+				if err := az.createVNetLink(ctx, vNetLinkName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
+					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in privateDNSResourceGroup(%s): %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, vnetResourceGroup, err)
+				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in privateDNSResourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 			}
 		}
 	}
@@ -724,8 +733,8 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.StorageType == StorageTypeBlob {
 			dnsZoneGroupName = dnsZoneGroupName + blobNameSuffix
 		}
-		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, vnetName, privateDNSZoneName); err != nil {
-			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointName, vnetName, vnetResourceGroup, err)
+		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
+			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), privateEndpointResourceGroup(%s), privateDNSZoneResourceGroup(%s): %w", privateEndpointName, vnetName, vnetResourceGroup, privateDNSResourceGroup, err)
 		}
 	}
 
@@ -788,9 +797,9 @@ func (az *AccountRepo) createPrivateEndpoint(ctx context.Context, accountName st
 	return err
 }
 
-func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGroup, privateDNSZoneName string) error {
+func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, privateDNSResourceGroup, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createPrivateDNSZone")
-	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "resourceGroup", privateDNSResourceGroup)
 	location := LocationGlobal
 	privateDNSZone := privatedns.PrivateZone{Location: &location}
 	clientFactory := az.NetworkClientFactory
@@ -800,9 +809,9 @@ func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGro
 	}
 	privatednsclient := clientFactory.GetPrivateZoneClient()
 
-	if _, err := privatednsclient.CreateOrUpdate(ctx, vnetResourceGroup, privateDNSZoneName, privateDNSZone); err != nil {
+	if _, err := privatednsclient.CreateOrUpdate(ctx, privateDNSResourceGroup, privateDNSZoneName, privateDNSZone); err != nil {
 		if strings.Contains(err.Error(), "exists already") {
-			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "resourceGroup", privateDNSResourceGroup)
 			return nil
 		}
 		return err
@@ -810,9 +819,9 @@ func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGro
 	return nil
 }
 
-func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetResourceGroup, vnetName, privateDNSZoneName string) error {
+func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createVNetLink")
-	logger.V(2).Info("Creating virtual network link", "vNetLinkName", vNetLinkName, "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating virtual network link", "vNetLinkName", vNetLinkName, "privateDNSZone", privateDNSZoneName, "vnetResourceGroup", vnetResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
 	clientFactory := az.NetworkClientFactory
 	if clientFactory == nil {
 		// multi-tenant support
@@ -828,20 +837,20 @@ func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetRes
 			VirtualNetwork:      &privatedns.SubResource{ID: &vnetID},
 			RegistrationEnabled: ptr.To(false)},
 	}
-	_, err := vnetLinkClient.CreateOrUpdate(ctx, vnetResourceGroup, privateDNSZoneName, vNetLinkName, parameters)
+	_, err := vnetLinkClient.CreateOrUpdate(ctx, privateDNSResourceGroup, privateDNSZoneName, vNetLinkName, parameters)
 	return err
 }
 
-func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, vnetName, privateDNSZoneName string) error {
+func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGroupName, privateEndpointName, privateEndpointResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createPrivateDNSZoneGroup")
-	logger.V(2).Info("Creating private DNS zone group", "dnsZoneGroup", dnsZoneGroupName, "privateEndpoint", privateEndpointName, "vnetName", vnetName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating private DNS zone group", "dnsZoneGroup", dnsZoneGroupName, "privateEndpoint", privateEndpointName, "vnetName", vnetName, "privateEndpointResourceGroup", privateEndpointResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
 	privateDNSZoneGroup := &armnetwork.PrivateDNSZoneGroup{
 		Properties: &armnetwork.PrivateDNSZoneGroupPropertiesFormat{
 			PrivateDNSZoneConfigs: []*armnetwork.PrivateDNSZoneConfig{
 				{
 					Name: &privateDNSZoneName,
 					Properties: &armnetwork.PrivateDNSZonePropertiesFormat{
-						PrivateDNSZoneID: to.Ptr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s", az.SubscriptionID, vnetResourceGroup, privateDNSZoneName)),
+						PrivateDNSZoneID: to.Ptr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s", az.SubscriptionID, privateDNSResourceGroup, privateDNSZoneName)),
 					},
 				},
 			},
@@ -852,7 +861,7 @@ func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGro
 		clientFactory = az.ComputeClientFactory
 	}
 	privatednsgroupClient := clientFactory.GetPrivateDNSZoneGroupClient()
-	_, err := privatednsgroupClient.CreateOrUpdate(ctx, vnetResourceGroup, privateEndpointName, dnsZoneGroupName, *privateDNSZoneGroup)
+	_, err := privatednsgroupClient.CreateOrUpdate(ctx, privateEndpointResourceGroup, privateEndpointName, dnsZoneGroupName, *privateDNSZoneGroup)
 	return err
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Add `privateDNSZoneResourceGroup` StorageClass parameter to allow specifying a separate resource group for private DNS zones, independent of the VNet resource group. This supports enterprise scenarios where DNS zones are managed in a dedicated resource group.

Also removes the `privateDNSZoneName` parameter — the DNS zone name is always `privatelink` for private endpoints (enforced by Azure).

Depends on: kubernetes-sigs/cloud-provider-azure#10189

**Which issue(s) this PR fixes:**

Fixes kubernetes-sigs/azurefile-csi-driver#2845

**Special notes for your reviewer:**

- New StorageClass parameter: `privateDNSZoneResourceGroup` (key: `privatednszoneresourcegroup`)
- Removed StorageClass parameter: `privateDNSZoneName` (always `privatelink` for PE)
- Vendor upgrade of cloud-provider-azure lib includes the cross-RG private DNS zone support
- Unit test added for validation error when used without private endpoint
- running example logs
<details>

```
I0416 08:05:56.453148       1 utils.go:105] GRPC call: /csi.v1.Controller/CreateVolume
I0416 08:05:56.453171       1 utils.go:106] GRPC request: {"capacity_range":{"required_bytes":107374182400},"name":"pvc-a1453b2b-1efd-4a65-92fe-bbc795e8a822","parameters":{"csi.storage.k8s.io/pv/name":"pvc-a1453b2b-1efd-4a65-92fe-bbc795e8a822","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azurefile-pvt-0","csi.storage.k8s.io/pvc/namespace":"default","networkEndpointType":"privateEndpoint","privateDNSZoneResourceGroup":"andy-aks133kaito","skuName":"Premium_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["dir_mode=0777","file_mode=0777","mfsymlinks","cache=strict","nosharesock","actimeo=30","nobrl"]}},"access_mode":{"mode":5}}]}
I0416 08:05:57.653731       1 azure_storageaccount.go:802] "Creating private DNS zone" logger="createPrivateDNSZone" privateDNSZone="privatelink.file.core.windows.net" resourceGroup="andy-aks133kaito"
I0416 08:06:31.006626       1 azure_storageaccount.go:824] "Creating virtual network link" logger="createVNetLink" vNetLinkName="aks-vnet-22157909-vnetlink" privateDNSZone="privatelink.file.core.windows.net" vnetResourceGroup="MC_andy-aks133kaito_andy-aks133kaito_westeurope" privateDNSResourceGroup="andy-aks133kaito"
I0416 08:07:03.474088       1 azure_storageaccount.go:549] "azure - no matching account found, begin to create a new account" logger="EnsureStorageAccount" accountName="f9c70f97bd3324ebb8a71dd" resourceGroup="MC_andy-aks133kaito_andy-aks133kaito_westeurope" location="westeurope" accountType="Premium_LRS" accountKind="FileStorage" tags={"k8s-azure-created-by":"azure"}
I0416 08:07:03.474130       1 azure_storageaccount.go:580] "set AllowBlobPublicAccess for storage account" logger="EnsureStorageAccount" AllowBlobPublicAccess=false account="f9c70f97bd3324ebb8a71dd"
I0416 08:07:24.225792       1 azure_storageaccount.go:752] "Creating private endpoint" logger="createPrivateEndpoint" privateEndpointName="f9c70f97bd3324ebb8a71dd-pvtendpoint" account="f9c70f97bd3324ebb8a71dd"
I0416 08:07:24.521460       1 azure_storageaccount.go:769] "PrivateEndpointNetworkPolicies is already set for subnet" logger="createPrivateEndpoint" vnetName="aks-vnet-22157909" subnetName="aks-subnet" PrivateEndpointNetworkPolicies="Disabled"
I0416 08:08:06.675260       1 azure_storageaccount.go:846] "Creating private DNS zone group" logger="createPrivateDNSZoneGroup" dnsZoneGroup="f9c70f97bd3324ebb8a71dd-dnszonegroup" privateEndpoint="f9c70f97bd3324ebb8a71dd-pvtendpoint" vnetName="aks-vnet-22157909" privateEndpointResourceGroup="MC_andy-aks133kaito_andy-aks133kaito_westeurope" privateDNSResourceGroup="andy-aks133kaito"
I0416 08:08:19.256441       1 controllerserver.go:695] begin to create file share(pvc-a1453b2b-1efd-4a65-92fe-bbc795e8a822) on account(f9c70f97bd3324ebb8a71dd) type(Premium_LRS) subID() rg(MC_andy-aks133kaito_andy-aks133kaito_westeurope) location() size(100) protocol(SMB)
I0416 08:08:20.216468       1 azurefile_mgmt_client.go:90] created share pvc-a1453b2b-1efd-4a65-92fe-bbc795e8a822 in account f9c70f97bd3324ebb8a71dd
I0416 08:08:20.216578       1 controllerserver.go:742] create file share pvc-a1453b2b-1efd-4a65-92fe-bbc795e8a822 on storage account f9c70f97bd3324ebb8a71dd successfully
I0416 08:08:20.263873       1 controllerserver.go:788] store account key to k8s secret(azure-storage-account-f9c70f97bd3324ebb8a71dd-secret) in default namespace
I0416 08:08:20.263957       1 metrics.go:168] "Observed Request Latency" logger="logLatency" latency_seconds=143.810302689 request="azurefile_csi_driver_controller_create_volume" success="true" resource_group="mc_andy-aks133kaito_andy-aks133kaito_westeurope" source="file.csi.azure.com" volumeid="MC_andy-aks133kaito_andy-aks133kaito_westeurope#f9c70f97bd3324ebb8a71dd#pvc-a1453b2b-1efd-4a65-92fe-bbc795e8a822###default"
I0416 08:08:20.263979       1 utils.go:112] GRPC response: {"volume":{"capacity_bytes":107374182400,"volume_context":{"csi.storage.k8s.io/pv/name":"pvc-a1453b2b-1efd-4a65-92fe-bbc795e8a822","csi.storage.k8s.io/pvc/name":"persistent-storage-statefulset-azurefile-pvt-0","csi.storage.k8s.io/pvc/namespace":"default","networkEndpointType":"privateEndpoint","privateDNSZoneResourceGroup":"andy-aks133kaito","secretnamespace":"default","server":"f9c70f97bd3324ebb8a71dd.privatelink.file.core.windows.net","skuName":"Premium_LRS"},"volume_id":"MC_andy-aks133kaito_andy-aks133kaito_westeurope#f9c70f97bd3324ebb8a71dd#pvc-a1453b2b-1efd-4a65-92fe-bbc795e8a822###default"}}
```

</details>

**Release note:**

```
feat: add privateDNSZoneResourceGroup StorageClass parameter for cross-resource-group private DNS zone support
```