### PR TITLE
test: add missing ReadOnly flag to readOnly volume mount tests

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -435,6 +435,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 						VolumeMount: testsuites.VolumeMountDetails{
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
+							ReadOnly:          true,
 						},
 						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany},
 					},
@@ -467,6 +468,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 						VolumeMount: testsuites.VolumeMountDetails{
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
+							ReadOnly:          true,
 						},
 						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany},
 					},


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
The two `[Windows]` readOnly volume e2e tests were missing `ReadOnly: true` in `VolumeMountDetails`, causing the volume to be mounted read-write. This made the tests flaky — the pod succeeded instead of failing with "Read-only file system" when writing to the mount.

The non-`[Windows]` version of the same test correctly sets `ReadOnly: true` (line 402), but the two `[Windows]` variants at line 425 and 456 did not.

### Fix:
Add `ReadOnly: true` to `VolumeMount` in both test cases, consistent with the non-`[Windows]` test.

## Which issue(s) this PR fixes:
Fixes flaky e2e test failures in `pull-azurefile-csi-driver-e2e-capz`:
- `should create a smb volume on demand and mount it as readOnly when volume access mode is readonly [Windows]`
- `should create a nfs volume on demand and mount it as readOnly when volume access mode is readonly [Windows]`

## Does this PR introduce a user-facing change?
```release-note
NONE
```