### PR TITLE
test: enable restore for oauth standard smb snapshot case

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -902,7 +902,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test.Run(ctx, cs, ns)
 	})
 
-	ginkgo.It("should create a pod, write and read to it, take a standard smb volume snapshot, and validate whether it is ready to use [file.csi.azure.com]", func(ctx ginkgo.SpecContext) {
+	ginkgo.It("should create a pod, write and read to it, take a standard smb volume snapshot, and validate whether it is ready to use (oauth) [file.csi.azure.com]", func(ctx ginkgo.SpecContext) {
 		skipIfTestingInWindowsCluster()
 		skipIfUsingInTreeVolumePlugin()
 
@@ -925,7 +925,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			CSIDriver:       testDriver,
 			Pod:             pod,
 			ShouldOverwrite: false,
-			ShouldRestore:   false,
+			ShouldRestore:   true,
 			PodWithSnapshot: podWithSnapshot,
 			StorageClassParameters: map[string]string{
 				"skuName":                     "Standard_LRS",


### PR DESCRIPTION
## What this PR does
- changes the OAuth standard SMB volume snapshot e2e case to set `ShouldRestore: true`
- updates the test title to explicitly include `(oauth)`

## Test case updated
- `should create a pod, write and read to it, take a standard smb volume snapshot, and validate whether it is ready to use (oauth) [file.csi.azure.com]`

## Why
This test is intended to cover the OAuth data-plane path for standard SMB snapshots.
Enabling restore makes the case validate snapshot restore behavior as part of the same flow, and the title update makes the OAuth coverage explicit.
