### PR TITLE
test: add managed identity mount e2e test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,6 @@ require (
 	cyphar.com/go-pathrs v0.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2 v2.0.0

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1879,6 +1879,9 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		if !isCapzTest {
 			ginkgo.Skip("test case is only available for capz test")
 		}
+		if !miRoleSetupSucceeded {
+			ginkgo.Skip("MI role assignment did not succeed, skipping managed identity mount test")
+		}
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1879,9 +1879,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		if !isCapzTest {
 			ginkgo.Skip("test case is only available for capz test")
 		}
-		if !miRoleSetupSucceeded {
-			ginkgo.Skip("MI role assignment did not succeed, skipping managed identity mount test")
-		}
+		gomega.Expect(miRoleSetupSucceeded).To(gomega.BeTrue(), "MI role assignment failed, cannot run managed identity mount test")
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1894,8 +1894,8 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			},
 		}
 		scParameters := map[string]string{
-			"skuName":                     "Standard_LRS",
-			"mountWithManagedIdentity":    "true",
+			"skuName":                  "Standard_LRS",
+			"mountWithManagedIdentity": "true",
 		}
 		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
 			CSIDriver:              testDriver,

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1873,6 +1873,38 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test.Run(ctx, cs, ns)
 	})
 
+	ginkgo.It("should create a volume on demand with managed identity mount [file.csi.azure.com]", func(ctx ginkgo.SpecContext) {
+		skipIfUsingInTreeVolumePlugin()
+		skipIfTestingInWindowsCluster()
+		if !isCapzTest {
+			ginkgo.Skip("test case is only available for capz test")
+		}
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		scParameters := map[string]string{
+			"skuName":                     "Standard_LRS",
+			"mountWithManagedIdentity":    "true",
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver:              testDriver,
+			Pods:                   pods,
+			StorageClassParameters: scParameters,
+		}
+		test.Run(ctx, cs, ns)
+	})
+
 })
 
 func restClient(group string, version string) (restclientset.Interface, error) {

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1896,6 +1896,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		scParameters := map[string]string{
 			"skuName":                  "Standard_LRS",
 			"mountWithManagedIdentity": "true",
+			"clientID":                 nodeIdentityClientID,
 		}
 		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
 			CSIDriver:              testDriver,

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1896,7 +1896,6 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		scParameters := map[string]string{
 			"skuName":                  "Standard_LRS",
 			"mountWithManagedIdentity": "true",
-			"clientID":                 nodeIdentityClientID,
 		}
 		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
 			CSIDriver:              testDriver,

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -97,11 +97,11 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		_, err = azureClient.EnsureResourceGroup(ctx, creds.ResourceGroup, creds.Location, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Assign Storage File Data SMB Share Elevated Contributor role to node identities
+		// Assign Storage File Data SMB MI Admin role to node identities
 		// This is required for mountWithManagedIdentity e2e tests (CAPZ only)
 		if isCapzTest {
 			if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
-				log.Printf("Warning: failed to assign Storage File Data SMB Share Elevated Contributor role to node identity: %v", err)
+				log.Printf("Warning: failed to assign Storage File Data SMB MI Admin role to node identity: %v", err)
 			}
 		}
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -64,6 +64,7 @@ var (
 	supportZRSwithNFS              bool
 	supportSnapshotwithNFS         bool
 	supportEncryptInTransitwithNFS bool
+	nodeIdentityClientID           string
 )
 
 type testCmd struct {
@@ -100,8 +101,11 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		// Assign Storage File Data SMB Share Elevated Contributor role to node identities
 		// This is required for mountWithManagedIdentity e2e tests (CAPZ only)
 		if isCapzTest {
-			if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
+			clientID, err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup)
+			if err != nil {
 				log.Printf("Warning: failed to assign Storage File Data SMB Share Elevated Contributor role to node identity: %v", err)
+			} else {
+				nodeIdentityClientID = clientID
 			}
 		}
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -100,7 +100,7 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		// Assign Storage File Data SMB Share Elevated Contributor role to node identities
 		// This is required for mountWithManagedIdentity e2e tests
 		if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
-			log.Printf("Warning: failed to assign Storage File Data SMB Share Elevated Contributor role to node identity: %v", err)
+			log.Printf("Warning: failed to assign Storage File Data SMB Share Elevated Contributor role to node identity: %v (non-AKS clusters may not have managed identities)", err)
 		}
 
 		// check whether current region supports Premium_ZRS with NFS protocol

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -98,9 +98,11 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Assign Storage File Data SMB Share Elevated Contributor role to node identities
-		// This is required for mountWithManagedIdentity e2e tests
-		if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
-			log.Printf("Warning: failed to assign Storage File Data SMB Share Elevated Contributor role to node identity: %v (non-AKS clusters may not have managed identities)", err)
+		// This is required for mountWithManagedIdentity e2e tests (CAPZ only)
+		if isCapzTest {
+			if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
+				log.Printf("Warning: failed to assign Storage File Data SMB Share Elevated Contributor role to node identity: %v", err)
+			}
 		}
 
 		// check whether current region supports Premium_ZRS with NFS protocol

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -101,11 +101,9 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		// Assign Storage File Data SMB MI Admin role to node identities
 		// This is required for mountWithManagedIdentity e2e tests (CAPZ only)
 		if isCapzTest {
-			if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
-				log.Printf("Warning: failed to assign Storage File Data SMB MI Admin role to node identity: %v", err)
-			} else {
-				miRoleSetupSucceeded = true
-			}
+			err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to assign Storage File Data SMB MI Admin role to node identity")
+			miRoleSetupSucceeded = true
 		}
 
 		// check whether current region supports Premium_ZRS with NFS protocol

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -64,6 +64,7 @@ var (
 	supportZRSwithNFS              bool
 	supportSnapshotwithNFS         bool
 	supportEncryptInTransitwithNFS bool
+	miRoleSetupSucceeded           bool
 )
 
 type testCmd struct {
@@ -102,6 +103,8 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		if isCapzTest {
 			if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
 				log.Printf("Warning: failed to assign Storage File Data SMB MI Admin role to node identity: %v", err)
+			} else {
+				miRoleSetupSucceeded = true
 			}
 		}
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -97,10 +97,10 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		_, err = azureClient.EnsureResourceGroup(ctx, creds.ResourceGroup, creds.Location, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Assign Storage File Data Privileged Contributor role to kubelet identity
+		// Assign Storage File Data SMB Share Elevated Contributor role to node identities
 		// This is required for mountWithManagedIdentity e2e tests
-		if err := azureClient.EnsureKubeletStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
-			log.Printf("Warning: failed to assign Storage File Data role to kubelet identity: %v", err)
+		if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
+			log.Printf("Warning: failed to assign Storage File Data SMB Share Elevated Contributor role to node identity: %v", err)
 		}
 
 		// check whether current region supports Premium_ZRS with NFS protocol

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -97,6 +97,12 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		_, err = azureClient.EnsureResourceGroup(ctx, creds.ResourceGroup, creds.Location, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		// Assign Storage File Data Privileged Contributor role to kubelet identity
+		// This is required for mountWithManagedIdentity e2e tests
+		if err := azureClient.EnsureKubeletStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
+			log.Printf("Warning: failed to assign Storage File Data role to kubelet identity: %v", err)
+		}
+
 		// check whether current region supports Premium_ZRS with NFS protocol
 		supportedRegions := []string{"southeastasia", "australiaeast", "europenorth", "europewest", "francecentral", "japaneast", "uksouth", "useast", "useast2", "uswest2"}
 		for _, region := range supportedRegions {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -64,7 +64,6 @@ var (
 	supportZRSwithNFS              bool
 	supportSnapshotwithNFS         bool
 	supportEncryptInTransitwithNFS bool
-	nodeIdentityClientID           string
 )
 
 type testCmd struct {
@@ -101,11 +100,8 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		// Assign Storage File Data SMB Share Elevated Contributor role to node identities
 		// This is required for mountWithManagedIdentity e2e tests (CAPZ only)
 		if isCapzTest {
-			clientID, err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup)
-			if err != nil {
+			if err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup); err != nil {
 				log.Printf("Warning: failed to assign Storage File Data SMB Share Elevated Contributor role to node identity: %v", err)
-			} else {
-				nodeIdentityClientID = clientID
 			}
 		}
 

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -180,10 +180,8 @@ func stringPointer(s string) *string {
 // GetNodeIdentityPrincipalIDs retrieves the principal IDs of managed identities from VMSS and VMs in the resource group.
 // Supports both system-assigned and user-assigned managed identities.
 // This works for both CAPZ and AKS clusters regardless of whether they use VMSS or availability set VMs.
-// Returns deduplicated principal IDs and the first user-assigned identity client ID found.
-func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup string) ([]string, string, error) {
+func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup string) ([]string, error) {
 	var principalIDs []string
-	var firstClientID string
 
 	// Check VMSS
 	log.Printf("Listing VMSS in resource group %s ...", resourceGroup)
@@ -191,7 +189,7 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 	for vmssPager.More() {
 		page, err := vmssPager.NextPage(ctx)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to list VMSS in resource group %s: %v", resourceGroup, err)
+			return nil, fmt.Errorf("failed to list VMSS in resource group %s: %v", resourceGroup, err)
 		}
 		for _, vmss := range page.Value {
 			name := ""
@@ -212,9 +210,6 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
 					log.Printf("VMSS %s: found user-assigned identity %s, principalID=%s", name, uaID, *uaIdentity.PrincipalID)
 					principalIDs = append(principalIDs, *uaIdentity.PrincipalID)
-					if firstClientID == "" && uaIdentity.ClientID != nil && *uaIdentity.ClientID != "" {
-						firstClientID = *uaIdentity.ClientID
-					}
 				}
 			}
 		}
@@ -226,7 +221,7 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 	for vmPager.More() {
 		page, err := vmPager.NextPage(ctx)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to list VMs in resource group %s: %v", resourceGroup, err)
+			return nil, fmt.Errorf("failed to list VMs in resource group %s: %v", resourceGroup, err)
 		}
 		for _, vm := range page.Value {
 			name := ""
@@ -247,16 +242,13 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
 					log.Printf("VM %s: found user-assigned identity %s, principalID=%s", name, uaID, *uaIdentity.PrincipalID)
 					principalIDs = append(principalIDs, *uaIdentity.PrincipalID)
-					if firstClientID == "" && uaIdentity.ClientID != nil && *uaIdentity.ClientID != "" {
-						firstClientID = *uaIdentity.ClientID
-					}
 				}
 			}
 		}
 	}
 
 	if len(principalIDs) == 0 {
-		return nil, "", fmt.Errorf("no VMSS or VM with managed identity found in resource group %s", resourceGroup)
+		return nil, fmt.Errorf("no VMSS or VM with managed identity found in resource group %s", resourceGroup)
 	}
 
 	// Deduplicate
@@ -269,7 +261,7 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 		}
 	}
 	log.Printf("Found %d unique principal IDs in resource group %s", len(unique), resourceGroup)
-	return unique, firstClientID, nil
+	return unique, nil
 }
 
 // AssignRoleToIdentity assigns an Azure role to a principal on a resource group scope.
@@ -304,13 +296,12 @@ func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, princ
 
 // EnsureNodeStorageFileDataRole gets the node identities from VMSS and VMs in the given
 // resource group and assigns them the "Storage File Data SMB Share Elevated Contributor" role.
-// It returns the first user-assigned managed identity client ID found (for use in StorageClass clientID).
-func (az *Client) EnsureNodeStorageFileDataRole(ctx context.Context, resourceGroup string) (string, error) {
+func (az *Client) EnsureNodeStorageFileDataRole(ctx context.Context, resourceGroup string) error {
 	log.Printf("Begin to assign Storage File Data SMB Share Elevated Contributor role to node identities in resource group %s", resourceGroup)
-	principalIDs, clientID, err := az.GetNodeIdentityPrincipalIDs(ctx, resourceGroup)
+	principalIDs, err := az.GetNodeIdentityPrincipalIDs(ctx, resourceGroup)
 	if err != nil {
 		log.Printf("Failed to get node identity principal IDs: %v", err)
-		return "", err
+		return err
 	}
 	// Storage File Data SMB Share Elevated Contributor
 	const storageFileDataSMBShareElevatedContributorRoleID = "a7264617-510b-434b-a828-9731dc254ea7"
@@ -318,13 +309,10 @@ func (az *Client) EnsureNodeStorageFileDataRole(ctx context.Context, resourceGro
 		log.Printf("Assigning Storage File Data SMB Share Elevated Contributor role to principal %s ...", principalID)
 		if err := az.AssignRoleToIdentity(ctx, resourceGroup, principalID, storageFileDataSMBShareElevatedContributorRoleID); err != nil {
 			log.Printf("Failed to assign role to principal %s: %v", principalID, err)
-			return "", err
+			return err
 		}
 		log.Printf("Successfully assigned Storage File Data SMB Share Elevated Contributor role to principal %s", principalID)
 	}
 	log.Printf("Successfully assigned Storage File Data SMB Share Elevated Contributor role to all %d node identities", len(principalIDs))
-	if clientID != "" {
-		log.Printf("First user-assigned managed identity clientID: %s", clientID)
-	}
-	return clientID, nil
+	return nil
 }

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -180,8 +180,10 @@ func stringPointer(s string) *string {
 // GetNodeIdentityPrincipalIDs retrieves the principal IDs of managed identities from VMSS and VMs in the resource group.
 // Supports both system-assigned and user-assigned managed identities.
 // This works for both CAPZ and AKS clusters regardless of whether they use VMSS or availability set VMs.
-func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup string) ([]string, error) {
+// Returns deduplicated principal IDs and the first user-assigned identity client ID found.
+func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup string) ([]string, string, error) {
 	var principalIDs []string
+	var firstClientID string
 
 	// Check VMSS
 	log.Printf("Listing VMSS in resource group %s ...", resourceGroup)
@@ -189,7 +191,7 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 	for vmssPager.More() {
 		page, err := vmssPager.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list VMSS in resource group %s: %v", resourceGroup, err)
+			return nil, "", fmt.Errorf("failed to list VMSS in resource group %s: %v", resourceGroup, err)
 		}
 		for _, vmss := range page.Value {
 			name := ""
@@ -210,6 +212,9 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
 					log.Printf("VMSS %s: found user-assigned identity %s, principalID=%s", name, uaID, *uaIdentity.PrincipalID)
 					principalIDs = append(principalIDs, *uaIdentity.PrincipalID)
+					if firstClientID == "" && uaIdentity.ClientID != nil && *uaIdentity.ClientID != "" {
+						firstClientID = *uaIdentity.ClientID
+					}
 				}
 			}
 		}
@@ -221,7 +226,7 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 	for vmPager.More() {
 		page, err := vmPager.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list VMs in resource group %s: %v", resourceGroup, err)
+			return nil, "", fmt.Errorf("failed to list VMs in resource group %s: %v", resourceGroup, err)
 		}
 		for _, vm := range page.Value {
 			name := ""
@@ -242,13 +247,16 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
 					log.Printf("VM %s: found user-assigned identity %s, principalID=%s", name, uaID, *uaIdentity.PrincipalID)
 					principalIDs = append(principalIDs, *uaIdentity.PrincipalID)
+					if firstClientID == "" && uaIdentity.ClientID != nil && *uaIdentity.ClientID != "" {
+						firstClientID = *uaIdentity.ClientID
+					}
 				}
 			}
 		}
 	}
 
 	if len(principalIDs) == 0 {
-		return nil, fmt.Errorf("no VMSS or VM with managed identity found in resource group %s", resourceGroup)
+		return nil, "", fmt.Errorf("no VMSS or VM with managed identity found in resource group %s", resourceGroup)
 	}
 
 	// Deduplicate
@@ -261,7 +269,7 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 		}
 	}
 	log.Printf("Found %d unique principal IDs in resource group %s", len(unique), resourceGroup)
-	return unique, nil
+	return unique, firstClientID, nil
 }
 
 // AssignRoleToIdentity assigns an Azure role to a principal on a resource group scope.
@@ -296,12 +304,13 @@ func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, princ
 
 // EnsureNodeStorageFileDataRole gets the node identities from VMSS and VMs in the given
 // resource group and assigns them the "Storage File Data SMB Share Elevated Contributor" role.
-func (az *Client) EnsureNodeStorageFileDataRole(ctx context.Context, resourceGroup string) error {
+// It returns the first user-assigned managed identity client ID found (for use in StorageClass clientID).
+func (az *Client) EnsureNodeStorageFileDataRole(ctx context.Context, resourceGroup string) (string, error) {
 	log.Printf("Begin to assign Storage File Data SMB Share Elevated Contributor role to node identities in resource group %s", resourceGroup)
-	principalIDs, err := az.GetNodeIdentityPrincipalIDs(ctx, resourceGroup)
+	principalIDs, clientID, err := az.GetNodeIdentityPrincipalIDs(ctx, resourceGroup)
 	if err != nil {
 		log.Printf("Failed to get node identity principal IDs: %v", err)
-		return err
+		return "", err
 	}
 	// Storage File Data SMB Share Elevated Contributor
 	const storageFileDataSMBShareElevatedContributorRoleID = "a7264617-510b-434b-a828-9731dc254ea7"
@@ -309,10 +318,13 @@ func (az *Client) EnsureNodeStorageFileDataRole(ctx context.Context, resourceGro
 		log.Printf("Assigning Storage File Data SMB Share Elevated Contributor role to principal %s ...", principalID)
 		if err := az.AssignRoleToIdentity(ctx, resourceGroup, principalID, storageFileDataSMBShareElevatedContributorRoleID); err != nil {
 			log.Printf("Failed to assign role to principal %s: %v", principalID, err)
-			return err
+			return "", err
 		}
 		log.Printf("Successfully assigned Storage File Data SMB Share Elevated Contributor role to principal %s", principalID)
 	}
 	log.Printf("Successfully assigned Storage File Data SMB Share Elevated Contributor role to all %d node identities", len(principalIDs))
-	return nil
+	if clientID != "" {
+		log.Printf("First user-assigned managed identity clientID: %s", clientID)
+	}
+	return clientID, nil
 }

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -20,10 +20,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
 	resources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	storage "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2"
+	"github.com/google/uuid"
 	"sigs.k8s.io/azurefile-csi-driver/pkg/azurefile"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/accountclient"
@@ -32,9 +37,12 @@ import (
 )
 
 type Client struct {
+	subscriptionID   string
 	groupsClient     resourcegroupclient.Interface
 	accountsClient   accountclient.Interface
 	filesharesClient fileshareclient.Interface
+	aksClient        *armcontainerservice.ManagedClustersClient
+	roleClient       *armauthorization.RoleAssignmentsClient
 }
 
 func GetAzureClient(cloud, subscriptionID, clientID, tenantID, clientSecret, aadFederatedTokenFile string) (*Client, error) {
@@ -67,10 +75,23 @@ func GetAzureClient(cloud, subscriptionID, clientID, tenantID, clientSecret, aad
 	if err != nil {
 		return nil, err
 	}
+
+	aksClient, err := armcontainerservice.NewManagedClustersClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AKS client: %v", err)
+	}
+	roleClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create role assignments client: %v", err)
+	}
+
 	return &Client{
+		subscriptionID:   subscriptionID,
 		groupsClient:     factory.GetResourceGroupClient(),
 		accountsClient:   factory.GetAccountClient(),
 		filesharesClient: factory.GetFileShareClient(),
+		aksClient:        aksClient,
+		roleClient:       roleClient,
 	}, nil
 }
 
@@ -140,4 +161,63 @@ func (az *Client) GetAccountNumByResourceGroup(ctx context.Context, groupName st
 
 func stringPointer(s string) *string {
 	return &s
+}
+
+// GetKubeletIdentityObjectID retrieves the kubelet managed identity object ID from an AKS cluster.
+// It lists all AKS clusters in the given resource group and returns the kubelet identity of the first one found.
+func (az *Client) GetKubeletIdentityObjectID(ctx context.Context, resourceGroup string) (string, error) {
+	pager := az.aksClient.NewListByResourceGroupPager(resourceGroup, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to list AKS clusters in resource group %s: %v", resourceGroup, err)
+		}
+		for _, cluster := range page.Value {
+			if cluster.Properties != nil && cluster.Properties.IdentityProfile != nil {
+				if kubeletIdentity, ok := cluster.Properties.IdentityProfile["kubeletidentity"]; ok && kubeletIdentity.ObjectID != nil {
+					return *kubeletIdentity.ObjectID, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("no AKS cluster with kubelet identity found in resource group %s", resourceGroup)
+}
+
+// AssignRoleToIdentity assigns an Azure role to a principal on a resource group scope.
+// roleDefinitionID should be just the GUID of the role definition.
+// Common roles:
+//   - Storage File Data Privileged Contributor: 69566ab7-960f-475b-8e7c-b3118f30c6bd
+//   - Storage File Data SMB Share Elevated Contributor: a7264617-510b-434b-a828-9731dc254ea7
+func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, principalID, roleDefinitionID string) error {
+	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", az.subscriptionID, resourceGroup)
+	fullRoleDefID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", az.subscriptionID, roleDefinitionID)
+	assignmentID := uuid.New().String()
+
+	_, err := az.roleClient.Create(ctx, scope, assignmentID, armauthorization.RoleAssignmentCreateParameters{
+		Properties: &armauthorization.RoleAssignmentProperties{
+			PrincipalID:      &principalID,
+			PrincipalType:    to.Ptr(armauthorization.PrincipalTypeServicePrincipal),
+			RoleDefinitionID: &fullRoleDefID,
+		},
+	}, nil)
+	if err != nil {
+		// Ignore "RoleAssignmentExists" conflict errors
+		if strings.Contains(err.Error(), "RoleAssignmentExists") {
+			return nil
+		}
+		return fmt.Errorf("failed to create role assignment for principal %s with role %s on scope %s: %v", principalID, roleDefinitionID, scope, err)
+	}
+	return nil
+}
+
+// EnsureKubeletStorageFileDataRole gets the kubelet identity from the AKS cluster in the given
+// resource group and assigns it the "Storage File Data Privileged Contributor" role on that resource group.
+func (az *Client) EnsureKubeletStorageFileDataRole(ctx context.Context, resourceGroup string) error {
+	principalID, err := az.GetKubeletIdentityObjectID(ctx, resourceGroup)
+	if err != nil {
+		return err
+	}
+	// Storage File Data Privileged Contributor
+	const storageFileDataPrivilegedContributorRoleID = "69566ab7-960f-475b-8e7c-b3118f30c6bd"
+	return az.AssignRoleToIdentity(ctx, resourceGroup, principalID, storageFileDataPrivilegedContributorRoleID)
 }

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -293,9 +293,9 @@ func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, princ
 		},
 	}, nil)
 	if err != nil {
-		// Ignore conflict (HTTP 409) — role assignment already exists
+		// Ignore conflict only when role assignment already exists
 		var respErr *azcore.ResponseError
-		if ok := errors.As(err, &respErr); ok && respErr.StatusCode == http.StatusConflict {
+		if ok := errors.As(err, &respErr); ok && respErr.StatusCode == http.StatusConflict && respErr.ErrorCode == "RoleAssignmentExists" {
 			return nil
 		}
 		return fmt.Errorf("failed to create role assignment for principal %s with role %s on scope %s: %v", principalID, roleDefinitionID, scope, err)

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -26,8 +26,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -82,10 +80,9 @@ func GetAzureClient(cloud, subscriptionID, clientID, tenantID, clientSecret, aad
 		return nil, err
 	}
 
-	armClientOpts := &arm.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Cloud: clientOps,
-		},
+	armClientOpts, err := azclient.GetDefaultResourceClientOption(armConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default ARM client options: %v", err)
 	}
 
 	vmssClient, err := armcompute.NewVirtualMachineScaleSetsClient(subscriptionID, cred, armClientOpts)
@@ -277,7 +274,7 @@ func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, princ
 	fullRoleDefID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", az.subscriptionID, roleDefinitionID)
 
 	// Deterministic assignment ID based on scope+principal+role to avoid duplicate assignments on retry
-	assignmentID := uuid.NewSHA1(uuid.NameSpaceURL, []byte(scope+principalID+roleDefinitionID)).String()
+	assignmentID := uuid.NewSHA1(uuid.NameSpaceURL, []byte(scope+"|"+principalID+"|"+roleDefinitionID)).String()
 
 	_, err := az.roleClient.Create(ctx, scope, assignmentID, armauthorization.RoleAssignmentCreateParameters{
 		Properties: &armauthorization.RoleAssignmentProperties{

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -84,7 +84,7 @@ func GetAzureClient(cloud, subscriptionID, clientID, tenantID, clientSecret, aad
 	if err != nil {
 		return nil, fmt.Errorf("failed to get default ARM client options: %v", err)
 	}
-	armClientOpts.Cloud = clientOps.Cloud
+	armClientOpts.Cloud = clientOps
 
 	vmssClient, err := armcompute.NewVirtualMachineScaleSetsClient(subscriptionID, cred, armClientOpts)
 	if err != nil {

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -18,12 +18,14 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
-	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -265,7 +267,9 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, principalID, roleDefinitionID string) error {
 	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", az.subscriptionID, resourceGroup)
 	fullRoleDefID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", az.subscriptionID, roleDefinitionID)
-	assignmentID := uuid.New().String()
+
+	// Deterministic assignment ID based on scope+principal+role to avoid duplicate assignments on retry
+	assignmentID := uuid.NewSHA1(uuid.NameSpaceURL, []byte(scope+principalID+roleDefinitionID)).String()
 
 	_, err := az.roleClient.Create(ctx, scope, assignmentID, armauthorization.RoleAssignmentCreateParameters{
 		Properties: &armauthorization.RoleAssignmentProperties{
@@ -275,8 +279,9 @@ func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, princ
 		},
 	}, nil)
 	if err != nil {
-		// Ignore "RoleAssignmentExists" conflict errors
-		if strings.Contains(err.Error(), "RoleAssignmentExists") {
+		// Ignore conflict (HTTP 409) — role assignment already exists
+		var respErr *azcore.ResponseError
+		if ok := errors.As(err, &respErr); ok && respErr.StatusCode == http.StatusConflict {
 			return nil
 		}
 		return fmt.Errorf("failed to create role assignment for principal %s with role %s on scope %s: %v", principalID, roleDefinitionID, scope, err)

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -208,7 +208,11 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 			// User-assigned identities
 			for uaID, uaIdentity := range vmss.Identity.UserAssignedIdentities {
 				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
-					log.Printf("VMSS %s: found user-assigned identity %s, principalID=%s", name, uaID, *uaIdentity.PrincipalID)
+					clientID := ""
+					if uaIdentity.ClientID != nil {
+						clientID = *uaIdentity.ClientID
+					}
+					log.Printf("VMSS %s: found user-assigned identity %s, principalID=%s, clientID=%s", name, uaID, *uaIdentity.PrincipalID, clientID)
 					principalIDs = append(principalIDs, *uaIdentity.PrincipalID)
 				}
 			}
@@ -240,7 +244,11 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 			// User-assigned identities
 			for uaID, uaIdentity := range vm.Identity.UserAssignedIdentities {
 				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
-					log.Printf("VM %s: found user-assigned identity %s, principalID=%s", name, uaID, *uaIdentity.PrincipalID)
+					clientID := ""
+					if uaIdentity.ClientID != nil {
+						clientID = *uaIdentity.ClientID
+					}
+					log.Printf("VM %s: found user-assigned identity %s, principalID=%s, clientID=%s", name, uaID, *uaIdentity.PrincipalID, clientID)
 					principalIDs = append(principalIDs, *uaIdentity.PrincipalID)
 				}
 			}
@@ -268,7 +276,7 @@ func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup
 // roleDefinitionID should be just the GUID of the role definition.
 // Common roles:
 //   - Storage File Data Privileged Contributor: 69566ab7-960f-475b-8e7c-b3118f30c6bd
-//   - Storage File Data SMB Share Elevated Contributor: a7264617-510b-434b-a828-9731dc254ea7
+//   - Storage File Data SMB MI Admin: a235d3ee-5935-4cfb-8cc5-a3303ad5995e
 func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, principalID, roleDefinitionID string) error {
 	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", az.subscriptionID, resourceGroup)
 	fullRoleDefID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", az.subscriptionID, roleDefinitionID)
@@ -295,24 +303,24 @@ func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, princ
 }
 
 // EnsureNodeStorageFileDataRole gets the node identities from VMSS and VMs in the given
-// resource group and assigns them the "Storage File Data SMB Share Elevated Contributor" role.
+// resource group and assigns them the "Storage File Data SMB MI Admin" role.
 func (az *Client) EnsureNodeStorageFileDataRole(ctx context.Context, resourceGroup string) error {
-	log.Printf("Begin to assign Storage File Data SMB Share Elevated Contributor role to node identities in resource group %s", resourceGroup)
+	log.Printf("Begin to assign Storage File Data SMB MI Admin role to node identities in resource group %s", resourceGroup)
 	principalIDs, err := az.GetNodeIdentityPrincipalIDs(ctx, resourceGroup)
 	if err != nil {
 		log.Printf("Failed to get node identity principal IDs: %v", err)
 		return err
 	}
-	// Storage File Data SMB Share Elevated Contributor
-	const storageFileDataSMBShareElevatedContributorRoleID = "a7264617-510b-434b-a828-9731dc254ea7"
+	// Storage File Data SMB MI Admin
+	const storageFileDataSMBMIAdminRoleID = "a235d3ee-5935-4cfb-8cc5-a3303ad5995e"
 	for _, principalID := range principalIDs {
-		log.Printf("Assigning Storage File Data SMB Share Elevated Contributor role to principal %s ...", principalID)
-		if err := az.AssignRoleToIdentity(ctx, resourceGroup, principalID, storageFileDataSMBShareElevatedContributorRoleID); err != nil {
+		log.Printf("Assigning Storage File Data SMB MI Admin role to principal %s ...", principalID)
+		if err := az.AssignRoleToIdentity(ctx, resourceGroup, principalID, storageFileDataSMBMIAdminRoleID); err != nil {
 			log.Printf("Failed to assign role to principal %s: %v", principalID, err)
 			return err
 		}
-		log.Printf("Successfully assigned Storage File Data SMB Share Elevated Contributor role to principal %s", principalID)
+		log.Printf("Successfully assigned Storage File Data SMB MI Admin role to principal %s", principalID)
 	}
-	log.Printf("Successfully assigned Storage File Data SMB Share Elevated Contributor role to all %d node identities", len(principalIDs))
+	log.Printf("Successfully assigned Storage File Data SMB MI Admin role to all %d node identities", len(principalIDs))
 	return nil
 }

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -19,13 +19,14 @@ package azure
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
-	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	resources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	storage "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2"
 	"github.com/google/uuid"
@@ -41,7 +42,8 @@ type Client struct {
 	groupsClient     resourcegroupclient.Interface
 	accountsClient   accountclient.Interface
 	filesharesClient fileshareclient.Interface
-	aksClient        *armcontainerservice.ManagedClustersClient
+	vmssClient       *armcompute.VirtualMachineScaleSetsClient
+	vmClient         *armcompute.VirtualMachinesClient
 	roleClient       *armauthorization.RoleAssignmentsClient
 }
 
@@ -76,9 +78,13 @@ func GetAzureClient(cloud, subscriptionID, clientID, tenantID, clientSecret, aad
 		return nil, err
 	}
 
-	aksClient, err := armcontainerservice.NewManagedClustersClient(subscriptionID, cred, nil)
+	vmssClient, err := armcompute.NewVirtualMachineScaleSetsClient(subscriptionID, cred, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create AKS client: %v", err)
+		return nil, fmt.Errorf("failed to create VMSS client: %v", err)
+	}
+	vmClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VM client: %v", err)
 	}
 	roleClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, cred, nil)
 	if err != nil {
@@ -90,7 +96,8 @@ func GetAzureClient(cloud, subscriptionID, clientID, tenantID, clientSecret, aad
 		groupsClient:     factory.GetResourceGroupClient(),
 		accountsClient:   factory.GetAccountClient(),
 		filesharesClient: factory.GetFileShareClient(),
-		aksClient:        aksClient,
+		vmssClient:       vmssClient,
+		vmClient:         vmClient,
 		roleClient:       roleClient,
 	}, nil
 }
@@ -163,24 +170,91 @@ func stringPointer(s string) *string {
 	return &s
 }
 
-// GetKubeletIdentityObjectID retrieves the kubelet managed identity object ID from an AKS cluster.
-// It lists all AKS clusters in the given resource group and returns the kubelet identity of the first one found.
-func (az *Client) GetKubeletIdentityObjectID(ctx context.Context, resourceGroup string) (string, error) {
-	pager := az.aksClient.NewListByResourceGroupPager(resourceGroup, nil)
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
+// GetNodeIdentityPrincipalIDs retrieves the principal IDs of managed identities from VMSS and VMs in the resource group.
+// Supports both system-assigned and user-assigned managed identities.
+// This works for both CAPZ and AKS clusters regardless of whether they use VMSS or availability set VMs.
+func (az *Client) GetNodeIdentityPrincipalIDs(ctx context.Context, resourceGroup string) ([]string, error) {
+	var principalIDs []string
+
+	// Check VMSS
+	log.Printf("Listing VMSS in resource group %s ...", resourceGroup)
+	vmssPager := az.vmssClient.NewListPager(resourceGroup, nil)
+	for vmssPager.More() {
+		page, err := vmssPager.NextPage(ctx)
 		if err != nil {
-			return "", fmt.Errorf("failed to list AKS clusters in resource group %s: %v", resourceGroup, err)
+			return nil, fmt.Errorf("failed to list VMSS in resource group %s: %v", resourceGroup, err)
 		}
-		for _, cluster := range page.Value {
-			if cluster.Properties != nil && cluster.Properties.IdentityProfile != nil {
-				if kubeletIdentity, ok := cluster.Properties.IdentityProfile["kubeletidentity"]; ok && kubeletIdentity.ObjectID != nil {
-					return *kubeletIdentity.ObjectID, nil
+		for _, vmss := range page.Value {
+			name := ""
+			if vmss.Name != nil {
+				name = *vmss.Name
+			}
+			if vmss.Identity == nil {
+				log.Printf("VMSS %s has no managed identity, skipping", name)
+				continue
+			}
+			// System-assigned identity
+			if vmss.Identity.PrincipalID != nil && *vmss.Identity.PrincipalID != "" {
+				log.Printf("VMSS %s: found system-assigned identity, principalID=%s", name, *vmss.Identity.PrincipalID)
+				principalIDs = append(principalIDs, *vmss.Identity.PrincipalID)
+			}
+			// User-assigned identities
+			for uaID, uaIdentity := range vmss.Identity.UserAssignedIdentities {
+				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
+					log.Printf("VMSS %s: found user-assigned identity %s, principalID=%s", name, uaID, *uaIdentity.PrincipalID)
+					principalIDs = append(principalIDs, *uaIdentity.PrincipalID)
 				}
 			}
 		}
 	}
-	return "", fmt.Errorf("no AKS cluster with kubelet identity found in resource group %s", resourceGroup)
+
+	// Check individual VMs (availability set scenario)
+	log.Printf("Listing VMs in resource group %s ...", resourceGroup)
+	vmPager := az.vmClient.NewListPager(resourceGroup, nil)
+	for vmPager.More() {
+		page, err := vmPager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list VMs in resource group %s: %v", resourceGroup, err)
+		}
+		for _, vm := range page.Value {
+			name := ""
+			if vm.Name != nil {
+				name = *vm.Name
+			}
+			if vm.Identity == nil {
+				log.Printf("VM %s has no managed identity, skipping", name)
+				continue
+			}
+			// System-assigned identity
+			if vm.Identity.PrincipalID != nil && *vm.Identity.PrincipalID != "" {
+				log.Printf("VM %s: found system-assigned identity, principalID=%s", name, *vm.Identity.PrincipalID)
+				principalIDs = append(principalIDs, *vm.Identity.PrincipalID)
+			}
+			// User-assigned identities
+			for uaID, uaIdentity := range vm.Identity.UserAssignedIdentities {
+				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
+					log.Printf("VM %s: found user-assigned identity %s, principalID=%s", name, uaID, *uaIdentity.PrincipalID)
+					principalIDs = append(principalIDs, *uaIdentity.PrincipalID)
+				}
+			}
+		}
+	}
+
+	if len(principalIDs) == 0 {
+		return nil, fmt.Errorf("no VMSS or VM with managed identity found in resource group %s", resourceGroup)
+	}
+
+	// Deduplicate
+	seen := make(map[string]bool)
+	unique := principalIDs[:0]
+	for _, id := range principalIDs {
+		if !seen[id] {
+			seen[id] = true
+			unique = append(unique, id)
+		}
+	}
+	log.Printf("Found %d unique principal IDs in resource group %s", len(unique), resourceGroup)
+	return unique, nil
 }
 
 // AssignRoleToIdentity assigns an Azure role to a principal on a resource group scope.
@@ -210,14 +284,25 @@ func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, princ
 	return nil
 }
 
-// EnsureKubeletStorageFileDataRole gets the kubelet identity from the AKS cluster in the given
-// resource group and assigns it the "Storage File Data Privileged Contributor" role on that resource group.
-func (az *Client) EnsureKubeletStorageFileDataRole(ctx context.Context, resourceGroup string) error {
-	principalID, err := az.GetKubeletIdentityObjectID(ctx, resourceGroup)
+// EnsureNodeStorageFileDataRole gets the node identities from VMSS and VMs in the given
+// resource group and assigns them the "Storage File Data SMB Share Elevated Contributor" role.
+func (az *Client) EnsureNodeStorageFileDataRole(ctx context.Context, resourceGroup string) error {
+	log.Printf("Begin to assign Storage File Data SMB Share Elevated Contributor role to node identities in resource group %s", resourceGroup)
+	principalIDs, err := az.GetNodeIdentityPrincipalIDs(ctx, resourceGroup)
 	if err != nil {
+		log.Printf("Failed to get node identity principal IDs: %v", err)
 		return err
 	}
-	// Storage File Data Privileged Contributor
-	const storageFileDataPrivilegedContributorRoleID = "69566ab7-960f-475b-8e7c-b3118f30c6bd"
-	return az.AssignRoleToIdentity(ctx, resourceGroup, principalID, storageFileDataPrivilegedContributorRoleID)
+	// Storage File Data SMB Share Elevated Contributor
+	const storageFileDataSMBShareElevatedContributorRoleID = "a7264617-510b-434b-a828-9731dc254ea7"
+	for _, principalID := range principalIDs {
+		log.Printf("Assigning Storage File Data SMB Share Elevated Contributor role to principal %s ...", principalID)
+		if err := az.AssignRoleToIdentity(ctx, resourceGroup, principalID, storageFileDataSMBShareElevatedContributorRoleID); err != nil {
+			log.Printf("Failed to assign role to principal %s: %v", principalID, err)
+			return err
+		}
+		log.Printf("Successfully assigned Storage File Data SMB Share Elevated Contributor role to principal %s", principalID)
+	}
+	log.Printf("Successfully assigned Storage File Data SMB Share Elevated Contributor role to all %d node identities", len(principalIDs))
+	return nil
 }

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -80,15 +82,21 @@ func GetAzureClient(cloud, subscriptionID, clientID, tenantID, clientSecret, aad
 		return nil, err
 	}
 
-	vmssClient, err := armcompute.NewVirtualMachineScaleSetsClient(subscriptionID, cred, nil)
+	armClientOpts := &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Cloud: clientOps,
+		},
+	}
+
+	vmssClient, err := armcompute.NewVirtualMachineScaleSetsClient(subscriptionID, cred, armClientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create VMSS client: %v", err)
 	}
-	vmClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, cred, nil)
+	vmClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, cred, armClientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create VM client: %v", err)
 	}
-	roleClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, cred, nil)
+	roleClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, cred, armClientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role assignments client: %v", err)
 	}

--- a/test/utils/azure/azure_helpers.go
+++ b/test/utils/azure/azure_helpers.go
@@ -84,6 +84,7 @@ func GetAzureClient(cloud, subscriptionID, clientID, tenantID, clientSecret, aad
 	if err != nil {
 		return nil, fmt.Errorf("failed to get default ARM client options: %v", err)
 	}
+	armClientOpts.Cloud = clientOps.Cloud
 
 	vmssClient, err := armcompute.NewVirtualMachineScaleSetsClient(subscriptionID, cred, armClientOpts)
 	if err != nil {


### PR DESCRIPTION
## What type of PR is this?
/kind test

## What this PR does / why we need it:
Adds end-to-end test coverage for **managed identity mount** (dynamic provisioning) on CAPZ clusters, along with the required RBAC setup.

### Changes:
1. **RBAC role assignment in BeforeSuite** (CAPZ only):
   - Discovers all managed identities (system-assigned + user-assigned) from VMs and VMSS in the test resource group
   - Assigns the **Storage File Data SMB MI Admin** role (`a235d3ee-5935-4cfb-8cc5-a3303ad5995e`) which includes `runAsBuiltInFileAdministrator` permission required for MI-based Kerberos auth
   - Logs both principalID and clientID for user-assigned identities for easier debugging
   - Uses deterministic UUID for role assignment ID to avoid duplicates
   - Uses `azclient.GetDefaultResourceClientOption` for consistent ARM client settings

2. **New e2e test**: `should create a volume on demand with managed identity mount`
   - Gated by `isCapzTest` (only runs in `pull-azurefile-csi-driver-e2e-capz`)
   - Dynamic provisioning with `mountWithManagedIdentity: "true"` StorageClass parameter

## Which issue(s) this PR fixes:
None

## Requirements:
- [x] reviewed the `developer guide`
- [x] reviewed the `contributor guide`