### PR TITLE
fix: use native platform for Dockerfile builder stage to avoid QEMU arm64 failures

### DIFF
--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -13,17 +13,19 @@
 # limitations under the License.
 
 ARG ARCH=amd64
+ARG BUILDPLATFORM
+ARG BASE_IMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.7
 
-FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.7 AS base
+FROM ${BASE_IMAGE} AS base
 
-FROM base AS builder
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS builder
 
-ARG ARCH
+ARG TARGETARCH
 
 RUN apt update \
     && apt install -y curl \
     && curl -Lso /tmp/packages-microsoft-prod-22.04.deb https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb \
-    && curl -Ls https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.4/azcopy_linux_${ARCH}_10.32.4.tar.gz \
+    && curl -Ls https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.4/azcopy_linux_${TARGETARCH}_10.32.4.tar.gz \
         | tar xvzf - --strip-components=1 -C /usr/local/bin/ --wildcards "*/azcopy"
 
 FROM base

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 ARG ARCH=amd64
-ARG BUILDPLATFORM
+ARG BUILDPLATFORM=linux/amd64
 ARG BASE_IMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.7
 
 FROM ${BASE_IMAGE} AS base
 
 FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS builder
 
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 RUN apt update \
     && apt install -y curl \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The builder stage in the Dockerfile runs `apt install curl` under QEMU emulation when building arm64 images on amd64 CI hosts. This intermittently fails with `Exec format error` when the binfmt registration is unstable in Docker-in-Docker environments.

By using `--platform=$BUILDPLATFORM`, the builder stage always runs natively (amd64) and downloads the correct arch-specific azcopy binary via `TARGETARCH`. This eliminates the QEMU dependency for the builder stage while keeping the final image on the correct target architecture.

**How `BUILDPLATFORM` and `TARGETARCH` work:**

Both `BUILDPLATFORM` and `TARGETARCH` are [BuildKit automatic platform ARGs](https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope). When using `docker buildx build --platform=linux/<arch>`, BuildKit **automatically injects** the correct values, overriding any Dockerfile defaults:

- `make container-linux ARCH=arm64` → `--platform=linux/arm64` → BuildKit sets `TARGETARCH=arm64` → downloads `azcopy_linux_arm64_10.32.4.tar.gz` ✅
- `make container-linux ARCH=amd64` → `--platform=linux/amd64` → BuildKit sets `TARGETARCH=amd64` → downloads `azcopy_linux_amd64_10.32.4.tar.gz` ✅
- Plain `docker build` (no buildx) → no injection → falls back to defaults (`BUILDPLATFORM=linux/amd64`, `TARGETARCH=amd64`) ✅

The defaults (`BUILDPLATFORM=linux/amd64`, `TARGETARCH=amd64`) are only a safety net for non-BuildKit builds. In CI, [`container-linux`](https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/Makefile#L145-L147) always uses `docker buildx --platform="linux/$(ARCH)"`, so BuildKit injects the actual target arch automatically.

**Which issue(s) this PR fixes**:
Fixes intermittent arm64 image build failures in CI (e.g. `pull-azurefile-csi-driver-external-e2e-nfs`).

**Does this PR introduce a user-facing change?**
```release-note
NONE
```