### PR TITLE
fix: update workload identity token and dedupe during nodestage

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -19,7 +19,9 @@ package azurefile
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1001,7 +1003,9 @@ func (d *Driver) GetAccountInfo(ctx context.Context, volumeID string, secrets, r
 		if err != nil {
 			return rgName, accountName, accountKey, fileShareName, diskName, subsID, tenantID, tokenFilePath, fmt.Errorf("failed to parse service account token: %v", err)
 		}
-		tokenFileName := clientID + "-" + accountName
+		// Use volume ID so concurrent mounts with same clientID and SA do not
+		// share a single token file.
+		tokenFileName := clientID + "-" + accountName + "-" + hashVolumeIDForTokenFile(volumeID)
 		if !isValidTokenFileName(tokenFileName) {
 			return rgName, accountName, accountKey, fileShareName, diskName, subsID, tenantID, tokenFilePath, fmt.Errorf("invalid token file name(%s) generated for clientID(%s) and accountName(%s)", tokenFileName, clientID, accountName)
 		}
@@ -1010,6 +1014,11 @@ func (d *Driver) GetAccountInfo(ctx context.Context, volumeID string, secrets, r
 		existingToken, readErr := os.ReadFile(tokenFilePath)
 		if readErr == nil && string(existingToken) == token {
 			klog.V(4).Infof("the token file(%s) already exists and the token value is the same, no need to rewrite the token file", tokenFilePath)
+			if strings.EqualFold(getValueInMap(reqContext, ephemeralField), trueValue) {
+				// The token file is unchanged, but return token file path so caller
+				// refreshes credential cache via setCredentialCache (inline only).
+				return rgName, accountName, accountKey, fileShareName, diskName, subsID, tenantID, tokenFilePath, nil
+			}
 			return rgName, accountName, accountKey, fileShareName, diskName, subsID, tenantID, "", nil
 		}
 		// write token to a file
@@ -1740,4 +1749,13 @@ func parseServiceAccountToken(tokenStr string) (string, error) {
 		return "", fmt.Errorf("token for audience %s not found", DefaultTokenAudience)
 	}
 	return token.APIAzureADTokenExchange.Token, nil
+}
+
+// hashVolumeIDForTokenFile returns a filesystem-safe, collision-resistant string
+// derived from the volume ID. It is appended to the workload-identity token cache
+// filename so each volume gets its own token file, preventing concurrent mounts
+// that share a clientID/accountName from racing on a single shared file.
+func hashVolumeIDForTokenFile(volumeID string) string {
+	sum := sha256.Sum256([]byte(volumeID))
+	return hex.EncodeToString(sum[:8])
 }

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -924,6 +924,76 @@ func TestGetAccountInfo(t *testing.T) {
 	}
 }
 
+// TestGetAccountInfoWorkloadIdentityTokenFile covers the workload-identity
+// token-file behaviors: (1) the token cache filename must be unique per volume
+// so shared clientID/accountName do not race on one shared file. (2) when the
+// token file is unchanged, (for inline volumes only) GetAccountInfo must still
+// return a non-empty tokenFilePath so the caller always refreshes the
+// credential cache.
+func TestGetAccountInfoWorkloadIdentityTokenFile(t *testing.T) {
+	skipIfTestingOnWindows(t)
+
+	origTokenDir := defaultAzureOAuthTokenDir
+	tokenDir := t.TempDir()
+	defaultAzureOAuthTokenDir = tokenDir
+	defer func() { defaultAzureOAuthTokenDir = origTokenDir }()
+
+	d := NewFakeDriver()
+	d.cloud = &storage.AccountRepo{}
+
+	const (
+		clientID    = "test-client-id-1234"
+		accountName = "testaccount"
+		tokenValue  = "test-token-value"
+	)
+	saToken := `{"api://AzureADTokenExchange":{"token":"` + tokenValue + `","expirationTimestamp":"2025-01-01T00:00:00Z"}}`
+	baseContext := func() map[string]string {
+		return map[string]string{
+			mountWithWITokenField:    "true",
+			clientIDField:            clientID,
+			tenantIDField:            "test-tenant-id",
+			storageAccountField:      accountName,
+			shareNameField:           "testshare",
+			serviceAccountTokenField: saToken,
+		}
+	}
+	ephemeralContext := func() map[string]string {
+		ctx := baseContext()
+		ctx[ephemeralField] = "true"
+		return ctx
+	}
+
+	// distinct volume IDs must yield distinct token file paths.
+	_, _, _, _, _, _, _, tokenFilePathA, err := d.GetAccountInfo(context.Background(), "volume-A", nil, baseContext())
+	assert.NoError(t, err)
+	_, _, _, _, _, _, _, tokenFilePathB, err := d.GetAccountInfo(context.Background(), "volume-B", nil, baseContext())
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, tokenFilePathA)
+	assert.NotEmpty(t, tokenFilePathB)
+	assert.NotEqual(t, tokenFilePathA, tokenFilePathB, "token file path must be unique per volume ID")
+	assert.True(t, strings.HasSuffix(tokenFilePathA, hashVolumeIDForTokenFile("volume-A")))
+	assert.True(t, strings.HasSuffix(tokenFilePathB, hashVolumeIDForTokenFile("volume-B")))
+	assert.Equal(t, filepath.Join(tokenDir, clientID+"-"+accountName+"-"+hashVolumeIDForTokenFile("volume-A")), tokenFilePathA)
+
+	// token file was actually written with the parsed token value.
+	written, readErr := os.ReadFile(tokenFilePathA)
+	assert.NoError(t, readErr)
+	assert.Equal(t, tokenValue, string(written))
+
+	// unchanged token, non-ephemeral volume: return an empty path so the caller
+	// skips the (unnecessary) credential-cache refresh.
+	_, _, _, _, _, _, _, tokenFilePathNonEphemeral, err := d.GetAccountInfo(context.Background(), "volume-A", nil, baseContext())
+	assert.NoError(t, err)
+	assert.Empty(t, tokenFilePathNonEphemeral, "unchanged token on a non-ephemeral volume must return an empty path")
+
+	// unchanged token, ephemeral inline volume: still return the token file path
+	// (non-empty) so the caller refreshes the credential cache and re-enforces identity.
+	_, _, _, _, _, _, _, tokenFilePathEphemeral, err := d.GetAccountInfo(context.Background(), "volume-A", nil, ephemeralContext())
+	assert.NoError(t, err)
+	assert.Equal(t, tokenFilePathA, tokenFilePathEphemeral, "unchanged token on an ephemeral volume must still return the token file path, not empty")
+}
+
 func TestCreateDisk(t *testing.T) {
 	skipIfTestingOnWindows(t)
 	d := NewFakeDriver()

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -963,10 +963,22 @@ func TestGetAccountInfoWorkloadIdentityTokenFile(t *testing.T) {
 		return ctx
 	}
 
+	getTokenFilePath := func(volumeID string, reqContext map[string]string) (string, error) {
+		rgName, returnedAccountName, accountKey, fileShareName, diskName, subsID, returnedTenantID, tokenFilePath, err := d.GetAccountInfo(context.Background(), volumeID, nil, reqContext)
+		_ = rgName
+		_ = returnedAccountName
+		_ = accountKey
+		_ = fileShareName
+		_ = diskName
+		_ = subsID
+		_ = returnedTenantID
+		return tokenFilePath, err
+	}
+
 	// distinct volume IDs must yield distinct token file paths.
-	_, _, _, _, _, _, _, tokenFilePathA, err := d.GetAccountInfo(context.Background(), "volume-A", nil, baseContext())
+	tokenFilePathA, err := getTokenFilePath("volume-A", baseContext())
 	assert.NoError(t, err)
-	_, _, _, _, _, _, _, tokenFilePathB, err := d.GetAccountInfo(context.Background(), "volume-B", nil, baseContext())
+	tokenFilePathB, err := getTokenFilePath("volume-B", baseContext())
 	assert.NoError(t, err)
 
 	assert.NotEmpty(t, tokenFilePathA)
@@ -983,13 +995,13 @@ func TestGetAccountInfoWorkloadIdentityTokenFile(t *testing.T) {
 
 	// unchanged token, non-ephemeral volume: return an empty path so the caller
 	// skips the (unnecessary) credential-cache refresh.
-	_, _, _, _, _, _, _, tokenFilePathNonEphemeral, err := d.GetAccountInfo(context.Background(), "volume-A", nil, baseContext())
+	tokenFilePathNonEphemeral, err := getTokenFilePath("volume-A", baseContext())
 	assert.NoError(t, err)
 	assert.Empty(t, tokenFilePathNonEphemeral, "unchanged token on a non-ephemeral volume must return an empty path")
 
 	// unchanged token, ephemeral inline volume: still return the token file path
 	// (non-empty) so the caller refreshes the credential cache and re-enforces identity.
-	_, _, _, _, _, _, _, tokenFilePathEphemeral, err := d.GetAccountInfo(context.Background(), "volume-A", nil, ephemeralContext())
+	tokenFilePathEphemeral, err := getTokenFilePath("volume-A", ephemeralContext())
 	assert.NoError(t, err)
 	assert.Equal(t, tokenFilePathA, tokenFilePathEphemeral, "unchanged token on an ephemeral volume must still return the token file path, not empty")
 }

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -792,6 +792,21 @@ func (d *Driver) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolume
 
 	klog.V(2).Infof("NodeUnstageVolume: unmount volume %s on %s successfully", volumeID, stagingTargetPath)
 
+	// Best effort removal of any per-volume workload-identity token cache file
+	// written by GetAccountInfo for this volume.
+	if runtime.GOOS != "windows" {
+		tokenFileGlob := filepath.Join(defaultAzureOAuthTokenDir, "*-"+hashVolumeIDForTokenFile(volumeID))
+		if matches, globErr := filepath.Glob(tokenFileGlob); globErr != nil {
+			klog.Warningf("NodeUnstageVolume: failed to list token cache files for volume %s: %v", volumeID, globErr)
+		} else {
+			for _, tokenFile := range matches {
+				if rmErr := os.Remove(tokenFile); rmErr != nil && !os.IsNotExist(rmErr) {
+					klog.Warningf("NodeUnstageVolume: failed to remove token cache file %s for volume %s: %v", tokenFile, volumeID, rmErr)
+				}
+			}
+		}
+	}
+
 	isOperationSucceeded = true
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

Fixes to workload identity mounts:
- Avoid different volumes in the same storage account using the same token file
- Force caller to refresh credential on NodeStageVolume via setCredentialCache even if token file unchanged

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
