### PR TITLE
chore: improve error message when EiT mount fails on unsupported OS

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -510,6 +510,10 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		if mountFsType == aznfs {
 			klog.V(2).Infof("encryptInTransit is enabled, mount by azurefile-proxy")
 			if err := d.mountWithProxy(ctx, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions); err != nil {
+				if strings.Contains(err.Error(), "no such file or directory") {
+					return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v. "+
+						"Encryption in Transit (EiT) does not support Ubuntu 20.04, please upgrade your node OS version.", cifsMountPath, err)
+				}
 				return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v", cifsMountPath, err)
 			}
 			klog.V(2).Infof("mount with proxy succeeded for %s", cifsMountPath)


### PR DESCRIPTION
## What type of PR is this?
/kind improvement

## What this PR does / why we need it:
When Encryption in Transit (EiT) mount fails with `no such file or directory` (azurefile-proxy.sock missing), the current error message is cryptic:

```
transport: Error while dialing: dial unix /csi/azurefile-proxy.sock: connect: no such file or directory
```

This PR adds a clear hint indicating that EiT does not support Ubuntu 20.04 and the user should upgrade their node OS version. This commonly affects CVM nodepools where the default OS is Ubuntu 20.04 (prior to K8s 1.36).

## Which issue(s) this PR fixes:
Improves user experience for EiT users on CVM nodepools.

## How to verify it:
1. Attempt to mount an Azure File volume with EiT enabled on a CVM node running Ubuntu 20.04
2. Observe the improved error message with actionable guidance
