### PR TITLE
Dev/rnhan/workload identity sovereign clouds

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -209,6 +209,12 @@ const (
 
 	defaultStorageEndPointSuffix = "core.windows.net"
 
+	// defaultActiveDirectoryEndpoint and defaultStorageResource are the default
+	// public-cloud AAD authority host and storage OAuth resource
+	// (workload-identity mounts).
+	defaultActiveDirectoryEndpoint = "https://login.microsoftonline.com/"
+	defaultStorageResource         = "https://storage.azure.com/"
+
 	VolumeID         = "volumeid"
 	SourceResourceID = "source_resource_id"
 	SnapshotName     = "snapshot_name"
@@ -1497,6 +1503,24 @@ func (d *Driver) getStorageEndPointSuffix() string {
 		return defaultStorageEndPointSuffix
 	}
 	return d.cloud.Environment.StorageEndpointSuffix
+}
+
+// getActiveDirectoryEndpoint returns the AAD authority host for the current cloud
+// (e.g. https://login.chinacloudapi.cn/ for Azure China), falling back to public AAD.
+func (d *Driver) getActiveDirectoryEndpoint() string {
+	if d.cloud == nil || d.cloud.Environment == nil || d.cloud.Environment.ActiveDirectoryEndpoint == "" {
+		return defaultActiveDirectoryEndpoint
+	}
+	return d.cloud.Environment.ActiveDirectoryEndpoint
+}
+
+// getStorageResource returns the AAD resource/scope used to request a storage
+// OAuth token for the current cloud, falling back to the public storage resource.
+func (d *Driver) getStorageResource() string {
+	if d.cloud == nil || d.cloud.Environment == nil || d.cloud.Environment.ResourceIdentifiers == nil || d.cloud.Environment.ResourceIdentifiers.Storage == "" {
+		return defaultStorageResource
+	}
+	return d.cloud.Environment.ResourceIdentifiers.Storage
 }
 
 func (d *Driver) getFileShareClientForSub(subscriptionID string) (fileshareclient.Interface, error) {

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -1539,6 +1539,96 @@ func TestGetStorageEndPointSuffix(t *testing.T) {
 	}
 }
 
+func TestGetActiveDirectoryEndpoint(t *testing.T) {
+	d := NewFakeDriver()
+
+	tests := []struct {
+		name     string
+		cloud    *storage.AccountRepo
+		expected string
+	}{
+		{
+			name:     "nil cloud",
+			cloud:    nil,
+			expected: defaultActiveDirectoryEndpoint,
+		},
+		{
+			name:     "empty environment",
+			cloud:    &storage.AccountRepo{},
+			expected: defaultActiveDirectoryEndpoint,
+		},
+		{
+			name: "public cloud",
+			cloud: &storage.AccountRepo{
+				Environment: &azclient.Environment{
+					ActiveDirectoryEndpoint: "https://login.microsoftonline.com/",
+				},
+			},
+			expected: "https://login.microsoftonline.com/",
+		},
+		{
+			name: "china cloud",
+			cloud: &storage.AccountRepo{
+				Environment: &azclient.Environment{
+					ActiveDirectoryEndpoint: "https://login.chinacloudapi.cn/",
+				},
+			},
+			expected: "https://login.chinacloudapi.cn/",
+		},
+	}
+
+	for _, test := range tests {
+		d.cloud = test.cloud
+		assert.Equal(t, test.expected, d.getActiveDirectoryEndpoint(), test.name)
+	}
+}
+
+func TestGetStorageResource(t *testing.T) {
+	d := NewFakeDriver()
+
+	tests := []struct {
+		name     string
+		cloud    *storage.AccountRepo
+		expected string
+	}{
+		{
+			name:     "nil cloud",
+			cloud:    nil,
+			expected: defaultStorageResource,
+		},
+		{
+			name: "nil resource identifiers",
+			cloud: &storage.AccountRepo{
+				Environment: &azclient.Environment{},
+			},
+			expected: defaultStorageResource,
+		},
+		{
+			name: "china cloud with custom storage resource",
+			cloud: &storage.AccountRepo{
+				Environment: &azclient.Environment{
+					ResourceIdentifiers: &azclient.ResourceIdentifier{
+						Storage: "https://storage.example.azure.com/",
+					},
+				},
+			},
+			expected: "https://storage.example.azure.com/",
+		},
+	}
+
+	for _, test := range tests {
+		d.cloud = test.cloud
+		assert.Equal(t, test.expected, d.getStorageResource(), test.name)
+	}
+}
+
+func TestGetEndpointsFromCloudName(t *testing.T) {
+	d := NewFakeDriver()
+	d.cloud = &storage.AccountRepo{Environment: azclient.EnvironmentFromName("AZURECHINACLOUD")}
+	assert.Equal(t, "https://login.chinacloudapi.cn/", d.getActiveDirectoryEndpoint())
+	assert.Equal(t, "https://storage.azure.com/", d.getStorageResource())
+}
+
 func TestGetStorageAccesskey(t *testing.T) {
 	options := &storage.AccountOptions{
 		Name:           "test-sa",

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -490,7 +490,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			klog.V(2).Infof("using workload identity token for volume %s with mount options: %v", volumeID, sensitiveMountOptions)
 			if tokenFilePath != "" {
 				// always set credential cache when token file is provided even mount does not happen
-				if out, err := setCredentialCache(server, clientID, tenantID, tokenFilePath, ""); err != nil {
+				if out, err := setCredentialCache(server, clientID, tenantID, tokenFilePath, "", d.getActiveDirectoryEndpoint(), d.getStorageResource()); err != nil {
 					return nil, status.Errorf(codes.Internal, "setCredentialCache failed for %s with error: %v, output: %s", server, err, out)
 				}
 			}
@@ -568,7 +568,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		} else {
 			execFunc := func() error {
 				if mountWithManagedIdentity && protocol != nfs && runtime.GOOS != "windows" {
-					if out, err := setCredentialCache(server, clientID, tenantID, tokenFilePath, ""); err != nil {
+					if out, err := setCredentialCache(server, clientID, tenantID, tokenFilePath, "", d.getActiveDirectoryEndpoint(), d.getStorageResource()); err != nil {
 						return fmt.Errorf("setCredentialCache failed for %s with error: %v, output: %s", server, err, out)
 					}
 				}
@@ -967,7 +967,7 @@ func (d *Driver) setCredentialCacheWithOAuthToken(ctx context.Context, volumeID 
 		return server, nil
 	}
 
-	if output, err := setCredentialCache(server, "", "", "", oauthToken); err != nil {
+	if output, err := setCredentialCache(server, "", "", "", oauthToken, "", ""); err != nil {
 		klog.Errorf("setCredentialCache failed for %s with output: %s, error: %v", server, strings.ReplaceAll(string(output), oauthToken, "<redacted>"), err)
 		return "", status.Errorf(codes.Internal, "setCredentialCache failed for %s: %v", server, err)
 	}

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -460,7 +460,7 @@ func getDefaultBandwidth(requestGiB int, storageAccountType string) *int32 {
 	return &bandwidth
 }
 
-func setCredentialCache(server, clientID, tenantID, tokenFile, token string) ([]byte, error) {
+func setCredentialCache(server, clientID, tenantID, tokenFile, token, authorityHost, resource string) ([]byte, error) {
 	if server == "" {
 		return nil, fmt.Errorf("server must be provided")
 	}
@@ -482,6 +482,13 @@ func setCredentialCache(server, clientID, tenantID, tokenFile, token string) ([]
 			return nil, fmt.Errorf("tenantID must be provided when tokenFile is provided")
 		}
 		args = []string{"set", serverURL, "--workload-identity", "--tenant-id", tenantID, "--client-id", clientID, "--token-file", tokenFile}
+		// pass the cloud-specific AAD authority host and storage resource
+		if authorityHost != "" {
+			args = append(args, "--authority-host", authorityHost)
+		}
+		if resource != "" {
+			args = append(args, "--resource", resource)
+		}
 	default:
 		if clientID == "" {
 			return nil, fmt.Errorf("clientID must be provided")

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -1603,7 +1603,7 @@ func TestSetCredentialCache(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := setCredentialCache(test.server, test.clientID, test.tenantID, test.tokenFile, "")
+		_, err := setCredentialCache(test.server, test.clientID, test.tenantID, test.tokenFile, "", defaultActiveDirectoryEndpoint, defaultStorageResource)
 		if test.expectedError != "" {
 			if err == nil {
 				t.Errorf("test[%s]: expected error containing %q, got nil", test.desc, test.expectedError)
@@ -1645,7 +1645,7 @@ func TestSetCredentialCache(t *testing.T) {
 	}
 
 	for _, test := range tokenTests {
-		_, err := setCredentialCache(test.server, "", "", test.tokenFile, test.token)
+		_, err := setCredentialCache(test.server, "", "", test.tokenFile, test.token, "", "")
 		if test.expectedError != "" {
 			if err == nil {
 				t.Errorf("test[%s]: expected error containing %q, got nil", test.desc, test.expectedError)

--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -47,7 +47,7 @@ RUN chmod +x /azurefile-proxy/*.sh && \
   chmod +x /azurefile-proxy/azurefile-proxy
 
 COPY --from=builder --chown=root:root /tmp/packages-microsoft-prod-22.04.deb /azurefile-proxy/packages-microsoft-prod-22.04.deb
-RUN dpkg -i /azurefile-proxy/packages-microsoft-prod-22.04.deb && apt update && apt install -y azfilesauth=1.0-10 && rm -f /azurefile-proxy/packages-microsoft-prod-22.04.deb
+RUN dpkg -i /azurefile-proxy/packages-microsoft-prod-22.04.deb && apt update && apt install -y azfilesauth=1.0-11 && rm -f /azurefile-proxy/packages-microsoft-prod-22.04.deb
 
 LABEL maintainers="andyzhangx"
 LABEL description="AzureFile CSI Driver"


### PR DESCRIPTION
 **What type of PR is this?**
 
 /kind bug
 /kind feature
 
 **What this PR does / why we need it**:
 
 Workload-identity Azure Files mounts currently fail in sovereign clouds (e.g. Mooncake). When requesting the storage OAuth token, the authenticator hardcodes the public-cloud AAD authority (`https://login.microsoftonline.com`) and storage resource (`https://storage.azure.com`), so the token exchange is performed against the wrong AAD authority in national clouds and the mount fails.
 
 This PR allows passing cloud-specific AAD authority host and storage OAuth resource via the driver's cloud `Environment` down to the authenticator:
 
 - Adds `getActiveDirectoryEndpoint()` and `getStorageResource()` on `Driver`, which read `cloud.Environment.ActiveDirectoryEndpoint` and `cloud.Environment.ResourceIdentifiers.Storage` (e.g. `https://login.chinacloudapi.cn/` for Azure China), falling back to the public-cloud defaults when unset.
 - Passes those values through `setCredentialCache()`, which forwards them to `azfilesauthmanager` via the new `--authority-host` / `--resource` flags. The flags are only emitted on the workload-identity path, managed-identity (IMDS) and OAuth-token paths are unchanged.
 - Bumps the `azfilesauth` package pin to `1.0-11`, which contains the matching authenticator support for `--authority-host` / `--resource`.
 
 Public-cloud behavior is unchanged: the getters return the existing public defaults, so the same authority/resource are used as before.
 
 **Requirements**:
 - [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
 - [x] includes documentation
 - [x] adds unit tests
 - [x] tested upgrade from previous version
 
 **Special notes for your reviewer**:
 
 This change depends on `azfilesauth 1.0-11` being published to the Microsoft package feed (Dockerfile installs it). The image build will not resolve the new version until that package is released. https://github.com/Azure/AzFilesAuthenticator/pull/44
 
 **Release note**:
 ```
 Fix workload identity Azure Files mounts in sovereign clouds (Azure China, US Gov) by using the cloud-specific AAD and storage resource.
 ```