### PR TITLE
docs: clarify Azure Files snapshot restore role requirement

### DIFF
--- a/deploy/example/snapshot/README.md
+++ b/deploy/example/snapshot/README.md
@@ -1,5 +1,7 @@
 # Azure File Snapshot and Restore feature
 
+> Important: `Storage File Data Privileged Contributor` must be granted to the CSI driver controller identity for volume snapshot restore; otherwise, the driver will utilize an SAS key for the restore data copy / volume cloning operation.
+
 > Restoring an NFS file share snapshot is supported starting from CSI driver version v1.33.4 or later.
 
 ### Limitations of Azure file **restore** feature
@@ -10,8 +12,6 @@ No extra configuration required.
 
 #### Storage account with firewall, private endpoint or `publicNetworkAccess=Disabled`
 Use `useDataPlaneAPI: "oauth"` in the `VolumeSnapshotClass` (and in the destination `StorageClass` if it also targets a private storage account). See [Using `useDataPlaneAPI: oauth` against private storage accounts](../../../docs/driver-parameters.md#using-usedataplaneapi-oauth-against-private-storage-accounts) for the full prerequisites (CSI driver v1.33.0+, `Storage File Data Privileged Contributor` role on the driver controller identity, `networkAcls.bypass` includes `AzureServices`).
-
-> Important: Ensure that you have granted the `Storage File Data Privileged Contributor` role to the CSI driver controller identity for volume snapshot restore; otherwise, the driver will utilize an SAS key for the restore data copy / volume cloning operation.
 
 Example `VolumeSnapshotClass` for private storage accounts:
 

--- a/deploy/example/snapshot/README.md
+++ b/deploy/example/snapshot/README.md
@@ -1,6 +1,6 @@
 # Azure File Snapshot and Restore feature
 
-> Important: `Storage File Data Privileged Contributor` must be granted to the CSI driver controller identity for volume snapshot restore; otherwise, the driver will utilize an SAS key for the restore data copy / volume cloning operation.
+> Important: For volume snapshot restore against storage accounts with firewall, private endpoint, or `publicNetworkAccess=Disabled` using `useDataPlaneAPI: "oauth"`, grant `Storage File Data Privileged Contributor` to the CSI driver controller identity on the storage account. Otherwise, the driver will fall back to SAS-based auth for the restore data copy / volume cloning operation.
 
 > Restoring an NFS file share snapshot is supported starting from CSI driver version v1.33.4 or later.
 

--- a/deploy/example/snapshot/README.md
+++ b/deploy/example/snapshot/README.md
@@ -11,6 +11,8 @@ No extra configuration required.
 #### Storage account with firewall, private endpoint or `publicNetworkAccess=Disabled`
 Use `useDataPlaneAPI: "oauth"` in the `VolumeSnapshotClass` (and in the destination `StorageClass` if it also targets a private storage account). See [Using `useDataPlaneAPI: oauth` against private storage accounts](../../../docs/driver-parameters.md#using-usedataplaneapi-oauth-against-private-storage-accounts) for the full prerequisites (CSI driver v1.33.0+, `Storage File Data Privileged Contributor` role on the driver controller identity, `networkAcls.bypass` includes `AzureServices`).
 
+> Important: Ensure that you have granted the `Storage File Data Privileged Contributor` role to the CSI driver controller identity; otherwise, the driver will utilize an SAS key for volume cloning operations.
+
 Example `VolumeSnapshotClass` for private storage accounts:
 
 ```yaml

--- a/deploy/example/snapshot/README.md
+++ b/deploy/example/snapshot/README.md
@@ -1,6 +1,6 @@
 # Azure File Snapshot and Restore feature
 
-> Important: For volume snapshot restore against storage accounts with firewall, private endpoint, or `publicNetworkAccess=Disabled` using `useDataPlaneAPI: "oauth"`, grant `Storage File Data Privileged Contributor` to the CSI driver controller identity on the storage account. Otherwise, the driver will fall back to SAS-based auth for the restore data copy / volume cloning operation.
+> Important: For volume snapshot restore using `useDataPlaneAPI: "oauth"`, grant `Storage File Data Privileged Contributor` to the CSI driver controller identity on the storage account. Otherwise, the driver will fall back to SAS-based auth for the restore data copy / volume cloning operation.
 
 > Restoring an NFS file share snapshot is supported starting from CSI driver version v1.33.4 or later.
 

--- a/deploy/example/snapshot/README.md
+++ b/deploy/example/snapshot/README.md
@@ -11,7 +11,7 @@ No extra configuration required.
 #### Storage account with firewall, private endpoint or `publicNetworkAccess=Disabled`
 Use `useDataPlaneAPI: "oauth"` in the `VolumeSnapshotClass` (and in the destination `StorageClass` if it also targets a private storage account). See [Using `useDataPlaneAPI: oauth` against private storage accounts](../../../docs/driver-parameters.md#using-usedataplaneapi-oauth-against-private-storage-accounts) for the full prerequisites (CSI driver v1.33.0+, `Storage File Data Privileged Contributor` role on the driver controller identity, `networkAcls.bypass` includes `AzureServices`).
 
-> Important: Ensure that you have granted the `Storage File Data Privileged Contributor` role to the CSI driver controller identity; otherwise, the driver will utilize an SAS key for volume cloning operations.
+> Important: Ensure that you have granted the `Storage File Data Privileged Contributor` role to the CSI driver controller identity for volume snapshot restore; otherwise, the driver will utilize an SAS key for the restore data copy / volume cloning operation.
 
 Example `VolumeSnapshotClass` for private storage accounts:
 


### PR DESCRIPTION
## What this PR does / why we need it

Add an explicit note to the Azure Files snapshot restore example README that the CSI driver controller identity must have the `Storage File Data Privileged Contributor` role.

Without that role, the driver may fall back to SAS-key based volume cloning / restore operations, which can be surprising when debugging private or VNet-restricted storage account scenarios.

## Which issue(s) this PR fixes

None.
