### PR TITLE
docs: add troubleshooting for managed identity mount AzAuthenticatorLib error

### DIFF
--- a/docs/managed-identity-mount.md
+++ b/docs/managed-identity-mount.md
@@ -167,17 +167,4 @@ Verify the following:
 
 1. **The managed identity has the correct role assignment.** Ensure the managed identity is assigned the **`Storage File Data SMB MI Admin`** role on the storage account (or the resource group for dynamic provisioning). Other roles such as `Storage File Data SMB Share Contributor` or `Storage File Data SMB Share Elevated Contributor` are **not sufficient** for managed identity mount.
 
-   ```bash
-   # Verify role assignment
-   az role assignment list --assignee <managed-identity-principal-id> --scope <storage-account-resource-id> --query "[].roleDefinitionName" -o tsv
-   ```
-
 2. **The SMBOauth property is enabled on the storage account.** Without this, the storage account does not support Kerberos ticket acquisition for managed identity authentication.
-
-   ```bash
-   # Check SMBOauth status
-   az storage account show --name <account-name> --resource-group <resource-group-name> --query "azureFilesIdentityBasedAuthentication"
-
-   # Enable SMBOauth if not enabled
-   az storage account update --name <account-name> --resource-group <resource-group-name> --enable-smb-oauth true
-   ```

--- a/docs/managed-identity-mount.md
+++ b/docs/managed-identity-mount.md
@@ -151,3 +151,33 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/azurefile-cs
 # kubectl exec -it statefulset-azurefile-0 -- mount | grep cifs
 //accountname.file.core.windows.net/pvc-1bfefee3-652e-4fd3-b32d-30044f28ef0e on /mnt/azurefile type cifs (rw,relatime,vers=3.1.1,sec=krb5,cruid=0,cache=strict,upcall_target=mount,username=c56002c7-a601-44d1-b5d0-9bbc593edb12,uid=0,noforceuid,gid=0,noforcegid,addr=52.239.239.104,file_mode=0777,dir_mode=0777,soft,persistenthandles,nounix,serverino,mapposix,nobrl,mfsymlinks,rsize=1048576,wsize=1048576,bsize=1048576,retrans=1,echo_interval=60,nosharesock,actimeo=30,closetimeo=1)
 ```
+
+## Troubleshooting
+
+### Error: `Error calling AzAuthenticatorLib: -1` / `Error getting Kerberos service ticket`
+
+If you see the following error in the CSI driver node pod logs:
+
+```
+Error calling AzAuthenticatorLib: -1
+Error getting Kerberos service ticket, check /var/log/syslog for more information.
+```
+
+Verify the following:
+
+1. **The managed identity has the correct role assignment.** Ensure the managed identity is assigned the **`Storage File Data SMB MI Admin`** role on the storage account (or the resource group for dynamic provisioning). Other roles such as `Storage File Data SMB Share Contributor` or `Storage File Data SMB Share Elevated Contributor` are **not sufficient** for managed identity mount.
+
+   ```bash
+   # Verify role assignment
+   az role assignment list --assignee <managed-identity-principal-id> --scope <storage-account-resource-id> --query "[].roleDefinitionName" -o tsv
+   ```
+
+2. **The SMBOauth property is enabled on the storage account.** Without this, the storage account does not support Kerberos ticket acquisition for managed identity authentication.
+
+   ```bash
+   # Check SMBOauth status
+   az storage account show --name <account-name> --resource-group <resource-group-name> --query "azureFilesIdentityBasedAuthentication"
+
+   # Enable SMBOauth if not enabled
+   az storage account update --name <account-name> --resource-group <resource-group-name> --enable-smb-oauth true
+   ```

--- a/docs/workload-identity-static-pv-mount.md
+++ b/docs/workload-identity-static-pv-mount.md
@@ -291,3 +291,20 @@ EOF
 # kubectl exec -it statefulset-azurefile-0 -- mount | grep cifs
 //accountname.file.core.windows.net/pvc-d62dcee0-9102-417f-9869-5f0e885f7f10 on /mnt/azurefile type cifs (rw,relatime,vers=3.1.1,sec=krb5,cruid=0,cache=strict,upcall_target=mount,username=root,uid=0,noforceuid,gid=0,noforcegid,addr=52.239.239.104,file_mode=0777,dir_mode=0777,soft,persistenthandles,nounix,serverino,mapposix,nobrl,mfsymlinks,rsize=1048576,wsize=1048576,bsize=1048576,retrans=1,echo_interval=60,nosharesock,actimeo=30,closetimeo=1)
 ```
+
+## Troubleshooting
+
+### Error: `Error calling AzAuthenticatorLib: -1` / `Error getting Kerberos service ticket`
+
+If you see the following error in the CSI driver node pod logs:
+
+```
+Error calling AzAuthenticatorLib: -1
+Error getting Kerberos service ticket, check /var/log/syslog for more information.
+```
+
+Verify the following:
+
+1. **The managed identity has the correct role assignment.** Ensure the managed identity is assigned the **`Storage File Data SMB MI Admin`** role on the storage account (or the resource group for dynamic provisioning). Other roles such as `Storage File Data SMB Share Contributor` or `Storage File Data SMB Share Elevated Contributor` are **not sufficient** for managed identity mount.
+
+2. **The SMBOauth property is enabled on the storage account.** Without this, the storage account does not support Kerberos ticket acquisition for managed identity authentication.


### PR DESCRIPTION
## What type of PR is this?
/kind documentation

## What this PR does / why we need it:
Adds a troubleshooting section to `docs/managed-identity-mount.md` for the common error:

```
Error calling AzAuthenticatorLib: -1
Error getting Kerberos service ticket, check /var/log/syslog for more information.
```

This error occurs when:
1. The managed identity is not assigned the **Storage File Data SMB MI Admin** role (other roles like `Storage File Data SMB Share Contributor` are not sufficient)
2. The **SMBOauth** property is not enabled on the storage account

The troubleshooting section includes verification commands and fix instructions for both cases.

## Requirements:
- [x] reviewed the `developer guide`
- [x] reviewed the `contributor guide`