### PR TITLE
fix: default DRIVER_NAME in azurefile-proxy install script

### DIFF
--- a/pkg/azurefile-proxy/install-proxy.sh
+++ b/pkg/azurefile-proxy/install-proxy.sh
@@ -16,6 +16,9 @@
 
 set -xe
 
+KUBELET_PATH=${KUBELET_PATH:-/var/lib/kubelet}
+DRIVER_NAME=${DRIVER_NAME:-file.csi.azure.com}
+
 if [ "${MIGRATE_K8S_REPO}" = "true" ]
 then
   # https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#how-to-migrate


### PR DESCRIPTION
Follow-up fix for #3289.

**What this PR does / why we need it**:

Defines default values for `KUBELET_PATH` and `DRIVER_NAME` inside `pkg/azurefile-proxy/install-proxy.sh`.

`init.sh` already sets these defaults before sourcing `install-proxy.sh`, but `install-proxy.sh` also references both variables directly when removing the existing socket path on the host. Adding the defaults in the install script itself makes it self-contained and avoids depending on the caller to populate `DRIVER_NAME`.

This is particularly important for `DRIVER_NAME`, since #3289 started using it in `install-proxy.sh` to clean up the socket path under `${KUBELET_PATH}/plugins/${DRIVER_NAME}`.

**Which issue(s) this PR fixes**:

Follow-up to #3289.

**Release note**:
```release-note
NONE
```
