### PR TITLE
fix: time out Windows SMB unstage unmount

### DIFF
--- a/pkg/azurefile/fake_mounter.go
+++ b/pkg/azurefile/fake_mounter.go
@@ -19,6 +19,7 @@ package azurefile
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	mount "k8s.io/mount-utils"
 )
@@ -81,6 +82,9 @@ func NewFakeMounter() (*mount.SafeFormatAndMount, error) {
 // Unmount overrides mount.FakeMounter.Unmount.
 func (f *fakeMounter) Unmount(target string) error {
 	f.unmountCount++
+	if strings.Contains(target, "slow_unmount") {
+		time.Sleep(200 * time.Millisecond)
+	}
 	if strings.Contains(target, "error") {
 		return fmt.Errorf("fake Unmount: target error")
 	}

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -54,6 +54,7 @@ import (
 var getRuntimeClassForPodFunc = getRuntimeClassForPod
 var isConfidentialRuntimeClassFunc = isConfidentialRuntimeClass
 var isWindowsOSFunc = func() bool { return runtime.GOOS == "windows" }
+var smbUnmountFunc = SMBUnmount
 var nodeUnstageSMBUnmountTimeout = MountTimeoutInSec * time.Second
 
 type MountClient struct {
@@ -774,7 +775,7 @@ func (d *Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolu
 
 	klog.V(2).Infof("NodeUnstageVolume: unmount volume %s on %s", volumeID, stagingTargetPath)
 	unmountFunc := func() error {
-		return SMBUnmount(d.mounter, stagingTargetPath, true /*extensiveMountPointCheck*/, d.removeSMBMountOnWindows)
+		return smbUnmountFunc(d.mounter, stagingTargetPath, true /*extensiveMountPointCheck*/, d.removeSMBMountOnWindows)
 	}
 	if d.removeSMBMountOnWindows && isWindowsOSFunc() {
 		timeout := nodeUnstageSMBUnmountTimeout

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -53,6 +53,7 @@ import (
 
 var getRuntimeClassForPodFunc = getRuntimeClassForPod
 var isConfidentialRuntimeClassFunc = isConfidentialRuntimeClass
+var isWindowsOSFunc = func() bool { return runtime.GOOS == "windows" }
 var nodeUnstageSMBUnmountTimeout = MountTimeoutInSec * time.Second
 
 type MountClient struct {
@@ -775,7 +776,7 @@ func (d *Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolu
 	unmountFunc := func() error {
 		return SMBUnmount(d.mounter, stagingTargetPath, true /*extensiveMountPointCheck*/, d.removeSMBMountOnWindows)
 	}
-	if d.removeSMBMountOnWindows {
+	if d.removeSMBMountOnWindows && isWindowsOSFunc() {
 		timeout := nodeUnstageSMBUnmountTimeout
 		if deadline, ok := ctx.Deadline(); ok {
 			if remaining := time.Until(deadline); remaining > 0 && remaining < timeout {

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -53,6 +53,7 @@ import (
 
 var getRuntimeClassForPodFunc = getRuntimeClassForPod
 var isConfidentialRuntimeClassFunc = isConfidentialRuntimeClass
+var nodeUnstageSMBUnmountTimeout = MountTimeoutInSec * time.Second
 
 type MountClient struct {
 	service mount_azurefile.MountServiceClient
@@ -748,7 +749,7 @@ func validateDiskIsRegularFile(diskPath string) error {
 }
 
 // NodeUnstageVolume unmount the volume from the staging path
-func (d *Driver) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+func (d *Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID missing in request")
@@ -771,8 +772,26 @@ func (d *Driver) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolume
 	}()
 
 	klog.V(2).Infof("NodeUnstageVolume: unmount volume %s on %s", volumeID, stagingTargetPath)
-	if err := SMBUnmount(d.mounter, stagingTargetPath, true /*extensiveMountPointCheck*/, d.removeSMBMountOnWindows); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to unmount staging target %s: %v", stagingTargetPath, err)
+	unmountFunc := func() error {
+		return SMBUnmount(d.mounter, stagingTargetPath, true /*extensiveMountPointCheck*/, d.removeSMBMountOnWindows)
+	}
+	if d.removeSMBMountOnWindows {
+		timeout := nodeUnstageSMBUnmountTimeout
+		if deadline, ok := ctx.Deadline(); ok {
+			if remaining := time.Until(deadline); remaining > 0 && remaining < timeout {
+				timeout = remaining
+			}
+		}
+		timeoutFunc := func() error {
+			return fmt.Errorf("windows SMB unmount operation timed out after %v for volume %s on %s", timeout, volumeID, stagingTargetPath)
+		}
+		if err := volumehelper.WaitUntilTimeout(timeout, unmountFunc, timeoutFunc); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to unmount staging target %s: %v", stagingTargetPath, err)
+		}
+	} else {
+		if err := unmountFunc(); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to unmount staging target %s: %v", stagingTargetPath, err)
+		}
 	}
 
 	if runtime.GOOS != "windows" {

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -1783,11 +1783,17 @@ func TestNodeUnstageVolumeTimeout(t *testing.T) {
 
 	oldTimeout := nodeUnstageSMBUnmountTimeout
 	oldIsWindowsOSFunc := isWindowsOSFunc
+	oldSMBUnmountFunc := smbUnmountFunc
 	nodeUnstageSMBUnmountTimeout = 50 * time.Millisecond
 	isWindowsOSFunc = func() bool { return true }
+	smbUnmountFunc = func(_ *mount.SafeFormatAndMount, _ string, _ bool, _ bool) error {
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	}
 	defer func() {
 		nodeUnstageSMBUnmountTimeout = oldTimeout
 		isWindowsOSFunc = oldIsWindowsOSFunc
+		smbUnmountFunc = oldSMBUnmountFunc
 		_ = os.RemoveAll(targetSlow)
 	}()
 

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -1782,9 +1782,12 @@ func TestNodeUnstageVolumeTimeout(t *testing.T) {
 	d.removeSMBMountOnWindows = true
 
 	oldTimeout := nodeUnstageSMBUnmountTimeout
+	oldIsWindowsOSFunc := isWindowsOSFunc
 	nodeUnstageSMBUnmountTimeout = 50 * time.Millisecond
+	isWindowsOSFunc = func() bool { return true }
 	defer func() {
 		nodeUnstageSMBUnmountTimeout = oldTimeout
+		isWindowsOSFunc = oldIsWindowsOSFunc
 		_ = os.RemoveAll(targetSlow)
 	}()
 

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -1784,13 +1784,16 @@ func TestNodeUnstageVolumeTimeout(t *testing.T) {
 	oldTimeout := nodeUnstageSMBUnmountTimeout
 	oldIsWindowsOSFunc := isWindowsOSFunc
 	oldSMBUnmountFunc := smbUnmountFunc
+	slowUnmountDone := make(chan struct{})
 	nodeUnstageSMBUnmountTimeout = 50 * time.Millisecond
 	isWindowsOSFunc = func() bool { return true }
 	smbUnmountFunc = func(_ *mount.SafeFormatAndMount, _ string, _ bool, _ bool) error {
+		defer close(slowUnmountDone)
 		time.Sleep(200 * time.Millisecond)
 		return nil
 	}
 	defer func() {
+		<-slowUnmountDone
 		nodeUnstageSMBUnmountTimeout = oldTimeout
 		isWindowsOSFunc = oldIsWindowsOSFunc
 		smbUnmountFunc = oldSMBUnmountFunc

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	volume "github.com/kata-containers/kata-containers/src/runtime/pkg/direct-volume"
@@ -1765,6 +1766,36 @@ func TestNodeUnstageVolume(t *testing.T) {
 	// Clean up
 	err = os.RemoveAll(errorTarget)
 	assert.NoError(t, err)
+}
+
+func TestNodeUnstageVolumeTimeout(t *testing.T) {
+	targetSlow := testutil.GetWorkDirPath("slow_unmount_false_is_likely", t)
+	d := NewFakeDriver()
+	mounter, err := NewFakeMounter()
+	if err != nil {
+		t.Fatalf("failed to get fake mounter: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		mounter.Exec = &testingexec.FakeExec{ExactOrder: true}
+	}
+	d.mounter = mounter
+	d.removeSMBMountOnWindows = true
+
+	oldTimeout := nodeUnstageSMBUnmountTimeout
+	nodeUnstageSMBUnmountTimeout = 50 * time.Millisecond
+	defer func() {
+		nodeUnstageSMBUnmountTimeout = oldTimeout
+		_ = os.RemoveAll(targetSlow)
+	}()
+
+	_ = makeDir(targetSlow, 0755)
+	_, err = d.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{StagingTargetPath: targetSlow, VolumeId: "vol_1"})
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "windows SMB unmount operation timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
 }
 
 func TestNodeGetVolumeStats(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR is being closed instead of merged.

## Why
After looking at the Windows unmount behavior again, the more likely issue is that application pods still have active access to the mounted Azure Files share when `NodeUnstageVolume` tries to remove the SMB global mapping.

In that situation, adding a driver-side timeout is not the right fix. A timeout would only make the unstage path fail faster, while the underlying problem would still be that the workload has not released the file share cleanly.

## Current recommendation
If Windows unmount gets stuck, the user should first resolve the application-side issue, for example by:
- identifying pods/processes that still access the mounted file share
- stopping or draining the affected workload/node so file handles are released
- retrying after the SMB mapping can be removed cleanly

Given that, this PR will be closed.
