### PR TITLE
[release-1.35] fix: ephemeral inline volume improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	google.golang.org/protobuf v1.36.11
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
+	k8s.io/apiserver v0.35.0
 	k8s.io/client-go v0.35.0
 	k8s.io/cloud-provider v0.35.0
 	k8s.io/component-base v0.35.0
@@ -144,7 +145,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
-	k8s.io/apiserver v0.35.0 // indirect
 	k8s.io/component-helpers v0.35.0 // indirect
 	k8s.io/controller-manager v0.35.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -143,6 +143,10 @@ const (
 	provisionedIopsField              = "provisionediops"
 	falseValue                        = "false"
 	trueValue                         = "true"
+	// inline volume secret authorization modes
+	inlineVolumeSecretAuthzOff        = "off"
+	inlineVolumeSecretAuthzWarn       = "warn"
+	inlineVolumeSecretAuthzEnforce    = "enforce"
 	defaultSecretAccountName          = "azurestorageaccountname"
 	defaultSecretAccountKey           = "azurestorageaccountkey"
 	proxyMount                        = "proxy-mount"
@@ -269,6 +273,7 @@ type Driver struct {
 	fsGroupChangePolicy                    string
 	allowEmptyCloudConfig                  bool
 	allowInlineVolumeKeyAccessWithIdentity bool
+	inlineVolumeSecretAuthz                string
 	enableVHDDiskFeature                   bool
 	enableGetVolumeStats                   bool
 	enableVolumeMountGroup                 bool
@@ -350,6 +355,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	driver.userAgentSuffix = options.UserAgentSuffix
 	driver.allowEmptyCloudConfig = options.AllowEmptyCloudConfig
 	driver.allowInlineVolumeKeyAccessWithIdentity = options.AllowInlineVolumeKeyAccessWithIdentity
+	driver.inlineVolumeSecretAuthz = options.InlineVolumeSecretAuthz
 	driver.enableVHDDiskFeature = options.EnableVHDDiskFeature
 	driver.enableVolumeMountGroup = options.EnableVolumeMountGroup
 	driver.enableGetVolumeStats = options.EnableGetVolumeStats

--- a/pkg/azurefile/azurefile_options.go
+++ b/pkg/azurefile/azurefile_options.go
@@ -30,6 +30,7 @@ type DriverOptions struct {
 	UserAgentSuffix                        string
 	AllowEmptyCloudConfig                  bool
 	AllowInlineVolumeKeyAccessWithIdentity bool
+	InlineVolumeSecretAuthz                string
 	EnableVHDDiskFeature                   bool
 	EnableVolumeMountGroup                 bool
 	EnableGetVolumeStats                   bool
@@ -71,6 +72,7 @@ func (o *DriverOptions) AddFlags() *flag.FlagSet {
 	fs.StringVar(&o.UserAgentSuffix, "user-agent-suffix", "", "userAgent suffix")
 	fs.BoolVar(&o.AllowEmptyCloudConfig, "allow-empty-cloud-config", true, "allow running driver without cloud config")
 	fs.BoolVar(&o.AllowInlineVolumeKeyAccessWithIdentity, "allow-inline-volume-key-access-with-identity", false, "allow accessing storage account key using cluster identity for inline volume")
+	fs.StringVar(&o.InlineVolumeSecretAuthz, "inline-volume-secret-authz", "off", "authorize inline volume Secret references via SubjectAccessReview before mount: off|warn|enforce")
 	fs.BoolVar(&o.EnableVHDDiskFeature, "enable-vhd", true, "enable VHD disk feature (experimental)")
 	fs.BoolVar(&o.EnableVolumeMountGroup, "enable-volume-mount-group", true, "indicates whether enabling VOLUME_MOUNT_GROUP")
 	fs.BoolVar(&o.EnableGetVolumeStats, "enable-get-volume-stats", true, "allow GET_VOLUME_STATS on agent node")

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -31,6 +31,10 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	volume "github.com/kata-containers/kata-containers/src/runtime/pkg/direct-volume"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume/util"
 
@@ -84,24 +88,29 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	mountPermissions := d.mountPermissions
 	context := req.GetVolumeContext()
 	if context != nil {
-		if getValueInMap(context, serviceAccountTokenField) != "" && shouldUseServiceAccountToken(context) {
-			if d.canSkipRepublishNodeStage(context, target) {
-				klog.V(2).Infof("NodePublishVolume: volume(%s) already mounted on %s with clientID auth, skipping NodeStageVolume (no time-bound credential to refresh)", volumeID, target)
-				return &csi.NodePublishVolumeResponse{}, nil
-			}
-			klog.V(2).Infof("NodePublishVolume: volume(%s) mount on %s with service account token, clientID: %s, mountWithWIToken: %s", volumeID, target, getValueInMap(context, clientIDField), getValueInMap(context, mountWithWITokenField))
-			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
-				StagingTargetPath: target,
-				VolumeContext:     context,
-				VolumeCapability:  volCap,
-				VolumeId:          volumeID,
-			})
-			return &csi.NodePublishVolumeResponse{}, err
-		}
-
-		// ephemeral volume
 		if strings.EqualFold(context[ephemeralField], trueValue) {
+			// Reject case duplicate keys
+			if key, ok := caseCollidingKey(context); ok {
+				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ephemeral volume request contains case-colliding volume attribute keys that normalize to %q", key))
+			}
 			setKeyValueInMap(context, secretNamespaceField, context[podNamespaceField])
+			// Inline volumes do not support NFS.
+			if strings.EqualFold(getValueInMap(context, protocolField), nfs) {
+				return nil, status.Error(codes.InvalidArgument, "NFS protocol is not supported for ephemeral volumes")
+			}
+			// Inline volumes do not support the VHD disk feature.
+			if getValueInMap(context, diskNameField) != "" || isDiskFsType(getValueInMap(context, fsTypeField)) {
+				return nil, status.Error(codes.InvalidArgument, "VHD disk feature (diskName or disk fsType) is not supported for ephemeral volumes")
+			}
+			// Inline volumes must describe a remote Azure Files mount only.
+			// Reject server / shareName that could become a local path,
+			// and reject local bind mount modes in mountOptions.
+			if err := validateInlineVolumeMountSource(getValueInMap(context, serverNameField), getValueInMap(context, shareNameField)); err != nil {
+				return nil, status.Error(codes.InvalidArgument, err.Error())
+			}
+			if opt, found := findLocalMountModeOption(getValueInMap(context, mountOptionsField)); found {
+				return nil, status.Errorf(codes.InvalidArgument, "mount option %q is not supported for ephemeral volumes", opt)
+			}
 			// When Managed Identity or OAuth token is used for ephemeral volumes then reject the request.
 			// Allowing access for inline volume with identity will open up risk of arbitrary pods accessing fileshares with node identity permissions.
 			if strings.EqualFold(getValueInMap(context, mountWithManagedIdentityField), trueValue) {
@@ -121,7 +130,29 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 				setKeyValueInMap(context, getAccountKeyFromSecretField, trueValue)
 				setKeyValueInMap(context, storageAccountField, "")
 			}
+			// For secret-based inline volumes, confirm the mounting pod's own ServiceAccount
+			// is authorized to read the referenced Secret before mounting.
+			if !useWIToken {
+				if err := d.authorizeInlineVolumeSecret(ctx, context); err != nil {
+					return nil, err
+				}
+			}
 			klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s", volumeID, target)
+			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
+				StagingTargetPath: target,
+				VolumeContext:     context,
+				VolumeCapability:  volCap,
+				VolumeId:          volumeID,
+			})
+			return &csi.NodePublishVolumeResponse{}, err
+		}
+
+		if getValueInMap(context, serviceAccountTokenField) != "" && shouldUseServiceAccountToken(context) {
+			if d.canSkipRepublishNodeStage(context, target) {
+				klog.V(2).Infof("NodePublishVolume: volume(%s) already mounted on %s with clientID auth, skipping NodeStageVolume (no time-bound credential to refresh)", volumeID, target)
+				return &csi.NodePublishVolumeResponse{}, nil
+			}
+			klog.V(2).Infof("NodePublishVolume: volume(%s) mount on %s with service account token, clientID: %s, mountWithWIToken: %s", volumeID, target, getValueInMap(context, clientIDField), getValueInMap(context, mountWithWITokenField))
 			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
 				StagingTargetPath: target,
 				VolumeContext:     context,
@@ -470,6 +501,10 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 	isDiskMount := isDiskFsType(fsType)
 	if isDiskMount {
+		// Reuse traversal check from GetFileShareInfo.
+		if err := validateVolumeIDSegment("diskName", diskName); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 		if !strings.HasSuffix(diskName, vhdSuffix) {
 			return nil, status.Errorf(codes.Internal, "diskname could not be empty, targetPath: %s", targetPath)
 		}
@@ -531,6 +566,13 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 				cifsMountFlags = util.JoinMountOptions(cifsMountFlags, strings.Split(ephemeralVolMountOptions, ","))
 			}
 			mountOptions = appendDefaultCifsMountOptions(cifsMountFlags, d.appendNoShareSockOption, d.appendClosetimeoOption)
+			if isDiskMount {
+				// A VHD PV is loop-mounted from a plain data blob and never needs CIFS
+				// symlink emulation (enabled by default).
+				if opts, existed := removeOptionIfExists(mountOptions, mfsymlinks); existed {
+					mountOptions = opts
+				}
+			}
 		}
 	}
 
@@ -656,6 +698,9 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		}
 
 		diskPath := filepath.Join(cifsMountPath, diskName)
+		if err := validateDiskIsRegularFile(diskPath); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid disk source: %v", err)
+		}
 		options := util.JoinMountOptions(mountFlags, []string{"loop"})
 		if strings.HasPrefix(fsType, "ext") {
 			// following mount options are only valid for ext2/ext3/ext4 file systems
@@ -680,6 +725,17 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+// validateDiskIsRegularFile verifies that diskPath is a real regular file. A
+// missing file is left to fail naturally later in FormatAndMount, and an
+// existing symlink is always reported as a link (never "not found") because
+// Lstat does not traverse it.
+func validateDiskIsRegularFile(diskPath string) error {
+	if fi, err := os.Lstat(diskPath); err == nil && !fi.Mode().IsRegular() {
+		return fmt.Errorf("disk path %q is not a regular file (mode %s)", diskPath, fi.Mode())
+	}
+	return nil
 }
 
 // NodeUnstageVolume unmount the volume from the staging path
@@ -1056,6 +1112,76 @@ func checkGidPresentInMountFlags(mountFlags []string) bool {
 		}
 	}
 	return false
+}
+
+// authorizeInlineVolumeSecret uses SubjectAccessReview to ensure the mounting pod's
+// ServiceAccount is authorized to "get" the referenced Secret before mounting on its behalf.
+// d.inlineVolumeSecretAuthz selects the mode: off (default, no check), warn (log only) or
+// enforce (deny unauthorized mounts).
+func (d *Driver) authorizeInlineVolumeSecret(ctx context.Context, volumeContext map[string]string) error {
+	var enforce bool
+	switch strings.ToLower(d.inlineVolumeSecretAuthz) {
+	case "", inlineVolumeSecretAuthzOff:
+		return nil
+	case inlineVolumeSecretAuthzWarn:
+	case inlineVolumeSecretAuthzEnforce:
+		enforce = true
+	default:
+		return status.Errorf(codes.InvalidArgument, "invalid inline-volume-secret-authz mode %q", d.inlineVolumeSecretAuthz)
+	}
+
+	// Resolve the Secret the mount will read. Use the same resolution as the
+	// read path (getSecretNamespace).
+	secretNamespace := getSecretNamespace(volumeContext)
+	secretName := getValueInMap(volumeContext, secretNameField)
+	if secretName == "" {
+		if accountName := getValueInMap(volumeContext, storageAccountField); accountName != "" {
+			secretName = fmt.Sprintf(secretNameTemplate, accountName)
+		}
+	}
+
+	if secretName == "" || secretNamespace == "" {
+		return nil
+	}
+
+	deny := func(reason string) error {
+		msg := fmt.Sprintf("inline volume Secret %s/%s: %s", secretNamespace, secretName, reason)
+		if enforce {
+			return status.Error(codes.PermissionDenied, msg)
+		}
+		klog.Warningf("inline-volume-secret-authz(warn): %s", msg)
+		return nil
+	}
+
+	podName := volumeContext[podNameField]
+	podNamespace := volumeContext[podNamespaceField]
+	if d.kubeClient == nil || podName == "" || podNamespace == "" {
+		return deny("kube client or pod identity (podInfoOnMount) unavailable")
+	}
+	pod, err := d.kubeClient.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return deny(fmt.Sprintf("failed to get pod %s/%s: %v", podNamespace, podName, err))
+	}
+	serviceAccountName := pod.Spec.ServiceAccountName
+	if serviceAccountName == "" {
+		serviceAccountName = "default"
+	}
+	// Mirror the identity the API server assigns to a ServiceAccount token (username plus
+	// the implicit groups) and do a SubjectAccessReview.
+	serviceAccountUser := serviceaccount.MakeUsername(podNamespace, serviceAccountName)
+	sar := &authorizationv1.SubjectAccessReview{Spec: authorizationv1.SubjectAccessReviewSpec{
+		User:               serviceAccountUser,
+		Groups:             append(serviceaccount.MakeGroupNames(podNamespace), user.AllAuthenticated),
+		ResourceAttributes: &authorizationv1.ResourceAttributes{Namespace: secretNamespace, Verb: "get", Resource: "secrets", Name: secretName},
+	}}
+	result, err := d.kubeClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+	if err != nil {
+		return deny(fmt.Sprintf("SubjectAccessReview for %s failed: %v", serviceAccountUser, err))
+	}
+	if !result.Status.Allowed {
+		return deny(fmt.Sprintf("service account %s is not authorized to get it", serviceAccountUser))
+	}
+	return nil
 }
 
 // shouldUseServiceAccountToken determines whether a service account token should be used for authentication based on the volume context attributes.

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -36,10 +36,13 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	testingclient "k8s.io/client-go/testing"
 	mount "k8s.io/mount-utils"
 	"k8s.io/utils/exec"
 	testingexec "k8s.io/utils/exec/testing"
@@ -257,6 +260,169 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			desc: "[Error] Ephemeral volume with mountWithOAuthToken and clientID should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e449",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:           "true",
+					storageAccountField:      "teststorageaccount",
+					shareNameField:           "testshare",
+					mountWithOAuthTokenField: "true",
+					clientIDField:            "branch-trigger",
+					serviceAccountTokenField: "fake-token",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "mountWithOAuthToken cannot be used for ephemeral volumes, please use secret based authentication"),
+				WindowsError: status.Error(codes.InvalidArgument, "mountWithOAuthToken cannot be used for ephemeral volumes, please use secret based authentication"),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with case-colliding secretNamespace keys should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e446",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:    "true",
+					shareNameField:    "testshare",
+					"secretNamespace": "namespace",
+					"SecretNamespace": "namespace-other",
+					podNamespaceField: "namespace",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "ephemeral volume request contains case-colliding volume attribute keys that normalize to \"secretnamespace\""),
+				WindowsError: status.Error(codes.InvalidArgument, "ephemeral volume request contains case-colliding volume attribute keys that normalize to \"secretnamespace\""),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with case-colliding mountWithManagedIdentity keys should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e372",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:             "true",
+					shareNameField:             "testshare",
+					"mountwithmanagedidentity": "false",
+					"MOUNTWITHMANAGEDIDENTITY": "true",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "ephemeral volume request contains case-colliding volume attribute keys that normalize to \"mountwithmanagedidentity\""),
+				WindowsError: status.Error(codes.InvalidArgument, "ephemeral volume request contains case-colliding volume attribute keys that normalize to \"mountwithmanagedidentity\""),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with protocol=nfs should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e440",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:  "true",
+					shareNameField:  "testshare",
+					protocolField:   nfs,
+					serverNameField: "192.0.2.60",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "NFS protocol is not supported for ephemeral volumes"),
+				WindowsError: status.Error(codes.InvalidArgument, "NFS protocol is not supported for ephemeral volumes"),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with diskName should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e441",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:  "true",
+					shareNameField:  "testshare",
+					serverNameField: "test_servername",
+					diskNameField:   "disk.vhd",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "VHD disk feature (diskName or disk fsType) is not supported for ephemeral volumes"),
+				WindowsError: status.Error(codes.InvalidArgument, "VHD disk feature (diskName or disk fsType) is not supported for ephemeral volumes"),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with disk fsType should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e442",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:  "true",
+					shareNameField:  "testshare",
+					serverNameField: "test_servername",
+					fsTypeField:     "ext4",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "VHD disk feature (diskName or disk fsType) is not supported for ephemeral volumes"),
+				WindowsError: status.Error(codes.InvalidArgument, "VHD disk feature (diskName or disk fsType) is not supported for ephemeral volumes"),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with server containing separators should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e443",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:  "true",
+					shareNameField:  "testshare",
+					serverNameField: "a/b",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "invalid server \"a/b\" for ephemeral volume: must be a hostname or address"),
+				WindowsError: status.Error(codes.InvalidArgument, "invalid server \"a/b\" for ephemeral volume: must be a hostname or address"),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with shareName containing separators should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e444",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:  "true",
+					serverNameField: "test_servername",
+					shareNameField:  "a/b",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "invalid shareName \"a/b\" for ephemeral volume: must be a single share name"),
+				WindowsError: status.Error(codes.InvalidArgument, "invalid shareName \"a/b\" for ephemeral volume: must be a single share name"),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with bind mount option should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8e445",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:    "true",
+					shareNameField:    "testshare",
+					serverNameField:   "test_servername",
+					mountOptionsField: "dir_mode=0777,bind",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "mount option \"bind\" is not supported for ephemeral volumes"),
+				WindowsError: status.Error(codes.InvalidArgument, "mount option \"bind\" is not supported for ephemeral volumes"),
+			},
+		},
+		{
 			desc: "[Error] Ephemeral volume with mountWithWIToken should preserve storageAccount",
 			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
 				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8ed84",
@@ -461,6 +627,224 @@ func TestNodePublishVolume(t *testing.T) {
 	assert.NoError(t, err)
 	err = os.RemoveAll(alreadyMountedTarget)
 	assert.NoError(t, err)
+}
+
+func TestAuthorizeInlineVolumeSecret(t *testing.T) {
+	const (
+		podNS       = "app-ns"
+		podName     = "app-pod"
+		saName      = "app-sa"
+		secretName  = "azure-secret"
+		accountName = "testaccount"
+	)
+
+	newPod := func(sa string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: podNS},
+			Spec:       corev1.PodSpec{ServiceAccountName: sa},
+		}
+	}
+	baseContext := func() map[string]string {
+		return map[string]string{
+			podNameField:         podName,
+			podNamespaceField:    podNS,
+			secretNamespaceField: podNS,
+			secretNameField:      secretName,
+		}
+	}
+
+	tests := []struct {
+		desc       string
+		mode       string
+		context    map[string]string
+		nilClient  bool
+		pod        *corev1.Pod
+		allowed    bool
+		sarErr     error
+		expectDeny bool
+	}{
+		{
+			desc:       "off mode is a no-op even when unauthorized",
+			mode:       inlineVolumeSecretAuthzOff,
+			context:    baseContext(),
+			pod:        newPod(saName),
+			allowed:    false,
+			expectDeny: false,
+		},
+		{
+			desc:       "enforce allows when SA is authorized",
+			mode:       inlineVolumeSecretAuthzEnforce,
+			context:    baseContext(),
+			pod:        newPod(saName),
+			allowed:    true,
+			expectDeny: false,
+		},
+		{
+			desc:       "enforce denies when SA is not authorized",
+			mode:       inlineVolumeSecretAuthzEnforce,
+			context:    baseContext(),
+			pod:        newPod(saName),
+			allowed:    false,
+			expectDeny: true,
+		},
+		{
+			desc:       "warn allows even when SA is not authorized",
+			mode:       inlineVolumeSecretAuthzWarn,
+			context:    baseContext(),
+			pod:        newPod(saName),
+			allowed:    false,
+			expectDeny: false,
+		},
+		{
+			desc:       "enforce denies when kube client is nil",
+			mode:       inlineVolumeSecretAuthzEnforce,
+			context:    baseContext(),
+			nilClient:  true,
+			expectDeny: true,
+		},
+		{
+			desc: "enforce denies when pod identity is missing",
+			mode: inlineVolumeSecretAuthzEnforce,
+			context: map[string]string{
+				secretNamespaceField: podNS,
+				secretNameField:      secretName,
+			},
+			pod:        newPod(saName),
+			expectDeny: true,
+		},
+		{
+			desc: "enforce denies when secret but no secret namespace",
+			mode: inlineVolumeSecretAuthzEnforce,
+			context: map[string]string{
+				secretNameField: secretName,
+			},
+			pod:        newPod(saName),
+			expectDeny: true,
+		},
+		{
+			desc: "no resolvable secret reference is a no-op",
+			mode: inlineVolumeSecretAuthzEnforce,
+			context: map[string]string{
+				podNameField:      podName,
+				podNamespaceField: podNS,
+			},
+			pod:        newPod(saName),
+			allowed:    false,
+			expectDeny: false,
+		},
+		{
+			desc:       "empty pod service account defaults to 'default'",
+			mode:       inlineVolumeSecretAuthzEnforce,
+			context:    baseContext(),
+			pod:        newPod(""),
+			allowed:    true,
+			expectDeny: false,
+		},
+	}
+
+	for _, test := range tests {
+		d := NewFakeDriver()
+		d.inlineVolumeSecretAuthz = test.mode
+		if test.nilClient {
+			d.kubeClient = nil
+		} else {
+			objs := []k8sruntime.Object{}
+			if test.pod != nil {
+				objs = append(objs, test.pod)
+			}
+			client := fake.NewSimpleClientset(objs...)
+			allowed := test.allowed
+			sarErr := test.sarErr
+			client.PrependReactor("create", "subjectaccessreviews", func(action testingclient.Action) (bool, k8sruntime.Object, error) {
+				if sarErr != nil {
+					return true, nil, sarErr
+				}
+				sar := action.(testingclient.CreateAction).GetObject().(*authorizationv1.SubjectAccessReview)
+				sar.Status.Allowed = allowed
+				return true, sar, nil
+			})
+			d.kubeClient = client
+		}
+
+		err := d.authorizeInlineVolumeSecret(context.Background(), test.context)
+		if test.expectDeny {
+			if err == nil {
+				t.Errorf("test %q: expected PermissionDenied, got nil", test.desc)
+			} else if status.Code(err) != codes.PermissionDenied {
+				t.Errorf("test %q: expected PermissionDenied, got %v", test.desc, err)
+			}
+		} else if err != nil {
+			t.Errorf("test %q: expected no error, got %v", test.desc, err)
+		}
+	}
+}
+
+func TestAuthorizeInlineVolumeSecretInvalidMode(t *testing.T) {
+	d := NewFakeDriver()
+	d.inlineVolumeSecretAuthz = "bogus"
+	d.kubeClient = fake.NewSimpleClientset()
+	err := d.authorizeInlineVolumeSecret(context.Background(), map[string]string{
+		podNameField:      "app-pod",
+		podNamespaceField: "app-ns",
+		secretNameField:   "azure-secret",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument for unknown mode, got %v", err)
+	}
+}
+
+func TestAuthorizeInlineVolumeSecretSubject(t *testing.T) {
+	const (
+		podNS      = "app-ns"
+		podName    = "app-pod"
+		saName     = "app-sa"
+		secretName = "azure-secret"
+	)
+	d := NewFakeDriver()
+	d.inlineVolumeSecretAuthz = inlineVolumeSecretAuthzEnforce
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: podNS},
+		Spec:       corev1.PodSpec{ServiceAccountName: saName},
+	}
+	client := fake.NewSimpleClientset(pod)
+	var captured *authorizationv1.SubjectAccessReview
+	client.PrependReactor("create", "subjectaccessreviews", func(action testingclient.Action) (bool, k8sruntime.Object, error) {
+		captured = action.(testingclient.CreateAction).GetObject().(*authorizationv1.SubjectAccessReview)
+		captured.Status.Allowed = true
+		return true, captured, nil
+	})
+	d.kubeClient = client
+
+	ctx := map[string]string{
+		podNameField:         podName,
+		podNamespaceField:    podNS,
+		secretNamespaceField: podNS,
+		secretNameField:      secretName,
+	}
+	if err := d.authorizeInlineVolumeSecret(context.Background(), ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("expected a SubjectAccessReview to be created")
+	}
+	if got, want := captured.Spec.User, "system:serviceaccount:app-ns:app-sa"; got != want {
+		t.Errorf("User = %q, want %q", got, want)
+	}
+	wantGroups := map[string]bool{
+		"system:serviceaccounts":        true,
+		"system:serviceaccounts:app-ns": true,
+		"system:authenticated":          true,
+	}
+	for _, g := range captured.Spec.Groups {
+		delete(wantGroups, g)
+	}
+	if len(wantGroups) != 0 {
+		t.Errorf("missing expected groups in SAR: %v (got %v)", wantGroups, captured.Spec.Groups)
+	}
+	ra := captured.Spec.ResourceAttributes
+	if ra == nil || ra.Verb != "get" || ra.Resource != "secrets" || ra.Namespace != podNS || ra.Name != secretName || ra.Group != "" {
+		t.Errorf("unexpected ResourceAttributes: %+v", ra)
+	}
 }
 
 func TestNodeUnpublishVolume(t *testing.T) {
@@ -816,6 +1200,21 @@ func TestNodeStageVolume(t *testing.T) {
 				Secrets:          secrets},
 			expectedErr: testutil.TestError{
 				DefaultError: status.Errorf(codes.Internal, "diskname could not be empty, targetPath: %s", sourceTest),
+			},
+		},
+		{
+			desc: "[Error] PV disk path: diskName traversal is rejected",
+			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1##", StagingTargetPath: sourceTest,
+				VolumeCapability: &stdVolCap,
+				VolumeContext: map[string]string{
+					fsTypeField:     "ext4",
+					diskNameField:   "../../../../host/marker.vhd",
+					shareNameField:  "test_sharename",
+					serverNameField: "test_servername",
+				},
+				Secrets: secrets},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Errorf(codes.InvalidArgument, "invalid %s %q: contains directory traversal sequence", "diskName", "../../../../host/marker.vhd"),
 			},
 		},
 		{
@@ -1667,6 +2066,45 @@ func TestGetKerberosHost(t *testing.T) {
 			got := getKerberosHost(tc.server)
 			if got != tc.expected {
 				t.Errorf("getKerberosHost(%q) = %q, want %q", tc.server, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestValidateDiskIsRegularFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping symlink-based test on windows")
+	}
+	shareDir := t.TempDir()
+
+	regularPath := filepath.Join(shareDir, "disk.vhd")
+	if err := os.WriteFile(regularPath, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A CIFS-emulated symlink surfaces to the VFS as a symlink; model that with a
+	// real symlink and assert the no-follow check rejects it regardless of target.
+	symlinkPath := filepath.Join(shareDir, "link.vhd")
+	if err := os.Symlink("/etc/hostname", symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		desc      string
+		diskPath  string
+		expectErr bool
+	}{
+		{desc: "regular file is accepted", diskPath: regularPath, expectErr: false},
+		{desc: "missing file is tolerated", diskPath: filepath.Join(shareDir, "absent.vhd"), expectErr: false},
+		{desc: "symlink is rejected", diskPath: symlinkPath, expectErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validateDiskIsRegularFile(tc.diskPath)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -290,6 +290,21 @@ func setKeyValueInMap(m map[string]string, key, value string) {
 	m[key] = value
 }
 
+// caseCollidingKey reports the first key in m that collides with an earlier key
+// under case-insensitive (lowercase) normalization. The returned
+// string is the normalized (lowercase) key that collided.
+func caseCollidingKey(m map[string]string) (string, bool) {
+	seen := make(map[string]struct{}, len(m))
+	for k := range m {
+		lower := strings.ToLower(k)
+		if _, ok := seen[lower]; ok {
+			return lower, true
+		}
+		seen[lower] = struct{}{}
+	}
+	return "", false
+}
+
 // getValueInMap get value from map by key
 // key in the map is case insensitive
 func getValueInMap(m map[string]string, key string) string {
@@ -521,6 +536,30 @@ func isValidFolderName(folderName string) error {
 		if strings.HasSuffix(seg, ".") || strings.HasSuffix(seg, " ") {
 			return fmt.Errorf("folderName(%q) segment %q must not end with a period or space", folderName, seg)
 		}
+	}
+	return nil
+}
+
+// findLocalMountModeOption returns the first comma-separated option in
+// mountOptions that requests a local bind mount.
+func findLocalMountModeOption(mountOptions string) (string, bool) {
+	for _, opt := range strings.Split(mountOptions, ",") {
+		trimmed := strings.TrimSpace(opt)
+		if strings.EqualFold(trimmed, "bind") || strings.EqualFold(trimmed, "rbind") {
+			return trimmed, true
+		}
+	}
+	return "", false
+}
+
+// validateInlineVolumeMountSource validates that there are no path
+// separators or dot-only segments.
+func validateInlineVolumeMountSource(server, shareName string) error {
+	if strings.ContainsAny(server, `/\`) || server == "." || server == ".." {
+		return fmt.Errorf("invalid server %q for ephemeral volume: must be a hostname or address", server)
+	}
+	if strings.ContainsAny(shareName, `/\`) || shareName == "." || shareName == ".." {
+		return fmt.Errorf("invalid shareName %q for ephemeral volume: must be a single share name", shareName)
 	}
 	return nil
 }

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -696,6 +696,47 @@ func TestGetValueInMap(t *testing.T) {
 	}
 }
 
+func TestCaseCollidingKey(t *testing.T) {
+	tests := []struct {
+		desc         string
+		m            map[string]string
+		expectedKey  string
+		expectedColl bool
+	}{
+		{
+			desc:         "nil map",
+			expectedColl: false,
+		},
+		{
+			desc:         "no collision",
+			m:            map[string]string{"secretNamespace": "ns", "shareName": "share"},
+			expectedColl: false,
+		},
+		{
+			desc:         "secretNamespace case collision",
+			m:            map[string]string{"secretNamespace": "attacker", "SecretNamespace": "victim"},
+			expectedKey:  "secretnamespace",
+			expectedColl: true,
+		},
+		{
+			desc:         "managed identity case collision",
+			m:            map[string]string{"mountwithmanagedidentity": "false", "MOUNTWITHMANAGEDIDENTITY": "true"},
+			expectedKey:  "mountwithmanagedidentity",
+			expectedColl: true,
+		},
+	}
+
+	for _, test := range tests {
+		key, ok := caseCollidingKey(test.m)
+		if ok != test.expectedColl {
+			t.Errorf("test[%s]: unexpected collision result: %v, expected: %v", test.desc, ok, test.expectedColl)
+		}
+		if ok && key != test.expectedKey {
+			t.Errorf("test[%s]: unexpected colliding key: %v, expected: %v", test.desc, key, test.expectedKey)
+		}
+	}
+}
+
 func TestReplaceWithMap(t *testing.T) {
 	tests := []struct {
 		desc     string
@@ -1650,6 +1691,65 @@ func TestIsValidFolderName(t *testing.T) {
 			}
 			if !tc.expectErr && err != nil {
 				t.Fatalf("isValidFolderName(%q) unexpected error: %v", tc.folder, err)
+			}
+		})
+	}
+}
+
+func TestFindLocalMountModeOption(t *testing.T) {
+	tests := []struct {
+		name    string
+		options string
+		wantOpt string
+		wantOk  bool
+	}{
+		{name: "empty", options: "", wantOpt: "", wantOk: false},
+		{name: "normal cifs options", options: "dir_mode=0777,file_mode=0777,cache=strict", wantOpt: "", wantOk: false},
+		{name: "bind present", options: "dir_mode=0777,bind", wantOpt: "bind", wantOk: true},
+		{name: "bind with spaces", options: "dir_mode=0777, bind ", wantOpt: "bind", wantOk: true},
+		{name: "uppercase bind", options: "BIND", wantOpt: "BIND", wantOk: true},
+		{name: "rbind", options: "ro,rbind", wantOpt: "rbind", wantOk: true},
+		{name: "remount not blocked", options: "remount", wantOpt: "", wantOk: false},
+		{name: "move not blocked", options: "move,ro", wantOpt: "", wantOk: false},
+		{name: "substring is not matched", options: "rebindable", wantOpt: "", wantOk: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opt, ok := findLocalMountModeOption(tc.options)
+			if ok != tc.wantOk || opt != tc.wantOpt {
+				t.Fatalf("findLocalMountModeOption(%q) = (%q, %v), want (%q, %v)", tc.options, opt, ok, tc.wantOpt, tc.wantOk)
+			}
+		})
+	}
+}
+
+func TestValidateInlineVolumeMountSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		server    string
+		shareName string
+		expectErr bool
+	}{
+		{name: "valid hostname and share", server: "acct.file.core.windows.net", shareName: "myshare", expectErr: false},
+		{name: "valid ip and share", server: "192.0.2.10", shareName: "my-share", expectErr: false},
+		{name: "empty server allowed (defaulted later)", server: "", shareName: "myshare", expectErr: false},
+		{name: "server with separators", server: "a/b", shareName: "myshare", expectErr: true},
+		{name: "server with leading slash", server: "/abc", shareName: "myshare", expectErr: true},
+		{name: "server with backslash", server: "a\\b", shareName: "myshare", expectErr: true},
+		{name: "server is dot", server: ".", shareName: "myshare", expectErr: true},
+		{name: "server is dotdot", server: "..", shareName: "myshare", expectErr: true},
+		{name: "shareName with slash", server: "acct.file.core.windows.net", shareName: "a/b", expectErr: true},
+		{name: "shareName with backslash", server: "acct.file.core.windows.net", shareName: "a\\b", expectErr: true},
+		{name: "shareName is dotdot", server: "acct.file.core.windows.net", shareName: "..", expectErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateInlineVolumeMountSource(tc.server, tc.shareName)
+			if tc.expectErr && err == nil {
+				t.Fatalf("validateInlineVolumeMountSource(%q, %q) expected error but got nil", tc.server, tc.shareName)
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("validateInlineVolumeMountSource(%q, %q) unexpected error: %v", tc.server, tc.shareName, err)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry-pick of #3296 to release-1.35.

Original PR: https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3296

**What this PR does / why we need it**:

Backports ephemeral inline volume improvements to release-1.35:
- Improve service account secret access
  - Use podInfoOnMount and read the spec.serviceAccountName
  - Issue a SubjectAccessReview asking whether system:serviceaccount:<namespace>:<serviceaccount> can GET the referenced secret
  - Proceed with the mount only if allowed; otherwise fail with PermissionDenied.
  - off|warn|enforce options, default to off to not break existing setups
- Enforce unsupported features (e.g. NFS/VHD for inline ephemeral volumes)
- Validation for PV disk mounts
- Case collision validation for volumeContext/volumeAttributes
- Validate server/sharename mounting for inline ephemeral volumes

**Cherry-pick notes**:

Conflict resolution:
- `pkg/azurefile/nodeserver.go`: adapted the SA-token check to release-1.35's pre-secrets form (`getValueInMap(context, serviceAccountTokenField)` instead of `serviceAccountTokens`, no `Secrets` field passed to `NodeStageVolumeRequest`).
- `pkg/azurefile/utils_test.go`: dropped `TestGetServiceAccountTokens` and `TestHasStorageAccountCredentials` (helpers do not exist on release-1.35); kept `TestCaseCollidingKey`.

**Release note**:
```
none
```
