### PR TITLE
chore(deps): bump build-image/debian-base from bookworm-v1.0.7 to bookworm-v1.0.8 in /pkg/azurefileplugin

### DIFF
--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG ARCH=amd64
 ARG BUILDPLATFORM=linux/amd64
-ARG BASE_IMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.7
+ARG BASE_IMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.8
 
 FROM ${BASE_IMAGE} AS base
 


### PR DESCRIPTION
Bumps build-image/debian-base from bookworm-v1.0.7 to bookworm-v1.0.8.

Same change as https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3640