### PR TITLE
fix: skip storing account key when using managed identity or workload identity token

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -336,6 +336,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Error(codes.InvalidArgument, "mountwithmanagedidentity and mountwithworkloadidentitytoken cannot be both true in storage class")
 	}
 
+	// When using managed identity or workload identity token for mount,
+	// the account key should not be stored in the secret since mount
+	// authentication uses identity-based tokens, not account keys.
+	if mountWithManagedIdentity || mountWithWIToken {
+		storeAccountKey = false
+	}
+
 	if matchTags && account != "" {
 		return nil, status.Errorf(codes.InvalidArgument, "matchTags must set as false when storageAccount(%s) is provided", account)
 	}

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -37,6 +37,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	cloudprovider "k8s.io/cloud-provider"
@@ -1117,6 +1118,100 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 				mockFileClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armstorage.FileShare{FileShareProperties: &armstorage.FileShareProperties{ShareQuota: &fakeShareQuota}}, nil).AnyTimes()
 				_, err := d.CreateVolume(ctx, req)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.When("mountWithManagedIdentity is true", func() {
+			ginkgo.It("should not store account key to secret", func(ctx context.Context) {
+				name := "baz"
+				SKU := "SKU"
+				kind := "StorageV2"
+				location := "centralus"
+				value := "foo bar"
+				accounts := []*armstorage.Account{
+					{Name: &name, SKU: &armstorage.SKU{Name: to.Ptr(armstorage.SKUName(SKU))}, Kind: to.Ptr(armstorage.Kind(kind)), Location: &location},
+				}
+				keys := []*armstorage.AccountKey{
+					{Value: &value},
+				}
+
+				params := map[string]string{
+					skuNameField:                  "premium",
+					locationField:                 "loc",
+					storageAccountField:           "stoacc",
+					resourceGroupField:            "rg",
+					secretNamespaceField:          "default",
+					mountWithManagedIdentityField: "true",
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name:               "vol-mi-no-secret",
+					VolumeCapabilities: stdVolCap,
+					CapacityRange:      lessThanPremCapRange,
+					Parameters:         params,
+				}
+
+				mockStorageAccountsClient := d.cloud.ComputeClientFactory.GetAccountClient().(*mock_accountclient.MockInterface)
+				mockFileClient.EXPECT().Create(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armstorage.FileShare{FileShareProperties: &armstorage.FileShareProperties{ShareQuota: nil}}, nil).AnyTimes()
+				mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(keys, nil).AnyTimes()
+				mockStorageAccountsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(accounts, nil).AnyTimes()
+				mockStorageAccountsClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				mockFileClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armstorage.FileShare{FileShareProperties: &armstorage.FileShareProperties{ShareQuota: &fakeShareQuota}}, nil).AnyTimes()
+
+				_, err := d.CreateVolume(ctx, req)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify no secret was created
+				secrets, listErr := d.kubeClient.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{})
+				gomega.Expect(listErr).NotTo(gomega.HaveOccurred())
+				gomega.Expect(secrets.Items).To(gomega.BeEmpty(), "expected no secret to be created when mountWithManagedIdentity is true")
+			})
+		})
+
+		ginkgo.When("mountWithWorkloadIdentityToken is true", func() {
+			ginkgo.It("should not store account key to secret", func(ctx context.Context) {
+				name := "baz"
+				SKU := "SKU"
+				kind := "StorageV2"
+				location := "centralus"
+				value := "foo bar"
+				accounts := []*armstorage.Account{
+					{Name: &name, SKU: &armstorage.SKU{Name: to.Ptr(armstorage.SKUName(SKU))}, Kind: to.Ptr(armstorage.Kind(kind)), Location: &location},
+				}
+				keys := []*armstorage.AccountKey{
+					{Value: &value},
+				}
+
+				params := map[string]string{
+					skuNameField:          "premium",
+					locationField:         "loc",
+					storageAccountField:   "stoacc",
+					resourceGroupField:    "rg",
+					secretNamespaceField:  "default",
+					mountWithWITokenField: "true",
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name:               "vol-wi-no-secret",
+					VolumeCapabilities: stdVolCap,
+					CapacityRange:      lessThanPremCapRange,
+					Parameters:         params,
+				}
+
+				mockStorageAccountsClient := d.cloud.ComputeClientFactory.GetAccountClient().(*mock_accountclient.MockInterface)
+				mockFileClient.EXPECT().Create(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armstorage.FileShare{FileShareProperties: &armstorage.FileShareProperties{ShareQuota: nil}}, nil).AnyTimes()
+				mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(keys, nil).AnyTimes()
+				mockStorageAccountsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(accounts, nil).AnyTimes()
+				mockStorageAccountsClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				mockFileClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armstorage.FileShare{FileShareProperties: &armstorage.FileShareProperties{ShareQuota: &fakeShareQuota}}, nil).AnyTimes()
+
+				_, err := d.CreateVolume(ctx, req)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify no secret was created
+				secrets, listErr := d.kubeClient.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{})
+				gomega.Expect(listErr).NotTo(gomega.HaveOccurred())
+				gomega.Expect(secrets.Items).To(gomega.BeEmpty(), "expected no secret to be created when mountWithWorkloadIdentityToken is true")
 			})
 		})
 

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1285,6 +1285,22 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		}
 		accountName := segments[3]
 
+		// Copy the storage account secret from default namespace to the test namespace
+		// so that the CSI inline volume's NodePublishVolume can find it.
+		secret, err := cs.CoreV1().Secrets("default").Get(ctx, secretName, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		secretCopy := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: ns.Name,
+			},
+			Data: secret.Data,
+			Type: secret.Type,
+		}
+		_, err = cs.CoreV1().Secrets(ns.Name).Create(ctx, secretCopy, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		log.Printf("copied secret %s from default to %s namespace\n", secretName, ns.Name)
+
 		shareName := "csi-inline-smb-volume"
 		req := makeCreateVolumeReq(shareName, ns.Name)
 		req.Parameters["storageAccount"] = accountName

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1374,6 +1374,22 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		}
 		accountName := segments[3]
 
+		// Copy the storage account secret from default namespace to the test namespace
+		// so that the in-tree azureFile volume plugin can find it.
+		secret, err := cs.CoreV1().Secrets("default").Get(ctx, secretName, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		secretCopy := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: ns.Name,
+			},
+			Data: secret.Data,
+			Type: secret.Type,
+		}
+		_, err = cs.CoreV1().Secrets(ns.Name).Create(ctx, secretCopy, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		log.Printf("copied secret %s from default to %s namespace\n", secretName, ns.Name)
+
 		shareName := "intree-inline-smb-volume"
 		req := makeCreateVolumeReq("intree-inline-smb-volume", ns.Name)
 		req.Parameters["storageAccount"] = accountName


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it
When `mountWithManagedIdentity` or `mountWithWorkloadIdentityToken` is `true`, the mount authentication uses identity-based tokens (from IMDS or federated token exchange), not storage account keys. 

Currently, `CreateVolume` still stores the storage account key into the Kubernetes secret. This is unnecessary and can interfere with identity-based mount flows — for example, if the secret is also used to store the identity token, the account key overwrites it.

This PR sets `storeAccountKey = false` when either `mountWithManagedIdentity` or `mountWithWorkloadIdentityToken` is enabled, skipping the account key write to the secret.

## Which issue(s) this PR fixes
N/A

## Does this PR introduce a user-facing change?
```release-note
fix: skip storing account key to secret when mountWithManagedIdentity or mountWithWorkloadIdentityToken is true
```