### PR TITLE
fix: managed identity mount fails when using private endpoint

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -489,9 +489,12 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			sensitiveMountOptions = []string{"sec=krb5,cruid=0,upcall_target=mount"}
 			klog.V(2).Infof("using workload identity token for volume %s with mount options: %v", volumeID, sensitiveMountOptions)
 			if tokenFilePath != "" {
+				// Kerberos SPN must be the canonical <account>.file.<suffix>; the CIFS
+				// mount source below still uses `server` (which may be privatelink).
+				krbHost := getKerberosHost(server)
 				// always set credential cache when token file is provided even mount does not happen
-				if out, err := setCredentialCache(server, clientID, tenantID, tokenFilePath, "", d.getActiveDirectoryEndpoint(), d.getStorageResource()); err != nil {
-					return nil, status.Errorf(codes.Internal, "setCredentialCache failed for %s with error: %v, output: %s", server, err, out)
+				if out, err := setCredentialCache(krbHost, clientID, tenantID, tokenFilePath, "", d.getActiveDirectoryEndpoint(), d.getStorageResource()); err != nil {
+					return nil, status.Errorf(codes.Internal, "setCredentialCache failed for %s with error: %v, output: %s", krbHost, err, out)
 				}
 			}
 		} else if mountWithOAuthToken && runtime.GOOS != "windows" {
@@ -568,8 +571,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		} else {
 			execFunc := func() error {
 				if mountWithManagedIdentity && protocol != nfs && runtime.GOOS != "windows" {
-					if out, err := setCredentialCache(server, clientID, tenantID, tokenFilePath, "", d.getActiveDirectoryEndpoint(), d.getStorageResource()); err != nil {
-						return fmt.Errorf("setCredentialCache failed for %s with error: %v, output: %s", server, err, out)
+					// Kerberos SPN must be the canonical <account>.file.<suffix>; the CIFS
+					// mount source below still uses `source` (which may be privatelink).
+					krbHost := getKerberosHost(server)
+					if out, err := setCredentialCache(krbHost, clientID, tenantID, tokenFilePath, "", d.getActiveDirectoryEndpoint(), d.getStorageResource()); err != nil {
+						return fmt.Errorf("setCredentialCache failed for %s with error: %v, output: %s", krbHost, err, out)
 					}
 				}
 				return SMBMount(d.mounter, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions)
@@ -918,6 +924,19 @@ func validateMountWithOAuthToken(protocol, fsType string, volumeContext map[stri
 	return nil
 }
 
+// getKerberosHost strips the ".privatelink" label from an Azure Files FQDN so
+// the Kerberos SPN matches the canonical <account>.file.<suffix> that Azure AD
+// (Entra) issues tickets for. The CIFS mount source is not changed; the
+// canonical name still resolves (via the privatelink private DNS zone) to the
+// private endpoint IP, so traffic keeps going through the private link.
+//
+// Callers should use this helper for anything passed to Kerberos (setCredentialCache,
+// SPN lookups) but keep the original server value for the CIFS mount source and
+// volume context.
+func getKerberosHost(server string) string {
+	return strings.Replace(server, ".privatelink.file.", ".file.", 1)
+}
+
 func (d *Driver) setCredentialCacheWithOAuthToken(ctx context.Context, volumeID string, volumeContext map[string]string) (string, error) {
 	secretName := getValueInMap(volumeContext, secretNameField)
 	if secretName == "" {
@@ -967,13 +986,14 @@ func (d *Driver) setCredentialCacheWithOAuthToken(ctx context.Context, volumeID 
 		return server, nil
 	}
 
-	if output, err := setCredentialCache(server, "", "", "", oauthToken, "", ""); err != nil {
-		klog.Errorf("setCredentialCache failed for %s with output: %s, error: %v", server, strings.ReplaceAll(string(output), oauthToken, "<redacted>"), err)
-		return "", status.Errorf(codes.Internal, "setCredentialCache failed for %s: %v", server, err)
+	krbHost := getKerberosHost(server)
+	if output, err := setCredentialCache(krbHost, "", "", "", oauthToken, "", ""); err != nil {
+		klog.Errorf("setCredentialCache failed for %s with output: %s, error: %v", krbHost, strings.ReplaceAll(string(output), oauthToken, "<redacted>"), err)
+		return "", status.Errorf(codes.Internal, "setCredentialCache failed for %s: %v", krbHost, err)
 	}
 
 	d.oauthTokenSHAMap.Store(server, tokenSHA)
-	klog.V(2).Infof("setCredentialCacheWithOAuthToken: refreshed credential cache for server %s using secret %s/%s", server, secretNamespace, secretName)
+	klog.V(2).Infof("setCredentialCacheWithOAuthToken: refreshed credential cache for server %s (SPN host %s) using secret %s/%s", server, krbHost, secretNamespace, secretName)
 	return server, nil
 }
 

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -1568,3 +1568,55 @@ func TestSetCredentialCacheWithOAuthToken(t *testing.T) {
 		})
 	}
 }
+
+func TestGetKerberosHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   string
+		expected string
+	}{
+		{
+			name:     "canonical name is unchanged",
+			server:   "acct.file.core.windows.net",
+			expected: "acct.file.core.windows.net",
+		},
+		{
+			name:     "privatelink name is canonicalized",
+			server:   "acct.privatelink.file.core.windows.net",
+			expected: "acct.file.core.windows.net",
+		},
+		{
+			name:     "privatelink in China cloud",
+			server:   "acct.privatelink.file.core.chinacloudapi.cn",
+			expected: "acct.file.core.chinacloudapi.cn",
+		},
+		{
+			name:     "privatelink in US government cloud",
+			server:   "acct.privatelink.file.core.usgovcloudapi.net",
+			expected: "acct.file.core.usgovcloudapi.net",
+		},
+		{
+			name:     "empty server",
+			server:   "",
+			expected: "",
+		},
+		{
+			name:     "custom endpoint without privatelink label",
+			server:   "acct.file.example.com",
+			expected: "acct.file.example.com",
+		},
+		{
+			name:     "only strips first .privatelink.file. occurrence",
+			server:   "acct.privatelink.file.privatelink.file.core.windows.net",
+			expected: "acct.file.privatelink.file.core.windows.net",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getKerberosHost(tc.server)
+			if got != tc.expected {
+				t.Errorf("getKerberosHost(%q) = %q, want %q", tc.server, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3245.

## What this PR does

When both `mountWithManagedIdentity: "true"` and a private endpoint
(`networkEndpointType: "privateEndpoint"`) are used on a dynamic StorageClass,
NodeStageVolume fails with:

```
setCredentialCache failed for <account>.privatelink.file.core.windows.net:
  Error calling AzAuthenticatorLib: -1
  Error getting Kerberos service ticket, check /var/log/syslog for more information.
```

### Root cause

`controllerserver.go` sets the volume `server` to the privatelink FQDN when a
private endpoint is provisioned:

```go
setKeyValueInMap(parameters, serverNameField,
    fmt.Sprintf("%s.privatelink.file.%s", accountName, storageEndpointSuffix))
```

`nodeserver.go` then passes that same string to `setCredentialCache`, so the
driver asks Azure AD Kerberos for a ticket against
`<account>.privatelink.file.core.windows.net`. Azure AD only issues tickets for
the canonical SPN `cifs/<account>.file.<suffix>`, so the request fails.

Static PVs work today because users write `server: <account>.file.core.windows.net`
themselves and rely on the private DNS zone to route the CIFS traffic through the
private endpoint.

### Fix

Introduce a `getKerberosHost(server)` helper that strips the `.privatelink`
label, and use it wherever we hand a hostname to `setCredentialCache`:

- `mountWithWIToken` branch (L488)
- `mountWithManagedIdentity` `execFunc` branch (L566)
- `setCredentialCacheWithOAuthToken` (L965)

The CIFS mount `source` and the volume context are unchanged. The canonical
name resolves (via the `privatelink.file.core.windows.net` private DNS zone
CNAME chain) to the private endpoint IP, so mount traffic still stays on the
private link.

## Test

New unit test `TestGetKerberosHost` covering:

- canonical name unchanged
- privatelink → canonical (public cloud)
- privatelink in China / US-gov sovereign clouds
- empty input
- custom endpoint suffix
- only the first `.privatelink.file.` is stripped

## Special notes for your reviewer

- No behavior change for accounts without a private endpoint (canonical name
  passes through untouched).
- Sovereign clouds are covered because the `.privatelink.file.` label is the
  same across public/China/US-gov.
- Suggest cherry-picking to `release-1.34` and `release-1.35` once merged.
