### PR TITLE
fix: normalize folderName "/" as root (empty string)

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -245,6 +245,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			volumeMetadataReplaceMap[pvNameMetadata] = v
 		case serverNameField:
 		case folderNameField:
+			v = strings.Trim(v, "/") // normalize "/" or "///" to empty (root)
 			if v != "" {
 				if err := isValidFolderName(v); err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid folderName in storage class: %v", err)

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -335,7 +335,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		case diskNameField:
 			diskName = v
 		case folderNameField:
-			folderName = v
+			folderName = strings.Trim(v, "/") // normalize "/" or "///" to empty (root)
 			if folderName != "" {
 				if err := isValidFolderName(folderName); err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid folderName: %v", err)


### PR DESCRIPTION
When `folderName` is set to `"/"` (or `"//"`, etc.), treat it the same as empty string (root of file share) instead of rejecting it with "folderName contains empty path segment" error.

This matches user expectations that `"/"` means root directory.

**What this PR does:**
- In `isValidFolderName()`, after trimming slashes, if the result is empty, return nil (valid) instead of proceeding to split and check segments.
- Added test cases for `"/"` and `"///"`.

Fixes: #3189