### PR TITLE
fix: normalize folderName to prevent double-slash in mount path

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -397,6 +397,9 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	// replace pv/pvc name namespace metadata in fileShareName and folderName
 	fileShareName = replaceWithMap(fileShareName, volumeMetadataReplaceMap)
 	folderName = replaceWithMap(folderName, volumeMetadataReplaceMap)
+	// Normalize folderName: trim leading/trailing slashes to prevent double-slash
+	// in the mount source path (e.g., //<server>/<share>//aa/bb).
+	folderName = strings.Trim(folderName, "/")
 
 	osSeparator := string(os.PathSeparator)
 	if strings.TrimSpace(server) == "" {

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -662,6 +662,20 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			desc: "folderName with leading slash is normalized",
+			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1", StagingTargetPath: sourceTest,
+				VolumeCapability: &stdVolCap,
+				VolumeContext: map[string]string{
+					shareNameField:             "test_sharename",
+					serverNameField:            "test_servername",
+					storageEndpointSuffixField: ".core",
+					folderNameField:            "/aa/bb",
+				}},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Errorf(codes.Internal, "accountName() or accountKey is empty"),
+			},
+		},
+		{
 			desc: "[Error] Volume operation in progress",
 			setup: func() {
 				d.volumeLocks.TryAcquire(fmt.Sprintf("%s-%s", "vol_1##", sourceTest))


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
When `folderName` starts with a leading slash (e.g., `/aa/bb`), the mount source path gets a double slash:
- SMB: `//<server>/<share>//aa/bb`
- NFS: `<server>:/<account>/<share>//aa/bb`

The folder creation path (`createFolderIfNotExists`) already trims leading/trailing slashes internally, but the mount path construction used the raw `folderName`, causing an inconsistency.

This fix normalizes `folderName` by trimming leading/trailing slashes after placeholder expansion, making both paths consistent.

## Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/3138

## How to test:
1. Create a PV with `folderName: /aa/bb` and `createFolderIfNotExist: "true"`
2. Mount the PV
3. Verify the mount source path does not contain double slashes