### PR TITLE
cleanup: add validation on volumeid

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -566,6 +566,9 @@ func GetFileShareInfo(id string) (string, string, string, string, string, string
 	var diskName, namespace, subsID string
 	if len(segments) > 3 {
 		diskName = segments[3]
+		if err := validateVolumeIDSegment("diskName", diskName); err != nil {
+			return "", "", "", "", "", "", err
+		}
 	}
 	if rg == "" {
 		// in csi migration, rg could be empty, then the 5th element is namespace
@@ -581,7 +584,29 @@ func GetFileShareInfo(id string) (string, string, string, string, string, string
 			subsID = segments[6]
 		}
 	}
+	if err := validateVolumeIDSegment("namespace", namespace); err != nil {
+		return "", "", "", "", "", "", err
+	}
 	return rg, segments[1], segments[2], diskName, namespace, subsID, nil
+}
+
+// validateVolumeIDSegment rejects volume id segments that contain path
+// traversal sequences ("..") so that segments parsed out of a CSI volume id
+// cannot be used to construct unsafe filesystem paths (e.g. when diskName is
+// joined with the CIFS mount path during VHD-on-Azure-File staging).
+func validateVolumeIDSegment(field, value string) error {
+	if value == "" {
+		return nil
+	}
+	segments := strings.FieldsFunc(value, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	for _, segment := range segments {
+		if segment == ".." {
+			return fmt.Errorf("invalid %s %q: contains directory traversal sequence", field, value)
+		}
+	}
+	return nil
 }
 
 // get snapshot info according to snapshot id, e.g.

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -397,6 +397,26 @@ func TestGetFileShareInfo(t *testing.T) {
 			subsID:            "",
 			expectedError:     nil,
 		},
+		{
+			id:                "rg#f5713de20cde511e8ba4900#fileShareName#../../etc/shadow#uuid#namespace",
+			resourceGroupName: "",
+			accountName:       "",
+			fileShareName:     "",
+			diskName:          "",
+			namespace:         "",
+			subsID:            "",
+			expectedError:     fmt.Errorf("invalid diskName %q: contains directory traversal sequence", "../../etc/shadow"),
+		},
+		{
+			id:                "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#../../evil",
+			resourceGroupName: "",
+			accountName:       "",
+			fileShareName:     "",
+			diskName:          "",
+			namespace:         "",
+			subsID:            "",
+			expectedError:     fmt.Errorf("invalid namespace %q: contains directory traversal sequence", "../../evil"),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds additional input validation when parsing CSI volume IDs to reduce the risk of unsafe filesystem path construction.

Changes:
- Add traversal validation for the `diskName` and `namespace` segments in `GetFileShareInfo()`.
- Add unit tests ensuring `diskName` and `namespace` path traversal sequences (e.g. `../../...`) are rejected.

**Which issue(s) this PR fixes**:
NONE

**Requirements**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
NONE
```