### PR TITLE
test: skip WI and MI role setup for Windows/intree/migration e2e tests

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -135,8 +135,8 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 			miRoleSetupSucceeded = true
 		}
 
-		// Set up workload identity for mountWithWorkloadIdentityToken e2e tests (CAPZ only)
-		if isCapzTest {
+		// Set up workload identity for mountWithWorkloadIdentityToken e2e tests (CAPZ Linux only, not for in-tree/migration tests)
+		if isCapzTest && !isWindowsCluster && !isUsingInTreeVolumePlugin && !isTestingMigration {
 			kubeConfig, err := framework.LoadConfig()
 			if err != nil {
 				log.Printf("WARNING: failed to load kubeconfig for WI setup: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Windows, in-tree volume plugin, and migration e2e tests do not use workload identity (mountWithWorkloadIdentityToken) or managed identity mount (mountWithManagedIdentity). The current code runs:
1. Full WI setup including a 45-minute AAD OIDC cache warm-up
2. MI role assignment (EnsureNodeStorageFileDataRole)

even for these test runs, which is unnecessary overhead and increases flakiness.

This PR skips both setups for tests that do not need them.

**Which issue(s) this PR fixes:**
None

**Special notes for your reviewer:**
Both guards change from:
```go
if isCapzTest {
```
to:
```go
if isCapzTest && !isWindowsCluster && !isUsingInTreeVolumePlugin && !isTestingMigration {
```

Only CAPZ Linux CSI driver tests actually exercise the workload identity and managed identity mount paths.