### PR TITLE
test: skip MI role and WI setup for Windows/intree/migration e2e tests

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -24,6 +24,6 @@ jobs:
       with:
         severity: warning
         check_together: 'yes'
-        disable_matcher: false
         ignore_paths: vendor release-tools hack
         format: gcc
+        version: v0.10.0

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1909,6 +1909,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 	ginkgo.It("should create a volume on demand with managed identity mount [file.csi.azure.com]", func(ctx ginkgo.SpecContext) {
 		skipIfUsingInTreeVolumePlugin()
 		skipIfTestingInWindowsCluster()
+		skipIfTestingInMigrationCluster()
 		if !isCapzTest {
 			ginkgo.Skip("test case is only available for capz test")
 		}

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1986,6 +1986,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 	ginkgo.It("should create a volume on demand with workload identity token mount [file.csi.azure.com]", ginkgo.Serial, func(ctx ginkgo.SpecContext) {
 		skipIfUsingInTreeVolumePlugin()
 		skipIfTestingInWindowsCluster()
+		skipIfTestingInMigrationCluster()
 		if !isCapzTest {
 			ginkgo.Skip("test case is only available for capz test")
 		}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -128,8 +128,8 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Assign Storage File Data SMB MI Admin role to node identities
-		// This is required for mountWithManagedIdentity e2e tests (CAPZ only)
-		if isCapzTest {
+		// This is required for mountWithManagedIdentity e2e tests (CAPZ Linux only)
+		if isCapzTest && !isWindowsCluster && !isUsingInTreeVolumePlugin && !isTestingMigration {
 			err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to assign Storage File Data SMB MI Admin role to node identity")
 			miRoleSetupSucceeded = true

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -127,16 +127,13 @@ var _ = ginkgo.BeforeSuite(func(ctx ginkgo.SpecContext) {
 		_, err = azureClient.EnsureResourceGroup(ctx, creds.ResourceGroup, creds.Location, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Assign Storage File Data SMB MI Admin role to node identities
-		// This is required for mountWithManagedIdentity e2e tests (CAPZ Linux only)
+		// Assign Storage File Data SMB MI Admin role to node identities and
+		// set up workload identity for mountWithManagedIdentity/mountWithWorkloadIdentityToken e2e tests (CAPZ Linux only)
 		if isCapzTest && !isWindowsCluster && !isUsingInTreeVolumePlugin && !isTestingMigration {
 			err := azureClient.EnsureNodeStorageFileDataRole(ctx, creds.ResourceGroup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to assign Storage File Data SMB MI Admin role to node identity")
 			miRoleSetupSucceeded = true
-		}
 
-		// Set up workload identity for mountWithWorkloadIdentityToken e2e tests (CAPZ Linux only, not for in-tree/migration tests)
-		if isCapzTest && !isWindowsCluster && !isUsingInTreeVolumePlugin && !isTestingMigration {
 			kubeConfig, err := framework.LoadConfig()
 			if err != nil {
 				log.Printf("WARNING: failed to load kubeconfig for WI setup: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Windows, in-tree volume plugin, and migration e2e tests do not use managed identity mount (`mountWithManagedIdentity`). The `EnsureNodeStorageFileDataRole` setup is unnecessary overhead for these test runs.

This PR skips the MI role assignment when running Windows, in-tree, or migration tests.

**Which issue(s) this PR fixes:**
None

**Special notes for your reviewer:**
The guard changes from:
```go
if isCapzTest {
```
to:
```go
if isCapzTest && !isWindowsCluster && !isUsingInTreeVolumePlugin && !isTestingMigration {
```

Only CAPZ Linux CSI driver tests actually exercise the managed identity mount path.