### PR TITLE
fix: fail fast on account limit for fixed storage account

### DIFF
--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -738,6 +738,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	shouldCleanupShare := (fileShareName == "")
 	if err := d.CreateFileShare(ctx, accountOptions, shareOptions, secret, useDataPlaneAPI); err != nil {
 		if strings.Contains(err.Error(), accountLimitExceedManagementAPI) || strings.Contains(err.Error(), accountLimitExceedDataPlaneAPI) {
+			if account != "" {
+				return nil, status.Errorf(codes.Internal, "account(%s) is in %s, wait for a few minutes to retry", accountName, accountLimitExceedManagementAPI)
+			}
 			klog.Warningf("create file share(%s) on account(%s) type(%s) subID(%s) rg(%s) location(%s) size(%d), error: %v, skip matching current account", validFileShareName, accountName, sku, subsID, resourceGroup, location, fileShareSize, err)
 			if rerr := d.cloud.AddStorageAccountTags(ctx, subsID, resourceGroup, accountName, skipMatchingTag); rerr != nil {
 				klog.Warningf("AddStorageAccountTags(%v) on account(%s) subsID(%s) rg(%s) failed with error: %v", tags, accountName, subsID, resourceGroup, rerr.Error())

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -1548,8 +1548,8 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 				gomega.Expect(err).To(gomega.Equal(expectedErr))
 			})
 		})
-		ginkgo.When("Account limit exceeded", func() {
-			ginkgo.It("should fail", func(ctx context.Context) {
+		ginkgo.When("Account limit exceeded on auto-selected account", func() {
+			ginkgo.It("should retry with another matching account", func(ctx context.Context) {
 				name := "baz"
 				SKU := "SKU"
 				kind := "StorageV2"
@@ -1565,7 +1565,6 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 					skuNameField:            "premium",
 					storageAccountTypeField: "stoacctype",
 					locationField:           "loc",
-					storageAccountField:     "stoacc",
 					resourceGroupField:      "rg",
 					shareNameField:          "",
 					diskNameField:           "diskname.vhd",
@@ -1598,6 +1597,48 @@ var _ = ginkgo.Describe("TestCreateVolume", func() {
 				_, err = d.CreateVolume(ctx, req)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+			})
+		})
+		ginkgo.When("Account limit exceeded on fixed storage account", func() {
+			ginkgo.It("should fail fast without recursively retrying the same account", func(ctx context.Context) {
+				name := "stoacc"
+				SKU := "SKU"
+				kind := "StorageV2"
+				location := "centralus"
+				value := "foo bar"
+				accounts := []*armstorage.Account{
+					{Name: &name, SKU: &armstorage.SKU{Name: to.Ptr(armstorage.SKUName(SKU))}, Kind: to.Ptr(armstorage.Kind(kind)), Location: &location},
+				}
+				keys := []*armstorage.AccountKey{{Value: &value}}
+				allParam := map[string]string{
+					skuNameField:            "premium",
+					storageAccountTypeField: "stoacctype",
+					locationField:           "loc",
+					storageAccountField:     "stoacc",
+					resourceGroupField:      "rg",
+					shareNameField:          "",
+					diskNameField:           "diskname.vhd",
+					fsTypeField:             "",
+					storeAccountKeyField:    "storeaccountkey",
+					secretNamespaceField:    "default",
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name:               "random-vol-name-fixed-account-limit",
+					VolumeCapabilities: stdVolCap,
+					CapacityRange:      lessThanPremCapRange,
+					Parameters:         allParam,
+				}
+				mockStorageAccountsClient := d.cloud.ComputeClientFactory.GetAccountClient().(*mock_accountclient.MockInterface)
+				mockFileClient.EXPECT().Create(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armstorage.FileShare{FileShareProperties: &armstorage.FileShareProperties{ShareQuota: nil}}, fmt.Errorf(accountLimitExceedManagementAPI)).Times(1)
+				mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(keys, nil).AnyTimes()
+				mockStorageAccountsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(accounts, nil).AnyTimes()
+				mockStorageAccountsClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				mockFileClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armstorage.FileShare{}, &azcore.ResponseError{StatusCode: http.StatusNotFound}).AnyTimes()
+
+				expectedErr := status.Errorf(codes.Internal, "account(%s) is in %s, wait for a few minutes to retry", "stoacc", accountLimitExceedManagementAPI)
+				_, err := d.CreateVolume(ctx, req)
+				gomega.Expect(err).To(gomega.Equal(expectedErr))
 			})
 		})
 		ginkgo.When("Premium storage account type (SKU) loads from storage account when not given as parameter and share request size is increased to min. size required by premium", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When `storageAccount` is explicitly specified in the StorageClass and `CreateFileShare` returns `TotalSharesProvisionedCapacityExceedsAccountLimit`, the current controller path immediately re-enters `CreateVolume()`.

That retry path is useful for auto-selected accounts because the driver can mark the current account with `skip-matching` and choose another matching account. But for a fixed `storageAccount`, the driver keeps using the same account, so it can rapidly re-issue `CreateFileShare` against an already-full account.

This PR simplifies the fixed-account path:
- return a clear retry-later error immediately instead of recursively re-entering `CreateVolume()`
- keep the existing retry-with-another-account behavior for auto-selected accounts
- add unit coverage for both paths

This works better with the external-provisioner retry model: once the driver returns an error, the external-provisioner retries provisioning with exponential backoff (default `--retry-interval-start=1s`, doubling on each failure up to default `--retry-interval-max=5m`). That avoids rapid repeated `CreateFileShare` attempts against the same fixed storage account while still allowing provisioning to recover automatically later.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
I could not run Go unit tests locally in this environment because the host does not have a Go toolchain (and no Docker fallback), so CI will be the first full validation gate.

**Release note**:
```none
Fail fast instead of recursively retrying CreateVolume when a fixed storage account hits TotalSharesProvisionedCapacityExceedsAccountLimit during volume provisioning.
```
