### PR TITLE
fix: skip unmount in ensureMountPoint to prevent stale mount cleanup race

### DIFF
--- a/pkg/azurefile/fake_mounter.go
+++ b/pkg/azurefile/fake_mounter.go
@@ -27,6 +27,7 @@ import (
 
 type fakeMounter struct {
 	mount.FakeMounter
+	unmountCount uint
 }
 
 // Mount overrides mount.FakeMounter.Mount.
@@ -79,4 +80,13 @@ func NewFakeMounter() (*mount.SafeFormatAndMount, error) {
 	return &mount.SafeFormatAndMount{
 		Interface: &fakeMounter{},
 	}, nil
+}
+
+// Unmount overrides mount.FakeMounter.Unmount.
+func (f *fakeMounter) Unmount(target string) error {
+	f.unmountCount++
+	if strings.Contains(target, "error") {
+		return fmt.Errorf("fake Unmount: target error")
+	}
+	return f.FakeMounter.Unmount(target)
 }

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -210,7 +210,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		klog.V(2).Infof("NodePublishVolume: refreshed OAuth token credential cache for volume(%s) server(%s)", volumeID, oauthServer)
 	}
 
-	// NodePublishVolume should only alter the content of volume post initial successfull mount
+	// NodePublishVolume should only alter volume content after the initial successful mount.
 	mnt, err := d.ensureMountPoint(target, os.FileMode(mountPermissions), false)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %s: %v", target, err)

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -880,7 +880,7 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode) (bool, error)
 		// The actual cleanup is deferred to NodeUnpublishVolume, which is the proper
 		// teardown path.
 		klog.Warningf("ReadDir %s failed with %v, skip unmount to avoid race condition", target, err)
-		return !notMnt, nil
+		return !notMnt, err
 	}
 	if err := makeDir(target, perm); err != nil {
 		klog.Errorf("MakeDir failed on target: %s (%v)", target, err)

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -869,14 +869,18 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode) (bool, error)
 			klog.V(2).Infof("already mounted to target %s", target)
 			return !notMnt, nil
 		}
-		// mount link is invalid, now unmount and remount later
-		klog.Warningf("ReadDir %s failed with %v, unmount this directory", target, err)
-		if err := d.mounter.Unmount(target); err != nil {
-			klog.Errorf("Unmount directory %s failed with %v", target, err)
-			return !notMnt, err
-		}
-		notMnt = true
-		return !notMnt, err
+		// Do not unmount here even if the mount is stale or broken (e.g., ESTALE on NFS).
+		// Unmounting during a periodic NodePublishVolume (requiresRepublish) creates a race
+		// condition: if the application container restarts at the same time, it may bind to
+		// the unmounted target path and write to the container's local filesystem instead of
+		// the persistent volume, causing silent data loss.
+		//
+		// Per the Kubernetes CSI spec, subsequent NodePublishVolume calls (republish) should
+		// only update the contents of the volume, not remount or alter mount state.
+		// The actual cleanup is deferred to NodeUnpublishVolume, which is the proper
+		// teardown path.
+		klog.Warningf("ReadDir %s failed with %v, skip unmount to avoid race condition", target, err)
+		return !notMnt, nil
 	}
 	if err := makeDir(target, perm); err != nil {
 		klog.Errorf("MakeDir failed on target: %s (%v)", target, err)

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -210,7 +210,8 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		klog.V(2).Infof("NodePublishVolume: refreshed OAuth token credential cache for volume(%s) server(%s)", volumeID, oauthServer)
 	}
 
-	mnt, err := d.ensureMountPoint(target, os.FileMode(mountPermissions))
+	// NodePublishVolume should only alter the content of volume post initial successfull mount
+	mnt, err := d.ensureMountPoint(target, os.FileMode(mountPermissions), false)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %s: %v", target, err)
 	}
@@ -528,7 +529,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 	klog.V(2).Infof("cifsMountPath(%v) fstype(%v) volumeID(%v) mountflags(%v) mountOptions(%v) volumeMountGroup(%s)", cifsMountPath, fsType, volumeID, mountFlags, mountOptions, volumeMountGroup)
 
-	isDirMounted, err := d.ensureMountPoint(cifsMountPath, os.FileMode(mountPermissions))
+	isDirMounted, err := d.ensureMountPoint(cifsMountPath, os.FileMode(mountPermissions), true)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %s: %v", cifsMountPath, err)
 	}
@@ -635,7 +636,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	if isDiskMount {
-		mnt, err := d.ensureMountPoint(targetPath, os.FileMode(mountPermissions))
+		mnt, err := d.ensureMountPoint(targetPath, os.FileMode(mountPermissions), true)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "mount %s on target %s failed with %v", volumeID, targetPath, err)
 		}
@@ -821,7 +822,7 @@ func (d *Driver) NodeExpandVolume(_ context.Context, _ *csi.NodeExpandVolumeRequ
 
 // ensureMountPoint: create mount point if not exists
 // return <true, nil> if it's already a mounted point otherwise return <false, nil>
-func (d *Driver) ensureMountPoint(target string, perm os.FileMode) (bool, error) {
+func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount bool) (bool, error) {
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
 	if err != nil && !os.IsNotExist(err) {
 		if IsCorruptedDir(target) {
@@ -868,6 +869,16 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode) (bool, error)
 		if err == nil {
 			klog.V(2).Infof("already mounted to target %s", target)
 			return !notMnt, nil
+		}
+		if shouldUnmount {
+			klog.Warningf("ReadDir %s failed with %v, unmounting stale mount to fix it", target, err)
+			// mount link is invalid, now unmount and remount later
+			if err := d.mounter.Unmount(target); err != nil {
+				klog.Errorf("Unmount directory %s failed with %v", target, err)
+				return !notMnt, err
+			}
+			notMnt = true
+			return !notMnt, err
 		}
 		// Do not unmount here even if the mount is stale or broken (e.g., ESTALE on NFS).
 		// Unmounting during a periodic NodePublishVolume (requiresRepublish) creates a race

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -1235,34 +1235,67 @@ func TestEnsureMountPoint(t *testing.T) {
 	azureFile := "./azure.go"
 
 	tests := []struct {
-		desc        string
-		target      string
-		expectedErr error
+		desc                 string
+		target               string
+		shouldUnmount        bool
+		expectedErr          error
+		expectedUnmountCount uint
 	}{
 		{
-			desc:        "[Error] Mocked by IsLikelyNotMountPoint",
-			target:      errorTarget,
-			expectedErr: fmt.Errorf("fake IsLikelyNotMountPoint: fake error"),
+			desc:                 "[Error] Mocked by IsLikelyNotMountPoint",
+			target:               errorTarget,
+			shouldUnmount:        true,
+			expectedErr:          fmt.Errorf("fake IsLikelyNotMountPoint: fake error"),
+			expectedUnmountCount: 0, // If IsLikelyNotMountPoint returns error, unmount should not be called
 		},
 		{
-			desc:        "[Error] Error opening file",
-			target:      falseTarget,
-			expectedErr: &os.PathError{Op: "open", Path: "./false_is_likely_target", Err: syscall.ENOENT},
+			desc:                 "[Error] Error opening file",
+			target:               falseTarget,
+			shouldUnmount:        true,
+			expectedErr:          &os.PathError{Op: "open", Path: "./false_is_likely_target", Err: syscall.ENOENT},
+			expectedUnmountCount: 1,
 		},
 		{
-			desc:        "[Error] Not a directory",
-			target:      azureFile,
-			expectedErr: &os.PathError{Op: "mkdir", Path: "./azure.go", Err: syscall.ENOTDIR},
+			desc:                 "[Error] Not a directory",
+			target:               azureFile,
+			shouldUnmount:        true,
+			expectedErr:          &os.PathError{Op: "mkdir", Path: "./azure.go", Err: syscall.ENOTDIR},
+			expectedUnmountCount: 0,
 		},
 		{
-			desc:        "[Success] Successful run",
-			target:      targetTest,
-			expectedErr: nil,
+			desc:                 "[Success] Successful run",
+			target:               targetTest,
+			shouldUnmount:        true,
+			expectedErr:          nil,
+			expectedUnmountCount: 0,
 		},
 		{
-			desc:        "[Success] Already existing mount",
-			target:      alreadyExistTarget,
-			expectedErr: nil,
+			desc:                 "[Success] Already existing mount",
+			target:               alreadyExistTarget,
+			shouldUnmount:        true,
+			expectedErr:          nil,
+			expectedUnmountCount: 0,
+		},
+		{
+			desc:                 "[Error] Opening file with shouldUnmount false",
+			target:               falseTarget,
+			shouldUnmount:        false,
+			expectedErr:          &os.PathError{Op: "open", Path: "./false_is_likely_target", Err: syscall.ENOENT},
+			expectedUnmountCount: 0, // Since Unmount flag is false, unmount count should be 0
+		},
+		{
+			desc:                 "[Error] Opening file with shouldUnmount false and unmount will return error shouldn't alter expected error",
+			target:               falseTarget,
+			shouldUnmount:        false,
+			expectedErr:          &os.PathError{Op: "open", Path: "./false_is_likely_target", Err: syscall.ENOENT},
+			expectedUnmountCount: 0,
+		},
+		{
+			desc:                 "[Success] Successful run with shouldUnmount false",
+			target:               targetTest,
+			shouldUnmount:        false,
+			expectedErr:          nil,
+			expectedUnmountCount: 0,
 		},
 	}
 
@@ -1277,10 +1310,15 @@ func TestEnsureMountPoint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := d.ensureMountPoint(test.target, 0777)
+		_, err := d.ensureMountPoint(test.target, 0777, test.shouldUnmount)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("[%s]: Unexpected Error: %v, expected error: %v", test.desc, err, test.expectedErr)
 		}
+		if fakeMounter.unmountCount != test.expectedUnmountCount {
+			t.Errorf("[%s]: Unexpected unmount count: %d, expected: %d", test.desc, fakeMounter.unmountCount, test.expectedUnmountCount)
+		}
+		// Reset unmount count before each test case
+		fakeMounter.unmountCount = 0
 	}
 
 	// Clean up


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR fixes a race condition between application container restarts and periodic `NodePublishVolume` calls triggered by `requiresRepublish: true`. During republish, **ensureMountPoint** was performing an unmount when it detected a stale or broken mount If the application container restarts at the same time as this unmount, writes to the mount path land on the container's local filesystem instead of the persistent fileshare, causing silent data loss.

Per the Kubernetes CSI documentation, when `requiresRepublish: true` is set, subsequent NodePublishVolume calls should only update the contents of the volume — not remount or alter mount state. This change removes the unmount from ensureMountPoint and instead reports the mount as already present, deferring cleanup to _NodeUnpublishVolume_.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
- Ran following script while performing test
```sh
 while true; do date; mount | grep nfs; ls -lrthas /var/lib/kubelet/pods/f5de012a-3994-4566-b78d-5104175afae8/volumes/kubernetes.io~csi/pvc-7d52523f-6b91-4753-b16e-d36e1809b3a5/mount; sleep 2; done
```
It produced following output:
```
Fri Jun 12 13:51:22 UTC 2026
f88010bbf2bfc461283e201.file.core.windows.net:/f88010bbf2bfc461283e201/pvcn-7d52523f-6b91-4753-b16e-d36e1809b3a5 on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/b7904ac2a05379a4e8c5e968c63e64945f578aacb48eb20f0c409ea874563159/globalmount type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,acregmin=30,acregmax=30,acdirmax=30,hard,noresvport,proto=tcp,nconnect=4,timeo=600,retrans=2,sec=sys,clientaddr=10.224.0.33,local_lock=none,addr=20.150.82.72)
f88010bbf2bfc461283e201.file.core.windows.net:/f88010bbf2bfc461283e201/pvcn-7d52523f-6b91-4753-b16e-d36e1809b3a5 on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/b7904ac2a05379a4e8c5e968c63e64945f578aacb48eb20f0c409ea874563159/globalmount type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,acregmin=30,acregmax=30,acdirmax=30,hard,noresvport,proto=tcp,nconnect=4,timeo=600,retrans=2,sec=sys,clientaddr=10.224.0.33,local_lock=none,addr=20.150.82.72)
f88010bbf2bfc461283e201.file.core.windows.net:/f88010bbf2bfc461283e201/pvcn-7d52523f-6b91-4753-b16e-d36e1809b3a5 on /var/lib/kubelet/pods/f5de012a-3994-4566-b78d-5104175afae8/volumes/kubernetes.io~csi/pvc-7d52523f-6b91-4753-b16e-d36e1809b3a5/mount type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,acregmin=30,acregmax=30,acdirmax=30,hard,noresvport,proto=tcp,nconnect=4,timeo=600,retrans=2,sec=sys,clientaddr=10.224.0.33,local_lock=none,addr=20.150.82.72)
f88010bbf2bfc461283e201.file.core.windows.net:/f88010bbf2bfc461283e201/pvcn-7d52523f-6b91-4753-b16e-d36e1809b3a5 on /var/lib/kubelet/pods/f5de012a-3994-4566-b78d-5104175afae8/volumes/kubernetes.io~csi/pvc-7d52523f-6b91-4753-b16e-d36e1809b3a5/mount type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,acregmin=30,acregmax=30,acdirmax=30,hard,noresvport,proto=tcp,nconnect=4,timeo=600,retrans=2,sec=sys,clientaddr=10.224.0.33,local_lock=none,addr=20.150.82.72)
total 7.5K
4.0K drwxr-x--- 3 root root  4.0K Jun 12 13:49 ..
 512 drwxrwsrwx 2 root 65532   64 Jun 12 13:49 .
3.0K -rw-r--r-- 1 root 65532 2.8K Jun 12 13:51 outfile
```
- when fileshare is deleted and unmount was performed by csi driver then application will write to local filesystem
```
Fri Jun 12 13:53:01 UTC 2026
f88010bbf2bfc461283e201.file.core.windows.net:/f88010bbf2bfc461283e201/pvcn-7d52523f-6b91-4753-b16e-d36e1809b3a5 on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/b7904ac2a05379a4e8c5e968c63e64945f578aacb48eb20f0c409ea874563159/globalmount type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,acregmin=30,acregmax=30,acdirmax=30,hard,noresvport,proto=tcp,nconnect=4,timeo=600,retrans=2,sec=sys,clientaddr=10.224.0.33,local_lock=none,addr=20.150.82.72)
f88010bbf2bfc461283e201.file.core.windows.net:/f88010bbf2bfc461283e201/pvcn-7d52523f-6b91-4753-b16e-d36e1809b3a5 on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/b7904ac2a05379a4e8c5e968c63e64945f578aacb48eb20f0c409ea874563159/globalmount type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,acregmin=30,acregmax=30,acdirmax=30,hard,noresvport,proto=tcp,nconnect=4,timeo=600,retrans=2,sec=sys,clientaddr=10.224.0.33,local_lock=none,addr=20.150.82.72)
total 12K
4.0K drwxr-xr-x 2 root root 4.0K Jun 12 13:52 .
4.0K drwxr-xr-x 3 root root 4.0K Jun 12 13:52 ..
4.0K -rw-r--r-- 1 root root  957 Jun 12 13:53 outfile
```
- State of pod directory points to ext3/ext2
```
root@aks-agentpool0-71348700-vmss000001:/# stat /var/lib/kubelet/pods/f5de012a-3994-4566-b78d-5104175afae8/volumes/kubernetes.io~csi/pvc-7d52523f-6b91-4753-b16e-d36e1809b3a5/mount -f
  File: "/var/lib/kubelet/pods/f5de012a-3994-4566-b78d-5104175afae8/volumes/kubernetes.io~csi/pvc-7d52523f-6b91-4753-b16e-d36e1809b3a5/mount"
    ID: 5aa59d5991d66bd3 Namelen: 255     Type: ext2/ext3
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 32229372   Free: 25336968   Available: 25332872
Inodes: Total: 16646144   Free: 16347425
```

**Release note**:
```
none
```
