### PR TITLE
docs: add known issue for AES-256-GCM mount failure workaround

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -50,8 +50,7 @@ resourceGroup | specify the resource group in which Azure file share will be cre
 subscriptionID | specify Azure subscription ID where Azure file share will be created | Azure subscription ID | No | if not empty, `resourceGroup` must be provided
 shareName | specify Azure file share name | existing or new Azure file name | No | if empty, driver will generate an Azure file share name
 shareNamePrefix | specify Azure file share name prefix created by driver | can only contain lowercase letters, numbers, hyphens, and length should be less than 21 | No |
-folderName | specify folder name in Azure file share | existing folder name in Azure file share, supports `${pvc.metadata.name}`, `${pvc.metadata.namespace}`, `${pv.metadata.name}` placeholders | No | if the folder does not exist in the file share, mount may fail unless `createFolderIfNotExist=true`
-createFolderIfNotExist | specify whether to create the folder if it does not exist in the Azure file share (supported from v1.34.0) | `true`,`false` | No | `false`
+folderName | specify folder name in Azure file share | existing folder name in Azure file share | No | if folder name does not exist in file share, mount would fail
 shareAccessTier | [Access tier for file share](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-planning#storage-tiers) (this parameter is ignored when using bring your own account key scenario) | For general-purpose v2 account, the available tiers are `TransactionOptimized`(default), `Hot`, and `Cool`. For file storage account, the available tier is `Premium`. | No | empty(use default setting for different storage account types)
 server | specify Azure storage account server address | existing server address, e.g. `accountname.file.core.windows.net` | No | if empty, driver will use default `accountname.file.core.windows.net` or other sovereign cloud account address
 disableDeleteRetentionPolicy | specify whether disable DeleteRetentionPolicy for storage account created by driver | `true`,`false` | No | `false`
@@ -113,8 +112,7 @@ volumeAttributes.subscriptionID | specify Azure subscription ID where Azure file
 volumeAttributes.resourceGroup | Azure resource group name | existing resource group name | No | if empty, driver will use the same resource group name as current k8s cluster
 volumeAttributes.storageAccount | existing storage account name | existing storage account name | Yes |
 volumeAttributes.shareName | Azure file share name | existing Azure file share name | Yes |
-volumeAttributes.folderName | specify folder name in Azure file share | existing folder name in Azure file share, supports `${pvc.metadata.name}`, `${pvc.metadata.namespace}`, `${pv.metadata.name}` placeholders | No | if folder name does not exist in file share, mount would fail unless `volumeAttributes.createFolderIfNotExist=true`
-volumeAttributes.createFolderIfNotExist | specify whether to create the folder if it does not exist in the Azure file share (supported from v1.34.0) | `true`,`false` | No | `false`
+volumeAttributes.folderName | specify folder name in Azure file share | existing folder name in Azure file share | No | if folder name does not exist in file share, mount would fail
 volumeAttributes.protocol | specify file share protocol | `smb`, `nfs` | No | `smb`
 volumeAttributes.server | specify Azure storage account server address | existing server address, e.g. `accountname.file.core.windows.net` | No | if empty, driver will use default `accountname.file.core.windows.net` or other sovereign cloud account address
 volumeAttributes.storageEndpointSuffix | specify Azure storage endpoint suffix | `core.windows.net`, `core.chinacloudapi.cn`, etc | No | if empty, driver will use default storage endpoint suffix according to cloud environment, e.g. `core.windows.net`
@@ -140,6 +138,14 @@ kubectl create secret generic azure-storage-account-{accountname}-secret --from-
 Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
 useDataPlaneAPI | specify whether use [data plane API](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/share.go) for snapshot create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account | `true`,`false` | No | `false`
+
+### Known Issues
+  - **AES-256-GCM encryption mount failure**: When an Azure Storage account is configured with **only AES-256-GCM** channel encryption (AES-128-GCM disabled), SMB mounts may fail with `permission denied (error 13)`. This is because the Azure Storage service may advertise AES-128-GCM during SMB negotiation even when it is disabled, causing the Linux CIFS client to select AES-128-GCM (preferred for performance) which is then rejected by the server. **Workaround**: Add `require_gcm_256` to `mountOptions` in your StorageClass or PersistentVolume to force the client to use AES-256-GCM:
+    ```yaml
+    mountOptions:
+      - require_gcm_256
+    ```
+    See [#2833](https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/2833) for details.
 
 ### Tips
   - mounting Azure SMB File share requires account key


### PR DESCRIPTION
Add a Known Issues section to driver-parameters.md documenting the AES-256-GCM mount failure when Azure Storage accounts have only AES-256-GCM channel encryption enabled.

**Problem:** Azure Storage may advertise AES-128-GCM during SMB negotiation even when it is disabled on the storage account. The Linux CIFS client prefers AES-128-GCM for performance and selects it, but the server then rejects the connection with error 13 (permission denied).

**Workaround:** Add `require_gcm_256` to `mountOptions` to force the client to use AES-256-GCM.

Fixes #2833