### PR TITLE
feat: support snapshot metadata in CreateSnapshot (cherry-pick #3337)

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -140,6 +140,7 @@ kubectl create secret generic azure-storage-account-{accountname}-secret --from-
 Name | Meaning | Available Value | Mandatory | Default value
 --- | --- | --- | --- | ---
 useDataPlaneAPI | specify whether use [data plane API](https://github.com/Azure/azure-sdk-for-go/blob/master/storage/share.go) for snapshot create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account | `true`,`false` | No | `false`
+metadata | metadata to store on the [file share snapshot](https://learn.microsoft.com/en-us/rest/api/storageservices/snapshot-share#request-headers). Metadata names must follow the Azure Files metadata naming rules. The `initiator` name is reserved by the driver. | key-value pairs in the same format as `tags`, e.g. `'comment=snapshot before database migration,environment=production'` | No | `""`
 
 ### `VolumeAttributesClass`
 

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -121,6 +121,7 @@ const (
 	secretNameField                   = "secretname"
 	createAccountField                = "createaccount"
 	useDataPlaneAPIField              = "usedataplaneapi"
+	metadataField                     = "metadata"
 	storeAccountKeyField              = "storeaccountkey"
 	getLatestAccountKeyField          = "getlatestaccountkey"
 	useSecretCacheField               = "usesecretcache"

--- a/pkg/azurefile/controllerserver.go
+++ b/pkg/azurefile/controllerserver.go
@@ -1075,6 +1075,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 	}
 
 	var useDataPlaneAPI string
+	snapshotMetadata := make(map[string]string)
 	for k, v := range req.GetParameters() {
 		switch strings.ToLower(k) {
 		case useDataPlaneAPIField:
@@ -1082,6 +1083,16 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 				return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %s in snapshot storage class", useDataPlaneAPIField, v)
 			}
 			useDataPlaneAPI = v
+		case metadataField:
+			snapshotMetadata, err = ConvertTagsToMap(v, "")
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid %s in snapshot storage class: %v", metadataField, err)
+			}
+			for key := range snapshotMetadata {
+				if strings.EqualFold(key, snapshotNameKey) {
+					return nil, status.Errorf(codes.InvalidArgument, "%q is reserved snapshot metadata", snapshotNameKey)
+				}
+			}
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "invalid parameter %q in storage class", k)
 		}
@@ -1117,19 +1128,18 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 		}, nil
 	}
 
+	metadata := getSnapshotMetadata(snapshotName, snapshotMetadata)
+
 	if len(req.GetSecrets()) > 0 || useDataPlaneAPI != "" {
 		shareClient, err := d.getShareClient(ctx, sourceVolumeID, req.GetSecrets(), useDataPlaneAPI)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get share url with (%s): %v", sourceVolumeID, err)
 		}
 
-		snapshotShare, err := shareClient.CreateSnapshot(ctx, &share.CreateSnapshotOptions{
-			Metadata: map[string]*string{snapshotNameKey: to.Ptr(snapshotName)},
-		})
+		snapshotShare, err := createShareSnapshot(ctx, shareClient, metadata)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "create snapshot from(%s) failed with %v", sourceVolumeID, err)
 		}
-
 		properties, err := shareClient.GetProperties(ctx, nil)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get snapshot properties from (%s): %v", *snapshotShare.Snapshot, err)
@@ -1144,7 +1154,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 			return nil, status.Errorf(codes.Internal, "failed to get snapshot client for subID(%s): %v", subsID, err)
 		}
 		snapshotShare, err := fileshareClient.Create(ctx, rgName, accountName, fileShareName, armstorage.FileShare{Name: to.Ptr(fileShareName),
-			FileShareProperties: &armstorage.FileShareProperties{Metadata: map[string]*string{snapshotNameKey: &snapshotName}}}, to.Ptr(snapshotsExpand))
+			FileShareProperties: &armstorage.FileShareProperties{Metadata: metadata}}, to.Ptr(snapshotsExpand))
 		if err != nil {
 			if isThrottlingError(err) {
 				klog.Warningf("switch to use data plane API instead for account %s since it's throttled", accountName)
@@ -1199,6 +1209,23 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 	}
 
 	return resp, nil
+}
+
+type snapshotShareClient interface {
+	CreateSnapshot(context.Context, *share.CreateSnapshotOptions) (share.CreateSnapshotResponse, error)
+}
+
+func getSnapshotMetadata(snapshotName string, snapshotMetadata map[string]string) map[string]*string {
+	metadata := make(map[string]*string, len(snapshotMetadata)+1)
+	metadata[snapshotNameKey] = to.Ptr(snapshotName)
+	for key, value := range snapshotMetadata {
+		metadata[key] = to.Ptr(value)
+	}
+	return metadata
+}
+
+func createShareSnapshot(ctx context.Context, shareClient snapshotShareClient, metadata map[string]*string) (share.CreateSnapshotResponse, error) {
+	return shareClient.CreateSnapshot(ctx, &share.CreateSnapshotOptions{Metadata: metadata})
 }
 
 // DeleteSnapshot delete a snapshot (todo)

--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	armstorage "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/share"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/onsi/ginkgo/v2"
@@ -2398,6 +2399,28 @@ var _ = ginkgo.Describe("CreateSnapshot", func() {
 					expectedErr: status.Errorf(codes.InvalidArgument, "invalid %s: %s in snapshot storage class", useDataPlaneAPIField, "invalid"),
 				},
 				{
+					desc: "Invalid snapshot metadata",
+					req: &csi.CreateSnapshotRequest{
+						SourceVolumeId: "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#subsID",
+						Name:           "snapname",
+						Parameters: map[string]string{
+							"metadata": "comment",
+						},
+					},
+					expectedErrMsg: "invalid metadata in snapshot storage class",
+				},
+				{
+					desc: "Reserved snapshot metadata",
+					req: &csi.CreateSnapshotRequest{
+						SourceVolumeId: "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#subsID",
+						Name:           "snapname",
+						Parameters: map[string]string{
+							"metadata": "Initiator=custom",
+						},
+					},
+					expectedErr: status.Errorf(codes.InvalidArgument, "%q is reserved snapshot metadata", snapshotNameKey),
+				},
+				{
 					desc: "Snapshot already exists",
 					req: &csi.CreateSnapshotRequest{
 						SourceVolumeId: "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#subsID",
@@ -2424,8 +2447,20 @@ var _ = ginkgo.Describe("CreateSnapshot", func() {
 					},
 					expectedErrMsg: "failed to check if snapshot(snapname) exists",
 				},
+				{
+					desc: "Create snapshot success with metadata",
+					req: &csi.CreateSnapshotRequest{
+						SourceVolumeId: "rg#f5713de20cde511e8ba4900#fileShareName#diskname.vhd#uuid#namespace#subsID",
+						Name:           "snapname",
+						Parameters: map[string]string{
+							"metadata": "comment=snapshot before migration,environment=production",
+						},
+					},
+					expectedErr: nil,
+				},
 			}
 
+			var createdShare armstorage.FileShare
 			for _, test := range tests {
 				if test.desc == "Snapshot already exists" {
 					mockFileClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*armstorage.FileShareItem{
@@ -2460,13 +2495,17 @@ var _ = ginkgo.Describe("CreateSnapshot", func() {
 							ShareQuota: to.Ptr(int32(100)),
 						},
 					}, nil).AnyTimes()
-					mockFileClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armstorage.FileShare{
-						Name: to.Ptr("fileShareName"),
-						FileShareProperties: &armstorage.FileShareProperties{
-							SnapshotTime: to.Ptr(time.Now()),
-							ShareQuota:   to.Ptr(int32(0)),
-						},
-					}, nil).AnyTimes()
+					mockFileClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, _, _, _ string, resource armstorage.FileShare, _ *string) (*armstorage.FileShare, error) {
+							createdShare = resource
+							return &armstorage.FileShare{
+								Name: to.Ptr("fileShareName"),
+								FileShareProperties: &armstorage.FileShareProperties{
+									SnapshotTime: to.Ptr(time.Now()),
+									ShareQuota:   to.Ptr(int32(0)),
+								},
+							}, nil
+						}).AnyTimes()
 				}
 
 				_, err := d.CreateSnapshot(context.Background(), test.req)
@@ -2479,10 +2518,45 @@ var _ = ginkgo.Describe("CreateSnapshot", func() {
 				} else {
 					gomega.Expect(err).To(gomega.BeNil())
 				}
+
+				if test.desc == "Create snapshot success with metadata" {
+					gomega.Expect(createdShare.FileShareProperties.Metadata).To(gomega.HaveKeyWithValue("comment", to.Ptr("snapshot before migration")))
+					gomega.Expect(createdShare.FileShareProperties.Metadata).To(gomega.HaveKeyWithValue("environment", to.Ptr("production")))
+					gomega.Expect(createdShare.FileShareProperties.Metadata).To(gomega.HaveKeyWithValue(snapshotNameKey, to.Ptr("snapname")))
+				}
 			}
+		})
+
+		ginkgo.It("passes metadata to the data-plane snapshot request", func(ctx context.Context) {
+			var capturedOptions *share.CreateSnapshotOptions
+			shareClient := &fakeSnapshotShareClient{
+				createSnapshot: func(_ context.Context, options *share.CreateSnapshotOptions) (share.CreateSnapshotResponse, error) {
+					capturedOptions = options
+					return share.CreateSnapshotResponse{}, nil
+				},
+			}
+
+			_, err := createShareSnapshot(ctx, shareClient, getSnapshotMetadata("snapname", map[string]string{
+				"comment":     "snapshot before migration",
+				"environment": "production",
+			}))
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(capturedOptions.Metadata).To(gomega.HaveKeyWithValue(snapshotNameKey, to.Ptr("snapname")))
+			gomega.Expect(capturedOptions.Metadata).To(gomega.HaveKeyWithValue("comment", to.Ptr("snapshot before migration")))
+			gomega.Expect(capturedOptions.Metadata).To(gomega.HaveKeyWithValue("environment", to.Ptr("production")))
 		})
 	})
 })
+
+type fakeSnapshotShareClient struct {
+	createSnapshot func(context.Context, *share.CreateSnapshotOptions) (share.CreateSnapshotResponse, error)
+}
+
+func (f *fakeSnapshotShareClient) CreateSnapshot(ctx context.Context, options *share.CreateSnapshotOptions) (share.CreateSnapshotResponse, error) {
+	return f.createSnapshot(ctx, options)
+}
+
 var _ = ginkgo.DescribeTable("DeleteSnapshot", func(req *csi.DeleteSnapshotRequest, expectedErr error) {
 	d := NewFakeDriver()
 	d.cloud = &storage.AccountRepo{}


### PR DESCRIPTION
Cherry-pick of #3337 to release-1.35.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Cherry-picks snapshot metadata support from #3337 into the release-1.35 branch.

- New `metadata` parameter accepted in `VolumeSnapshotClass` parameters
- Reuses existing `ConvertTagsToMap` helper to parse metadata into key-value pairs
- Writes custom metadata on both data plane and SRP snapshot creation paths
- Reserves the driver-owned `initiator` metadata key

**Release note**:
```release-note
feat: support custom metadata in VolumeSnapshotClass for Azure file share snapshots
```