### PR TITLE
doc: add oauth value for useDataPlaneAPI parameter

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -69,7 +69,7 @@ storeAccountKey | Should the storage account key be stored in a Kubernetes secre
 getLatestAccountKey | whether getting the latest account key based on the creation time, this driver would get the first key by default | `true`,`false` | No | `false`
 secretName | specify secret name to store account key | | No |
 secretNamespace | specify the namespace of secret to store account key | `default`,`kube-system`, etc | No | pvc namespace (`csi.storage.k8s.io/pvc/namespace`)
-useDataPlaneAPI | specify whether use [data plane API](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/share.go) for file share create/delete/resize, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account | `true`,`false` | No | `false`
+useDataPlaneAPI | specify whether use [data plane API](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/share.go) for file share create/delete/resize, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account. `oauth` value is supported from v1.33.0, which uses OAuth token for data plane API authentication | `true`,`false`,`oauth` | No | `false`
 enableMultichannel | specify whether enable [SMB multi-channel](https://learn.microsoft.com/en-us/azure/storage/files/files-smb-protocol?tabs=azure-portal#smb-multichannel) for **Premium** storage account <br> Note: this feature is used with `max_channels=4` (or 2,3) mount option | `true`,`false` | No | `false`
 clientID | Specify the Azure client ID that will be used to create the Azure file share | Azure client ID | No | If left empty, the kubelet managed identity will be used when mounting without an account key
 --- | **Following parameters are only for NFS protocol** | --- | --- |
@@ -139,7 +139,7 @@ kubectl create secret generic azure-storage-account-{accountname}-secret --from-
 
 Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
-useDataPlaneAPI | specify whether use [data plane API](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/share.go) for snapshot create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account | `true`,`false` | No | `false`
+useDataPlaneAPI | specify whether use [data plane API](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/share.go) for snapshot create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account. `oauth` value is supported from v1.33.0, which uses OAuth token for data plane API authentication | `true`,`false`,`oauth` | No | `false`
 
 ### `VolumeAttributesClass`
 

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -69,7 +69,7 @@ storeAccountKey | Should the storage account key be stored in a Kubernetes secre
 getLatestAccountKey | whether getting the latest account key based on the creation time, this driver would get the first key by default | `true`,`false` | No | `false`
 secretName | specify secret name to store account key | | No |
 secretNamespace | specify the namespace of secret to store account key | `default`,`kube-system`, etc | No | pvc namespace (`csi.storage.k8s.io/pvc/namespace`)
-useDataPlaneAPI | specify whether use [data plane API](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/share.go) for file share create/delete/resize, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account. `oauth` value is supported from v1.33.0, which uses OAuth token for data plane API authentication | `true`,`false`,`oauth` | No | `false`
+useDataPlaneAPI | specify whether use [data plane API](https://learn.microsoft.com/en-us/rest/api/storageservices/file-service-rest-api) for file share create/delete/resize, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account. `oauth` value is supported from v1.33.0, which uses OAuth token for data plane API authentication | `true`,`false`,`oauth` | No | `false`
 enableMultichannel | specify whether enable [SMB multi-channel](https://learn.microsoft.com/en-us/azure/storage/files/files-smb-protocol?tabs=azure-portal#smb-multichannel) for **Premium** storage account <br> Note: this feature is used with `max_channels=4` (or 2,3) mount option | `true`,`false` | No | `false`
 clientID | Specify the Azure client ID that will be used to create the Azure file share | Azure client ID | No | If left empty, the kubelet managed identity will be used when mounting without an account key
 --- | **Following parameters are only for NFS protocol** | --- | --- |
@@ -139,7 +139,7 @@ kubectl create secret generic azure-storage-account-{accountname}-secret --from-
 
 Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
-useDataPlaneAPI | specify whether use [data plane API](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/share.go) for snapshot create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account. `oauth` value is supported from v1.33.0, which uses OAuth token for data plane API authentication | `true`,`false`,`oauth` | No | `false`
+useDataPlaneAPI | specify whether use [data plane API](https://learn.microsoft.com/en-us/rest/api/storageservices/file-service-rest-api) for snapshot create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account. `oauth` value is supported from v1.33.0, which uses OAuth token for data plane API authentication | `true`,`false`,`oauth` | No | `false`
 
 ### `VolumeAttributesClass`
 


### PR DESCRIPTION
Add documentation for the `oauth` value of `useDataPlaneAPI` parameter which is supported from v1.33.0.

## Changes
- Updated `useDataPlaneAPI` parameter in Dynamic Provisioning section to include `oauth` as a valid value
- Updated `useDataPlaneAPI` parameter in VolumeSnapshotClass section to include `oauth` as a valid value
- Added note that `oauth` value is supported from v1.33.0, which uses OAuth token for data plane API authentication

/kind documentation