### PR TITLE
fix: include snapshots in data plane file share delete

### DIFF
--- a/pkg/azurefile/azurefile_dataplane_client.go
+++ b/pkg/azurefile/azurefile_dataplane_client.go
@@ -96,7 +96,9 @@ func (f *azureFileDataplaneClient) CreateFileShare(ctx context.Context, shareOpt
 
 // delete a file share
 func (f *azureFileDataplaneClient) DeleteFileShare(ctx context.Context, shareName string) error {
-	_, err := f.Client.NewShareClient(shareName).Delete(ctx, nil)
+	_, err := f.Client.NewShareClient(shareName).Delete(ctx, &share.DeleteOptions{
+		DeleteSnapshots: to.Ptr(share.DeleteSnapshotsOptionTypeInclude),
+	})
 	return err
 }
 


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
When `DeleteVolume` uses the Azure File data plane client (including the OAuth path), deleting a share that still has snapshots can fail with:

```text
409 The share has snapshots and the operation requires no snapshots.
ErrorCode: ShareHasSnapshots
```

This change updates the data plane `DeleteFileShare` call to pass `DeleteSnapshotsOptionTypeInclude` so the backing share delete includes snapshots instead of failing with `ShareHasSnapshots`.

## Which issue(s) this PR fixes:
Fixes #

## Special notes for your reviewer:
Observed failure from controller logs:

```text
DeleteFileShare pvc-... failed with error: ...
RESPONSE 409: 409 The share has snapshots and the operation requires no snapshots.
ERROR CODE: ShareHasSnapshots
```

This is intentionally scoped to the data plane delete path.

## Does this PR introduce a user-facing change?
```release-note
fix: include snapshots when deleting Azure File shares through the data plane client
```
