### PR TITLE
docs(charts): add GitHub Pages as alternate helm repo source

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -16,8 +16,26 @@
    - `--set linux.kubelet="/var/snap/microk8s/common/var/lib/kubelet"` - sets correct path to microk8s kubelet even though a user has a folder link to it.
 
 ### install a specific version
+
+Add the helm repo — pick **one** source (both host the same charts; the two commands share the repo name `azurefile-csi-driver`, so running the second after the first will fail unless you pass `--force-update`):
+
+Option 1: raw.githubusercontent.com (default)
+
 ```console
 helm repo add azurefile-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/charts
+```
+
+Option 2: GitHub Pages mirror (available since 1.34.5, not affected by raw.githubusercontent.com rate limits)
+
+```console
+helm repo add azurefile-csi-driver https://kubernetes-sigs.github.io/azurefile-csi-driver
+```
+
+Then update the repo cache, search for available versions, and install:
+
+```console
+helm repo update azurefile-csi-driver
+helm search repo azurefile-csi-driver --versions
 helm install azurefile-csi-driver azurefile-csi-driver/azurefile-csi-driver --namespace kube-system --version 1.35.6
 ```
 


### PR DESCRIPTION
## What this PR does

Documents `https://kubernetes-sigs.github.io/azurefile-csi-driver` as an alternate helm repository source alongside the existing `raw.githubusercontent.com` source in `charts/README.md`.

Both sources host the same charts. The GitHub Pages mirror is not affected by `raw.githubusercontent.com` rate limits and is available starting from chart version **1.34.5** (the first version published by the workflow added in #3294).

## Why

`raw.githubusercontent.com` is aggressively rate-limited from shared IPs (CI runners, corporate NAT, etc.). Offering a GitHub Pages mirror gives users an unrate-limited alternative without breaking the existing installation path.

## Changes

- `charts/README.md`: replace the single `helm repo add` block under **install a specific version** with two separate code blocks (one per source), plus an explicit "pick **one**" note so users don't accidentally run both (since `helm repo add` with an existing repo name errors out unless `--force-update` is passed).
- Also add `helm repo update azurefile-csi-driver` + `helm search repo azurefile-csi-driver --versions` to the install snippet for consistency.

Mirrors kubernetes-sigs/blob-csi-driver#2593.

/kind documentation
/sig storage
/assign @andyzhangx
