### PR TITLE
test: add ModifyVolume sanity test

### DIFF
--- a/test/sanity/create-volume-params.yaml
+++ b/test/sanity/create-volume-params.yaml
@@ -1,0 +1,1 @@
+skuName: StandardV2_LRS

--- a/test/sanity/modify-volume-params.yaml
+++ b/test/sanity/modify-volume-params.yaml
@@ -1,0 +1,2 @@
+provisionediops: "3000"
+provisionedbandwidth: "125"

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -54,7 +54,7 @@ sleep 1
 
 echo 'Begin to run sanity test...'
 readonly CSI_SANITY_BIN='csi-sanity'
-"$CSI_SANITY_BIN" --ginkgo.v --ginkgo.noColor --csi.endpoint="$endpoint" --ginkgo.skip='should fail when requesting to create a snapshot with already existing name and different source volume ID'
+"$CSI_SANITY_BIN" --ginkgo.v --ginkgo.noColor --csi.endpoint="$endpoint" --csi.testvolumesize=34359738368 --csi.testvolumeparameters="test/sanity/create-volume-params.yaml" --csi.testvolumemutableparameters="test/sanity/modify-volume-params.yaml" --ginkgo.skip='should fail when requesting to create a snapshot with already existing name and different source volume ID'
 
 testvolumeparameters='/tmp/vhd.yaml'
 cat > $testvolumeparameters << EOF


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it:
Add sanity test configuration for `ControllerModifyVolume`:
- `modify-volume-params.yaml` with `provisionediops` and `provisionedbandwidth` parameters
- Update `run-test.sh` to pass `--csi.testvolumemutableparameters` flag

## Which issue(s) this PR fixes:
None

## Does this PR introduce a user-facing change?
```release-note
NONE
```