### PR TITLE
fix(windows): self-heal stale node-global SMB session for subPath pods on NodePublishVolume

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
@@ -133,7 +134,6 @@ require (
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/pkg/azurefile/azure_common_darwin.go
+++ b/pkg/azurefile/azure_common_darwin.go
@@ -31,6 +31,14 @@ func SMBMount(m *mount.SafeFormatAndMount, source, target, fsType string, option
 	return nil
 }
 
+func RevalidateSMBMount(_ *mount.SafeFormatAndMount, _ string, _ func() (username, password string, err error)) error {
+	return nil
+}
+
+func readStagedRemotePath(_ string) (string, error) {
+	return "", nil
+}
+
 func SMBUnmount(m *mount.SafeFormatAndMount, target string, _, _ bool) error {
 	return nil
 }

--- a/pkg/azurefile/azure_common_linux.go
+++ b/pkg/azurefile/azure_common_linux.go
@@ -33,6 +33,18 @@ func SMBMount(m *mount.SafeFormatAndMount, source, target, fsType string, option
 	return m.MountSensitive(source, target, fsType, options, sensitiveMountOptions)
 }
 
+// RevalidateSMBMount is a no-op on Linux: the stale node-global SMB session
+// self-heal only applies to Windows (New-SmbGlobalMapping).
+func RevalidateSMBMount(_ *mount.SafeFormatAndMount, _ string, _ func() (username, password string, err error)) error {
+	return nil
+}
+
+// readStagedRemotePath returns empty on Linux so the publish-path SMB revalidation
+// is skipped (staging is a real mount, not a symlink-to-UNC as on Windows).
+func readStagedRemotePath(_ string) (string, error) {
+	return "", nil
+}
+
 func SMBUnmount(m *mount.SafeFormatAndMount, target string, extensiveMountCheck, _ bool) error {
 	return mount.CleanupMountPoint(target, m.Interface, extensiveMountCheck)
 }

--- a/pkg/azurefile/azure_common_windows.go
+++ b/pkg/azurefile/azure_common_windows.go
@@ -21,6 +21,7 @@ package azurefile
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/sys/windows"
@@ -37,6 +38,21 @@ func SMBMount(m *mount.SafeFormatAndMount, source, target, fsType string, mountO
 		return proxy.SMBMount(source, target, fsType, mountOptions, sensitiveMountOptions)
 	}
 	return fmt.Errorf("could not cast to csi proxy class")
+}
+
+func RevalidateSMBMount(m *mount.SafeFormatAndMount, remotePath string, getCredentials func() (username, password string, err error)) error {
+	if proxy, ok := m.Interface.(mounter.CSIProxyMounter); ok {
+		return proxy.RevalidateSMBMount(remotePath, getCredentials)
+	}
+	return fmt.Errorf("could not cast to csi proxy class")
+}
+
+// readStagedRemotePath returns the remote UNC path backing a Windows staging path.
+// On Windows the driver creates the staging path as a symlink that points at
+// \\<account>.file.<suffix>\<share>[\<folder>], so reading the link yields the
+// remote path used to (re)validate the SMB mapping.
+func readStagedRemotePath(source string) (string, error) {
+	return os.Readlink(source)
 }
 
 func SMBUnmount(m *mount.SafeFormatAndMount, target string, extensiveMountCheck, removeSMBMountOnWindows bool) error {

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -187,6 +187,19 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		return nil, status.Error(codes.InvalidArgument, "Staging target not provided")
 	}
 
+	// Windows self-heal for stale node-global SMB sessions.
+	//
+	// On Windows the SMB share is mounted once per node via New-SmbGlobalMapping during
+	// NodeStageVolume; the staging path is a symlink to the remote UNC path. kubelet calls
+	// NodeStageVolume only once per volume per node, so when that node-global session goes
+	// stale (credential rotation, idle/NAT teardown, storage maintenance, etc.) the existing
+	// self-heal in NodeStageVolume never re-runs for subsequently created pods. Those new pods
+	// re-traverse the share (e.g. kubelet's subPath preparation) against the dead session and
+	// fail with "failed to prepare subPath for volumeMount" until the node is replaced.
+	if err := d.revalidateStaleSMBMount(ctx, source, volumeID, secrets, context); err != nil {
+		return nil, err
+	}
+
 	mountOptions := []string{"bind"}
 	if req.GetReadonly() {
 		mountOptions = append(mountOptions, "ro")
@@ -234,6 +247,48 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	klog.V(2).Infof("NodePublishVolume: mount %s at %s successfully", source, target)
 
 	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+// revalidateStaleSMBMount repairs the node-global SMB mapping backing the staged source
+// when it has gone stale/missing, before the per-pod bind/symlink. On non-Windows platforms
+// readStagedRemotePath returns empty, so this is a no-op. RevalidateSMBMount probes the
+// mapping (cheap, read-only) and invokes the credential resolver only when a remap is
+// actually needed, so healthy publishes and co-tenant pods on the same share are unaffected.
+//
+// Revalidation is serialized per node-global SMB mapping (keyed by the UNC remotePath,
+// shared by every pod/volume on this node referencing the same share). Without this lock,
+// concurrent NodePublishVolume calls could race RemoveSmbGlobalMapping + NewSmbGlobalMapping,
+// where one remap removes the mapping another just recreated (a destructive, node-global
+// operation). TryAcquire fails fast; the caller surfaces Aborted so kubelet retries the
+// publish, by which point the in-flight call has revalidated the mapping. The lock is
+// released as soon as revalidation completes (this helper returns), not spanning the bind.
+func (d *Driver) revalidateStaleSMBMount(ctx context.Context, source, volumeID string, secrets, volContext map[string]string) error {
+	remotePath, rlErr := readStagedRemotePath(source)
+	if rlErr != nil || remotePath == "" {
+		return nil
+	}
+
+	revalidateLockKey := fmt.Sprintf("smb-revalidate-%s", remotePath)
+	if acquired := d.volumeLocks.TryAcquire(revalidateLockKey); !acquired {
+		return status.Errorf(codes.Aborted, volumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer d.volumeLocks.Release(revalidateLockKey)
+
+	getCredentials := func() (string, string, error) {
+		klog.Warningf("NodePublishVolume: node-global SMB mapping for %s is missing or stale, revalidating before publish of volume(%s)", remotePath, volumeID)
+		_, accountName, accountKey, _, _, _, _, _, gaErr := d.GetAccountInfo(ctx, volumeID, secrets, volContext)
+		if gaErr != nil {
+			return "", "", status.Errorf(codes.Internal, "failed to get account info to revalidate SMB mount for volume(%s): %v", volumeID, gaErr)
+		}
+		if accountName == "" || accountKey == "" {
+			return "", "", status.Errorf(codes.Internal, "accountName(%s) or accountKey is empty, cannot revalidate SMB mount for volume(%s)", accountName, volumeID)
+		}
+		return fmt.Sprintf("AZURE\\%s", accountName), accountKey, nil
+	}
+	if rvErr := RevalidateSMBMount(d.mounter, remotePath, getCredentials); rvErr != nil {
+		return status.Errorf(codes.Internal, "NodePublishVolume: failed to revalidate SMB mount for %s of volume(%s): %v", remotePath, volumeID, rvErr)
+	}
+	return nil
 }
 
 // NodeUnpublishVolume unmount the volume from the target path

--- a/pkg/mounter/safe_mounter_host_process_windows.go
+++ b/pkg/mounter/safe_mounter_host_process_windows.go
@@ -85,36 +85,9 @@ func (mounter *winMounter) SMBMount(source, target, fsType string, mountOptions,
 		return fmt.Errorf("remote path is empty")
 	}
 
-	isMapped, err := mounter.smbAPI.IsSmbMapped(remotePath)
-	if err != nil {
-		klog.Errorf("IsSmbMapped(%s) failed with %v", remotePath, err)
-		isMapped = false
-	}
-
-	if isMapped {
-		valid, err := filesystem.PathValid(context.Background(), remotePath)
-		if err != nil {
-			klog.Warningf("PathValid(%s) failed with %v, ignore error", remotePath, err)
-		}
-
-		if !valid {
-			klog.Warningf("RemotePath %s is not valid, removing now", remotePath)
-			if err := mounter.smbAPI.RemoveSmbGlobalMapping(remotePath); err != nil {
-				klog.Errorf("RemoveSmbGlobalMapping(%s) failed with %v", remotePath, err)
-				return err
-			}
-			isMapped = false
-		}
-	}
-
-	if !isMapped {
-		klog.V(2).Infof("Remote %s not mapped. Mapping now!", remotePath)
-		username := mountOptions[0]
-		password := sensitiveMountOptions[0]
-		if err := mounter.smbAPI.NewSmbGlobalMapping(remotePath, username, password); err != nil {
-			klog.Errorf("NewSmbGlobalMapping(%s) failed with %v", remotePath, err)
-			return err
-		}
+	creds := func() (string, string, error) { return mountOptions[0], sensitiveMountOptions[0], nil }
+	if err := mounter.revalidateSMBMapping(remotePath, creds); err != nil {
+		return err
 	}
 
 	if len(localPath) != 0 {
@@ -127,6 +100,66 @@ func (mounter *winMounter) SMBMount(source, target, fsType string, mountOptions,
 	}
 	klog.V(2).Infof("mount %s on %s successfully", source, normalizedTarget)
 	return nil
+}
+
+// probeSMBMapping reports whether a node-global SMB mapping for remotePath exists
+// (isMapped) and, if so, whether it is still usable (valid). Both checks are local and
+// read-only; a PathValid error is treated as not-valid so a disconnected session heals
+// rather than being trusted.
+func (mounter *winMounter) probeSMBMapping(remotePath string) (isMapped, valid bool) {
+	mapped, err := mounter.smbAPI.IsSmbMapped(remotePath)
+	if err != nil {
+		klog.Errorf("IsSmbMapped(%s) failed with %v", remotePath, err)
+		return false, false
+	}
+	if !mapped {
+		return false, false
+	}
+	ok, err := filesystem.PathValid(context.Background(), remotePath)
+	if err != nil {
+		klog.Warningf("PathValid(%s) failed with %v, treating mapping as not valid", remotePath, err)
+		return true, false
+	}
+	return true, ok
+}
+
+// revalidateSMBMapping ensures the node-global SMB mapping backing remotePath is alive:
+// it removes and recreates a stale mapping, creates a missing one, and is a no-op when the
+// mapping is already healthy. getCredentials is invoked only when a (re)mapping is actually
+// required, so callers on the hot path pay no credential-resolution cost while the mapping
+// is healthy. It does NOT create the staging symlink (see SMBMount).
+func (mounter *winMounter) revalidateSMBMapping(remotePath string, getCredentials func() (string, string, error)) error {
+	if remotePath == "" {
+		return fmt.Errorf("remote path is empty")
+	}
+	isMapped, valid := mounter.probeSMBMapping(remotePath)
+	if isMapped && valid {
+		return nil
+	}
+	if isMapped {
+		klog.Warningf("RemotePath %s is not valid, removing now", remotePath)
+		if err := mounter.smbAPI.RemoveSmbGlobalMapping(remotePath); err != nil {
+			return fmt.Errorf("RemoveSmbGlobalMapping(%s) failed: %w", remotePath, err)
+		}
+	}
+	username, password, err := getCredentials()
+	if err != nil {
+		return err
+	}
+	klog.V(2).Infof("(re)mapping remote %s", remotePath)
+	if err := mounter.smbAPI.NewSmbGlobalMapping(remotePath, username, password); err != nil {
+		return fmt.Errorf("NewSmbGlobalMapping(%s) failed: %w", remotePath, err)
+	}
+	return nil
+}
+
+// RevalidateSMBMount revalidates (and, if needed, remaps) the node-global SMB mapping
+// backing remotePath, resolving credentials lazily via getCredentials only when a remap is
+// required. It is invoked from the per-pod publish path so that a stale mapping is repaired
+// before a new pod (e.g. one using subPath) re-traverses the share.
+func (mounter *winMounter) RevalidateSMBMount(remotePath string, getCredentials func() (string, string, error)) error {
+	remotePath = strings.Replace(remotePath, "/", "\\", -1)
+	return mounter.revalidateSMBMapping(remotePath, getCredentials)
 }
 
 // Mount just creates a soft link at target pointing to source.

--- a/pkg/mounter/safe_mounter_host_process_windows_test.go
+++ b/pkg/mounter/safe_mounter_host_process_windows_test.go
@@ -1,0 +1,110 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mounter
+
+import (
+	"fmt"
+	"testing"
+)
+
+// fakeSMBAPI is a programmable smb.SMBAPI used to exercise the host-process
+// mounter self-heal logic without touching real PowerShell/SMB.
+type fakeSMBAPI struct {
+	mapped        bool
+	isMappedErr   error
+	newCalled     int
+	newErr        error
+	removeCalled  int
+	removeErr     error
+	lastNewRemote string
+	lastNewUser   string
+	lastNewPass   string
+}
+
+func (f *fakeSMBAPI) IsSmbMapped(_ string) (bool, error) {
+	return f.mapped, f.isMappedErr
+}
+
+func (f *fakeSMBAPI) NewSmbGlobalMapping(remotePath, username, password string) error {
+	f.newCalled++
+	f.lastNewRemote = remotePath
+	f.lastNewUser = username
+	f.lastNewPass = password
+	return f.newErr
+}
+
+func (f *fakeSMBAPI) RemoveSmbGlobalMapping(_ string) error {
+	f.removeCalled++
+	return f.removeErr
+}
+
+func okCreds() func() (string, string, error) {
+	return func() (string, string, error) { return "AZURE\\acc", "key==", nil }
+}
+
+func TestRevalidateSMBMount_NotMappedRemaps(t *testing.T) {
+	api := &fakeSMBAPI{mapped: false}
+	m := &winMounter{smbAPI: api}
+
+	// remotePath with forward slashes should be normalized to backslashes.
+	err := m.RevalidateSMBMount("//acc.file.core.windows.net/share", okCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.newCalled != 1 {
+		t.Fatalf("expected NewSmbGlobalMapping to be called once, got %d", api.newCalled)
+	}
+	if api.removeCalled != 0 {
+		t.Fatalf("expected RemoveSmbGlobalMapping not to be called, got %d", api.removeCalled)
+	}
+	if api.lastNewRemote != `\\acc.file.core.windows.net\share` {
+		t.Fatalf("remotePath not normalized, got %q", api.lastNewRemote)
+	}
+	if api.lastNewUser != "AZURE\\acc" || api.lastNewPass != "key==" {
+		t.Fatalf("unexpected creds: user=%q pass=%q", api.lastNewUser, api.lastNewPass)
+	}
+}
+
+func TestRevalidateSMBMount_NewMappingError(t *testing.T) {
+	api := &fakeSMBAPI{mapped: false, newErr: fmt.Errorf("boom")}
+	m := &winMounter{smbAPI: api}
+	if err := m.RevalidateSMBMount(`\\acc.file.core.windows.net\share`, okCreds()); err == nil {
+		t.Fatalf("expected error from NewSmbGlobalMapping, got nil")
+	}
+}
+
+func TestRevalidateSMBMount_CredentialError(t *testing.T) {
+	api := &fakeSMBAPI{mapped: false}
+	m := &winMounter{smbAPI: api}
+	creds := func() (string, string, error) { return "", "", fmt.Errorf("no creds") }
+	if err := m.RevalidateSMBMount(`\\acc.file.core.windows.net\share`, creds); err == nil {
+		t.Fatalf("expected credential error to propagate, got nil")
+	}
+	if api.newCalled != 0 {
+		t.Fatalf("expected no remap when credentials fail, got %d", api.newCalled)
+	}
+}
+
+func TestRevalidateSMBMapping_EmptyPath(t *testing.T) {
+	m := &winMounter{smbAPI: &fakeSMBAPI{}}
+	if err := m.revalidateSMBMapping("", okCreds()); err == nil {
+		t.Fatalf("expected error for empty remote path, got nil")
+	}
+}

--- a/pkg/mounter/safe_mounter_v1beta_windows.go
+++ b/pkg/mounter/safe_mounter_v1beta_windows.go
@@ -91,6 +91,12 @@ func (mounter *csiProxyMounterV1Beta) SMBMount(source, target, fsType string, mo
 	return nil
 }
 
+// RevalidateSMBMount is a no-op for the csi-proxy v1beta mounter; the publish-path
+// self-heal is only implemented for the host-process mounter.
+func (mounter *csiProxyMounterV1Beta) RevalidateSMBMount(_ string, _ func() (string, string, error)) error {
+	return nil
+}
+
 // Mount just creates a soft link at target pointing to source.
 func (mounter *csiProxyMounterV1Beta) Mount(source string, target string, fstype string, options []string) error {
 	klog.V(4).Infof("Mount: old name: %s. new name: %s", source, target)

--- a/pkg/mounter/safe_mounter_windows.go
+++ b/pkg/mounter/safe_mounter_windows.go
@@ -42,6 +42,10 @@ type CSIProxyMounter interface {
 	mount.Interface
 
 	SMBMount(source, target, fsType string, mountOptions, sensitiveMountOptions []string) error
+	// RevalidateSMBMount revalidates and, if needed, remaps the node-global SMB mapping
+	// backing remotePath (without creating a staging symlink), resolving credentials
+	// lazily via getCredentials only when a remap is required.
+	RevalidateSMBMount(remotePath string, getCredentials func() (username, password string, err error)) error
 	MakeDir(path string) error
 	Rmdir(path string) error
 	IsMountPointMatch(mp mount.MountPoint, dir string) bool
@@ -98,6 +102,12 @@ func (mounter *csiProxyMounter) SMBMount(source, target, fsType string, mountOpt
 		return fmt.Errorf("smb mapping failed with error: %v", err)
 	}
 	klog.V(2).Infof("mount %s on %s successfully", source, normalizedTarget)
+	return nil
+}
+
+// RevalidateSMBMount is a no-op for the csi-proxy mounter; the publish-path self-heal
+// is only implemented for the host-process mounter.
+func (mounter *csiProxyMounter) RevalidateSMBMount(_ string, _ func() (string, string, error)) error {
 	return nil
 }
 

--- a/pkg/os/filesystem/filesystem.go
+++ b/pkg/os/filesystem/filesystem.go
@@ -25,12 +25,27 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
 	"golang.org/x/sys/windows"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/azurefile-csi-driver/pkg/util"
 )
+
+// pathValidDefaultTimeout bounds the GetFileAttributes probe in PathValid. A UNC path
+// backed by a dead SMB session can make GetFileAttributes block; without a bound a
+// single wedged connection could stall NodeStage/NodePublish indefinitely.
+const pathValidDefaultTimeout = 30 * time.Second
+
+// pathValidGroup deduplicates concurrent PathValid probes for the same path. When the
+// underlying GetFileAttributes call against a wedged UNC path blocks past the timeout,
+// the probing goroutine cannot be cancelled (the Windows syscall is not interruptible).
+// singleflight ensures at most one such goroutine is in flight per path, so repeated
+// kubelet retries against the same dead session reuse the in-flight probe instead of
+// accumulating unbounded blocked goroutines.
+var pathValidGroup singleflight.Group
 
 var invalidPathCharsRegexWindows = regexp.MustCompile(`["/\:\?\*|]`)
 var absPathRegexWindows = regexp.MustCompile(`^[a-zA-Z]:\\`)
@@ -85,8 +100,46 @@ func PathExists(path string) (bool, error) {
 	return pathExists(path)
 }
 
-func PathValid(_ context.Context, path string) (bool, error) {
+func PathValid(ctx context.Context, path string) (bool, error) {
 	klog.V(6).Infof("PathValid called with path: %s", path)
+
+	// Bound the probe: GetFileAttributes against a UNC path whose SMB session is dead
+	// can block, so run it on a goroutine and honor the context deadline. If the caller
+	// did not supply a deadline, apply a default one.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, pathValidDefaultTimeout)
+		defer cancel()
+	}
+
+	type result struct {
+		valid bool
+		err   error
+	}
+	// Deduplicate the actual probe per path via singleflight so concurrent callers
+	// (and rapid kubelet retries) share a single in-flight GetFileAttributes goroutine.
+	// This bounds the number of goroutines that can be left blocked on a wedged UNC path
+	// to at most one per path. resultCh is buffered so the worker can always send and
+	// exit once the (possibly delayed) syscall finally returns, even after we time out.
+	resultCh := make(chan result, 1)
+	go func() {
+		v, _, _ := pathValidGroup.Do(path, func() (interface{}, error) {
+			valid, err := getPathAttributesValid(path)
+			return result{valid: valid, err: err}, nil
+		})
+		resultCh <- v.(result)
+	}()
+
+	select {
+	case <-ctx.Done():
+		klog.Warningf("PathValid(%s) timed out or was cancelled: %v", path, ctx.Err())
+		return false, fmt.Errorf("PathValid(%s) timed out: %w", path, ctx.Err())
+	case r := <-resultCh:
+		return r.valid, r.err
+	}
+}
+
+func getPathAttributesValid(path string) (bool, error) {
 	pathString, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		klog.V(6).Infof("failed to convert path %s to UTF16: %v", path, err)

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -341,6 +341,42 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test.Run(ctx, cs, ns)
 	})
 
+	ginkgo.It("should self-heal a stale node-global SMB session for newly created subPath pods [file.csi.azure.com] [Windows]", func(ctx ginkgo.SpecContext) {
+		skipIfUsingInTreeVolumePlugin()
+		if !isWindowsCluster {
+			ginkgo.Skip("stale node-global SMB session self-heal only applies to Windows nodes")
+		}
+
+		pod := testsuites.PodDetails{
+			Cmd: convertToPowershellCommandIfNecessary("echo 'hello world' >> /mnt/test-1/data && while true; do sleep 3600; done"),
+			Volumes: []testsuites.VolumeDetails{
+				{
+					ClaimSize:   "100Gi",
+					AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+			IsWindows:    isWindowsCluster,
+			WinServerVer: winServerVer,
+		}
+
+		scParameters := map[string]string{
+			"skuName":         "Standard_LRS",
+			"secretNamespace": "kube-system",
+			"shareNamePrefix": "stalesmb",
+		}
+		test := testsuites.DynamicallyProvisionedStaleSMBSubpathTester{
+			CSIDriver:              testDriver,
+			Pod:                    pod,
+			StorageClassParameters: scParameters,
+			WinServerVer:           winServerVer,
+		}
+		test.Run(ctx, cs, ns)
+	})
+
 	ginkgo.It("should create multiple PV objects, bind to PVCs and attach all to different pods on the same node [kubernetes.io/azure-file] [file.csi.azure.com] [Windows]", func(ctx ginkgo.SpecContext) {
 		pods := []testsuites.PodDetails{
 			{

--- a/test/e2e/testsuites/dynamically_provisioned_stale_smb_subpath_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_stale_smb_subpath_tester.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+
+	"sigs.k8s.io/azurefile-csi-driver/test/e2e/driver"
+
+	"github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// staleSMBChaosCommand removes every node-global SMB mapping on the node, simulating a
+// stale/invalidated SMB session (credential rotation, idle/NAT teardown, storage
+// maintenance, etc.) without replacing the node. It is best-effort and always exits 0.
+const staleSMBChaosCommand = `try { Get-SmbGlobalMapping | Remove-SmbGlobalMapping -Force -ErrorAction SilentlyContinue } catch {}; exit 0`
+
+// DynamicallyProvisionedStaleSMBSubpathTester verifies the Windows self-heal for stale
+// node-global SMB sessions on the per-pod publish path.
+//
+// Scenario:
+//  1. Pod A mounts a subPath of an SMB share and keeps running. This establishes the
+//     node-global SMB mapping and keeps the volume staged (so kubelet does not unstage
+//     when a single pod is replaced).
+//  2. A HostProcess "chaos" pod on the same node tears down the node-global SMB
+//     mapping. Pod A survives on its already-open handles.
+//  3. Pod B is created on the same node and mounts a (different) subPath of the same
+//     share. Before the fix, Pod B fails with "failed to prepare subPath for
+//     volumeMount" because NodePublishVolume binds against the dead session and never
+//     re-validates it; only node replacement recovers. With the fix, NodePublishVolume
+//     detects the missing/stale mapping, remaps it, and Pod B reaches Running.
+type DynamicallyProvisionedStaleSMBSubpathTester struct {
+	CSIDriver              driver.DynamicPVTestDriver
+	Pod                    PodDetails
+	StorageClassParameters map[string]string
+	WinServerVer           string
+}
+
+func (t *DynamicallyProvisionedStaleSMBSubpathTester) Run(ctx context.Context, client clientset.Interface, namespace *v1.Namespace) {
+	if len(t.Pod.Volumes) == 0 {
+		framework.Failf("DynamicallyProvisionedStaleSMBSubpathTester requires at least one volume")
+	}
+	volume := t.Pod.Volumes[0]
+
+	// Provision a single shared PVC up front so both pods reference the same staged volume.
+	tpvc, cleanupFuncs := volume.SetupDynamicPersistentVolumeClaim(ctx, client, namespace, t.CSIDriver, t.StorageClassParameters)
+	for i := range cleanupFuncs {
+		defer cleanupFuncs[i](ctx)
+	}
+	pvc := tpvc.persistentVolumeClaim
+
+	ginkgo.By("deploying pod A which establishes the node-global SMB mount")
+	podA := NewTestPod(client, namespace, t.Pod.Cmd, t.Pod.IsWindows, t.WinServerVer)
+	podA.SetupVolumeMountWithSubpath(pvc, "stale-smb-volume", "/mnt/test-1", "stalesubpath-a", false)
+	podA.Create(ctx)
+	defer podA.Cleanup(ctx)
+	podA.WaitForRunning(ctx)
+
+	nodeName := podA.GetNodeName(ctx)
+	gomegaExpectNonEmptyNode(nodeName)
+
+	ginkgo.By("invalidating the node-global SMB session on node " + nodeName + " via a HostProcess chaos pod")
+	chaos := NewTestPod(client, namespace, staleSMBChaosCommand, true, t.WinServerVer)
+	chaos.SetHostProcess()
+	chaos.SetNodeName(nodeName)
+	chaos.Create(ctx)
+	defer chaos.Cleanup(ctx)
+	chaos.WaitForSuccess(ctx)
+
+	ginkgo.By("deploying pod B on the same node after the SMB session was invalidated; it must self-heal and reach Running")
+	podB := NewTestPod(client, namespace, t.Pod.Cmd, t.Pod.IsWindows, t.WinServerVer)
+	podB.SetupVolumeMountWithSubpath(pvc, "stale-smb-volume", "/mnt/test-1", "stalesubpath-b", false)
+	podB.SetNodeName(nodeName)
+	podB.Create(ctx)
+	defer podB.Cleanup(ctx)
+	podB.WaitForRunning(ctx)
+}
+
+func gomegaExpectNonEmptyNode(nodeName string) {
+	if nodeName == "" {
+		framework.Failf("pod A was not scheduled to any node; cannot co-locate chaos and pod B")
+	}
+}

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -856,6 +856,34 @@ func (t *TestPod) SetNodeSelector(nodeSelector map[string]string) {
 	t.pod.Spec.NodeSelector = nodeSelector
 }
 
+// SetNodeName pins the pod to a specific node. Used to co-locate pods that must share
+// the same node-global SMB mount.
+func (t *TestPod) SetNodeName(nodeName string) {
+	t.pod.Spec.NodeName = nodeName
+}
+
+// GetNodeName returns the node the pod was scheduled on (after Create).
+func (t *TestPod) GetNodeName(ctx context.Context) string {
+	pod, err := t.client.CoreV1().Pods(t.namespace.Name).Get(ctx, t.pod.Name, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	return pod.Spec.NodeName
+}
+
+// SetHostProcess turns the pod into a Windows HostProcess pod running as
+// NT AUTHORITY\SYSTEM with host networking, which is required to manipulate the
+// node-global SMB sessions that the CSI driver (also a HostProcess) creates.
+func (t *TestPod) SetHostProcess() {
+	hostProcess := true
+	userName := "NT AUTHORITY\\SYSTEM"
+	t.pod.Spec.SecurityContext = &v1.PodSecurityContext{
+		WindowsOptions: &v1.WindowsSecurityContextOptions{
+			HostProcess:   &hostProcess,
+			RunAsUserName: &userName,
+		},
+	}
+	t.pod.Spec.HostNetwork = true
+}
+
 func (t *TestPod) Cleanup(ctx context.Context) {
 	cleanupPodOrFail(ctx, t.client, t.pod.Name, t.namespace.Name)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

On **Windows** node pools, a newly created pod that mounts an Azure File (SMB) volume
with `subPath` fails at startup once the node-global SMB session (created by
`New-SmbGlobalMapping` during `NodeStageVolume`) has gone stale or been torn down
(credential rotation, idle/NAT teardown, storage maintenance, etc.):

```
MountVolume.SetUp failed ... failed to prepare subPath for volumeMount "..." : Access is denied.
```

`NodeStageVolume` runs only once per volume per node, so its existing self-heal
(`IsSmbMapped` → `PathValid` → `RemoveSmbGlobalMapping` → `New-SmbGlobalMapping`) never
re-runs for subsequently created pods. Those new pods re-traverse the share (e.g. kubelet's
subPath preparation) against the dead session and fail until the node is replaced. Existing
pods keep working on already-open handles, which makes the failure look intermittent.

This PR invokes the same self-heal on the per-pod `NodePublishVolume` path:

- `NodePublishVolume` now probes the node-global SMB mapping backing the staged source
  (cheap, read-only) and, only when it is proven stale/missing, resolves credentials and
  remaps before the bind/symlink. Healthy publishes and co-tenant pods on the same share
  are unaffected (credentials are resolved lazily, only when a remap is actually needed).
- Revalidation is **serialized per node-global SMB mapping** (keyed by the UNC remotePath)
  so concurrent `NodePublishVolume` calls cannot race `RemoveSmbGlobalMapping` +
  `New-SmbGlobalMapping` and clobber each other's mapping.
- `PathValid` now bounds its `GetFileAttributes` probe with a timeout (a wedged UNC path can
  block indefinitely) and deduplicates concurrent probes per path via `singleflight`, so
  repeated kubelet retries against a dead session cannot accumulate blocked goroutines.
- The shared probe logic is factored into a single helper reused by both the stage and
  publish paths.

The change is **Windows-only** in effect (`readStagedRemotePath` returns empty on
Linux/Darwin, making the new path a no-op there).

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

- New host-process mounter unit tests cover the remap, remap-error, credential-error and
  empty-path cases. Windows-tagged code is compile-checked via `GOOS=windows go vet`.
- A new Windows e2e spec (`should self-heal a stale node-global SMB session for newly
  created subPath pods`) reproduces the failure: it invalidates the node-global mapping
  with a hostprocess `Remove-SmbGlobalMapping`, then deploys a fresh subPath pod and asserts
  it self-heals and reaches Running.
- Validated end-to-end on a Windows Server 2022 AKS node pool: the focused Windows e2e suite
  (mount-options / subpath / self-heal / deployment write-read) passes with no regression,
  and a stock build reproduces the exact customer error under the same scenario.

**Release note**:
```
Fix Azure File (SMB) subPath mount failures ("failed to prepare subPath ... Access is denied") for newly created pods on Windows nodes after the node-global SMB session goes stale, by revalidating and, if needed, remapping the SMB session on NodePublishVolume.
```
