### PR TITLE
fix: add missing fields to storage account lockKey

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           check_filenames: true
           skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,crd-csi-snapshot-ga.yaml,crd-csi-snapshot.yaml
-          ignore_words_list: "AKS,aks,complies,ro,NotIn"
+          ignore_words_list: "AKS,aks,complies,ro,NotIn,ue"

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -617,13 +617,14 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey = fmt.Sprintf("%s%s%s%s%s%s%s%s%v%v%v%v%v%v%v%v%v%v%s%s%s%s",
+			lockKey = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%v|%v|%v|%v|%v|%v|%v|%s|%s|%s|%s|%s|%v|%v",
 				sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier, privateDNSZoneResourceGroup,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false), ptr.Deref(requireInfraEncryption, false),
 				ptr.Deref(enableLFS, false), ptr.Deref(disableDeleteRetentionPolicy, false),
 				ptr.Deref(allowCrossTenantReplication, true), ptr.Deref(allowSharedKeyAccess, true),
 				ptr.Deref(requiresSmbOAuth, false), ptr.Deref(isMultichannelEnabled, false),
-				enableHTTPSTrafficOnly, publicNetworkAccess, vnetResourceGroup, vnetName, subnetName)
+				enableHTTPSTrafficOnly, publicNetworkAccess, vnetResourceGroup, vnetName, vnetLinkName, subnetName,
+				matchTags, tags)
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -1727,12 +1727,16 @@ func (d *Driver) ControllerModifyVolume(ctx context.Context, req *csi.Controller
 
 // serializeTags produces a deterministic string representation of a tags map
 // by sorting keys and joining as "k1=v1,k2=v2".
-// serializeTags produces a deterministic string representation of a tags map.
-// Uses json.Marshal which sorts keys and properly escapes values.
+// serializeTags produces a deterministic JSON string from a tags map.
+// json.Marshal sorts map keys alphabetically and escapes special characters,
+// avoiding ambiguity that hand-rolled k=v serialization would have.
 func serializeTags(tags map[string]string) string {
 	if len(tags) == 0 {
 		return ""
 	}
-	b, _ := json.Marshal(tags)
+	b, err := json.Marshal(tags)
+	if err != nil {
+		return fmt.Sprintf("%v", tags)
+	}
 	return string(b)
 }

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -18,11 +18,11 @@ package azurefile
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -618,14 +618,14 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%v|%v|%v|%v|%v|%v|%v|%s|%s|%s|%s|%s|%v|%v",
+			lockKey = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%v|%v|%v|%v|%v|%v|%v|%s|%s|%s|%s|%s|%v|%s|%s",
 				sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier, privateDNSZoneResourceGroup,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false), ptr.Deref(requireInfraEncryption, false),
 				ptr.Deref(enableLFS, false), ptr.Deref(disableDeleteRetentionPolicy, false),
 				ptr.Deref(allowCrossTenantReplication, true), ptr.Deref(allowSharedKeyAccess, true),
 				ptr.Deref(requiresSmbOAuth, false), ptr.Deref(isMultichannelEnabled, false),
 				enableHTTPSTrafficOnly, publicNetworkAccess, vnetResourceGroup, vnetName, vnetLinkName, subnetName,
-				matchTags, serializeTags(tags))
+				matchTags, serializeTags(tags), storageEndpointSuffix)
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {
@@ -1727,18 +1727,12 @@ func (d *Driver) ControllerModifyVolume(ctx context.Context, req *csi.Controller
 
 // serializeTags produces a deterministic string representation of a tags map
 // by sorting keys and joining as "k1=v1,k2=v2".
+// serializeTags produces a deterministic string representation of a tags map.
+// Uses json.Marshal which sorts keys and properly escapes values.
 func serializeTags(tags map[string]string) string {
 	if len(tags) == 0 {
 		return ""
 	}
-	keys := make([]string, 0, len(tags))
-	for k := range tags {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	pairs := make([]string, 0, len(tags))
-	for _, k := range keys {
-		pairs = append(pairs, k+"="+tags[k])
-	}
-	return strings.Join(pairs, ",")
+	b, _ := json.Marshal(tags)
+	return string(b)
 }

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -624,7 +625,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				ptr.Deref(allowCrossTenantReplication, true), ptr.Deref(allowSharedKeyAccess, true),
 				ptr.Deref(requiresSmbOAuth, false), ptr.Deref(isMultichannelEnabled, false),
 				enableHTTPSTrafficOnly, publicNetworkAccess, vnetResourceGroup, vnetName, vnetLinkName, subnetName,
-				matchTags, tags)
+				matchTags, serializeTags(tags))
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {
@@ -1722,4 +1723,22 @@ func (d *Driver) ControllerModifyVolume(ctx context.Context, req *csi.Controller
 	isOperationSucceeded = true
 	klog.V(2).Infof("ControllerModifyVolume(%s) succeeded", volumeID)
 	return &csi.ControllerModifyVolumeResponse{}, nil
+}
+
+// serializeTags produces a deterministic string representation of a tags map
+// by sorting keys and joining as "k1=v1,k2=v2".
+func serializeTags(tags map[string]string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([]string, 0, len(tags))
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+tags[k])
+	}
+	return strings.Join(pairs, ",")
 }

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -1725,8 +1725,6 @@ func (d *Driver) ControllerModifyVolume(ctx context.Context, req *csi.Controller
 	return &csi.ControllerModifyVolumeResponse{}, nil
 }
 
-// serializeTags produces a deterministic string representation of a tags map
-// by sorting keys and joining as "k1=v1,k2=v2".
 // serializeTags returns a deterministic JSON string for a tags map.
 // json.Marshal sorts map keys and escapes special characters in values.
 func serializeTags(tags map[string]string) string {

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -617,10 +617,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey = fmt.Sprintf("%s%s%s%s%s%s%s%s%v%v%v%v%v%v%v", sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier, privateDNSZoneResourceGroup,
+			lockKey = fmt.Sprintf("%s%s%s%s%s%s%s%s%v%v%v%v%v%v%v%v%v%v%s%s%s%s",
+				sku, accountKind, resourceGroup, location, protocol, subsID, accountAccessTier, privateDNSZoneResourceGroup,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false), ptr.Deref(requireInfraEncryption, false),
 				ptr.Deref(enableLFS, false), ptr.Deref(disableDeleteRetentionPolicy, false),
-				ptr.Deref(allowCrossTenantReplication, true), ptr.Deref(allowSharedKeyAccess, true))
+				ptr.Deref(allowCrossTenantReplication, true), ptr.Deref(allowSharedKeyAccess, true),
+				ptr.Deref(requiresSmbOAuth, false), ptr.Deref(isMultichannelEnabled, false),
+				enableHTTPSTrafficOnly, publicNetworkAccess, vnetResourceGroup, vnetName, subnetName)
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -1727,16 +1727,17 @@ func (d *Driver) ControllerModifyVolume(ctx context.Context, req *csi.Controller
 
 // serializeTags produces a deterministic string representation of a tags map
 // by sorting keys and joining as "k1=v1,k2=v2".
-// serializeTags produces a deterministic JSON string from a tags map.
-// json.Marshal sorts map keys alphabetically and escapes special characters,
-// avoiding ambiguity that hand-rolled k=v serialization would have.
+// serializeTags returns a deterministic JSON string for a tags map.
+// json.Marshal sorts map keys and escapes special characters in values.
 func serializeTags(tags map[string]string) string {
 	if len(tags) == 0 {
 		return ""
 	}
 	b, err := json.Marshal(tags)
 	if err != nil {
-		return fmt.Sprintf("%v", tags)
+		// json.Marshal on map[string]string should never fail,
+		// but return empty string rather than non-deterministic output
+		return ""
 	}
 	return string(b)
 }

--- a/pkg/azurefile/serializetags_test.go
+++ b/pkg/azurefile/serializetags_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurefile
+
+import "testing"
+
+func TestSerializeTags(t *testing.T) {
+	tests := []struct {
+		desc     string
+		tags     map[string]string
+		expected string
+	}{
+		{
+			desc:     "nil map",
+			tags:     nil,
+			expected: "",
+		},
+		{
+			desc:     "empty map",
+			tags:     map[string]string{},
+			expected: "",
+		},
+		{
+			desc:     "single tag",
+			tags:     map[string]string{"key1": "value1"},
+			expected: `{"key1":"value1"}`,
+		},
+		{
+			desc:     "multiple tags sorted by key",
+			tags:     map[string]string{"beta": "2", "alpha": "1", "gamma": "3"},
+			expected: `{"alpha":"1","beta":"2","gamma":"3"}`,
+		},
+		{
+			desc:     "special characters in values",
+			tags:     map[string]string{"key": "val\"ue"},
+			expected: `{"key":"val\"ue"}`,
+		},
+		{
+			desc:     "deterministic output on repeated calls",
+			tags:     map[string]string{"z": "1", "a": "2", "m": "3"},
+			expected: `{"a":"2","m":"3","z":"1"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			result := serializeTags(test.tags)
+			if result != test.expected {
+				t.Errorf("serializeTags(%v) = %q, expected %q", test.tags, result, test.expected)
+			}
+		})
+		// verify determinism
+		if test.tags != nil {
+			first := serializeTags(test.tags)
+			second := serializeTags(test.tags)
+			if first != second {
+				t.Errorf("serializeTags not deterministic for %v: %q != %q", test.tags, first, second)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
The `lockKey` in `CreateVolume` is used to cache and reuse storage accounts. Several `accountOptions` fields that affect account properties were missing from the key, causing volumes with different requirements to incorrectly share the same storage account.

### Missing fields added:
| Field | Impact |
|-------|--------|
| `requiresSmbOAuth` | MI mount needs SmbOAuth-enabled accounts; without this, MI mount reuses a non-OAuth account and fails with `Error calling AzAuthenticatorLib: -1` |
| `isMultichannelEnabled` | SMB multi-channel requires different account config |
| `enableHTTPSTrafficOnly` | Affects account transport security |
| `publicNetworkAccess` | Affects network accessibility |
| `vnetResourceGroup` / `vnetName` / `subnetName` | Affects private endpoint configuration |

### Root cause example:
When a regular e2e test creates a storage account (no SmbOAuth), it gets cached. A subsequent MI mount test matches the same `lockKey` and reuses that account. Since SmbOAuth is not enabled on the account, `azfilesauthmanager` fails to acquire a Kerberos ticket.

## Which issue(s) this PR fixes:
None

## Requirements:
- [x] reviewed the `developer guide`
- [x] reviewed the `contributor guide`