### PR TITLE
test: set networkEndpointType=serviceEndpoint on smb readOnly e2e

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -448,7 +448,8 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			},
 		}
 		scParameters := map[string]string{
-			"skuName": "Standard_LRS",
+			"skuName":             "Standard_LRS",
+			"networkEndpointType": "serviceEndpoint",
 		}
 		test := testsuites.DynamicallyProvisionedReadOnlyVolumeTest{
 			CSIDriver:              testDriver,


### PR DESCRIPTION
### What

Set `networkEndpointType: serviceEndpoint` on the StorageClass for the "SMB readOnly volume-access-mode" e2e in `test/e2e/dynamic_provisioning_test.go` (the `[Windows]`-tagged It block right below the block linked in the review request), so this spec exercises the service-endpoint provisioning path in addition to the existing `skuName=Standard_LRS`.

### Why

Test-only PR to add coverage for `networkEndpointType=serviceEndpoint` on dynamic SMB provisioning.

### Notes

- Only the `scParameters` map changes; provisioning topology, pod spec, and assertion path are unchanged.
- `gofmt -w` applied.

/kind test
/release-note-none
