### PR TITLE
[release-1.34] chore(deps): bump build-image/debian-base from bookworm-v1.0.7 to bookworm-v1.0.8

### DIFF
--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG ARCH=amd64
 
-FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.7 AS base
+FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.8 AS base
 
 FROM base AS builder
 


### PR DESCRIPTION
Cherry-pick of #3185 to release-1.34.

Bumps `registry.k8s.io/build-image/debian-base` from bookworm-v1.0.7 to bookworm-v1.0.8.