### PR TITLE
test(e2e): add metadata parameter to snapshot storage class

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -176,7 +176,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			PodOverwrite:                   podOverwrite,
 			PodWithSnapshot:                podWithSnapshot,
 			StorageClassParameters:         map[string]string{"skuName": "Standard_LRS"},
-			SnapshotStorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
+			SnapshotStorageClassParameters: map[string]string{"skuName": "Premium_LRS", "metadata": "comment=e2e-snapshot,environment=test"},
 		}
 		test.Run(ctx, cs, snapshotrcs, ns)
 	})

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -176,7 +176,8 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			PodOverwrite:                   podOverwrite,
 			PodWithSnapshot:                podWithSnapshot,
 			StorageClassParameters:         map[string]string{"skuName": "Standard_LRS"},
-			SnapshotStorageClassParameters: map[string]string{"skuName": "Premium_LRS", "metadata": "comment=e2e-snapshot,environment=test"},
+			SnapshotStorageClassParameters: map[string]string{"skuName": "Premium_LRS"},
+			VolumeSnapshotClassParameters:  map[string]string{"metadata": "comment=e2e-snapshot,environment=test"},
 		}
 		test.Run(ctx, cs, snapshotrcs, ns)
 	})

--- a/test/e2e/testsuites/dynamically_provisioned_volume_snapshot_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_volume_snapshot_tester.go
@@ -64,13 +64,7 @@ func (t *DynamicallyProvisionedVolumeSnapshotTest) Run(ctx context.Context, clie
 	time.Sleep(time.Millisecond * 10000)
 
 	ginkgo.By("creating volume snapshot class")
-	tvsc, cleanup := CreateVolumeSnapshotClass(ctx, restclient, namespace, t.CSIDriver)
-	if tvsc.volumeSnapshotClass.Parameters == nil {
-		tvsc.volumeSnapshotClass.Parameters = map[string]string{}
-	}
-	for k, v := range t.VolumeSnapshotClassParameters {
-		tvsc.volumeSnapshotClass.Parameters[k] = v
-	}
+	tvsc, cleanup := CreateVolumeSnapshotClass(ctx, restclient, namespace, t.CSIDriver, t.VolumeSnapshotClassParameters)
 	defer cleanup()
 
 	ginkgo.By("sleeping for 5 seconds to wait for data to be written to the volume")

--- a/test/e2e/testsuites/dynamically_provisioned_volume_snapshot_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_volume_snapshot_tester.go
@@ -43,6 +43,7 @@ type DynamicallyProvisionedVolumeSnapshotTest struct {
 	PodWithSnapshot                PodDetails
 	StorageClassParameters         map[string]string
 	SnapshotStorageClassParameters map[string]string
+	VolumeSnapshotClassParameters  map[string]string
 }
 
 func (t *DynamicallyProvisionedVolumeSnapshotTest) Run(ctx context.Context, client clientset.Interface, restclient restclientset.Interface, namespace *v1.Namespace) {
@@ -66,6 +67,9 @@ func (t *DynamicallyProvisionedVolumeSnapshotTest) Run(ctx context.Context, clie
 	tvsc, cleanup := CreateVolumeSnapshotClass(ctx, restclient, namespace, t.CSIDriver)
 	if tvsc.volumeSnapshotClass.Parameters == nil {
 		tvsc.volumeSnapshotClass.Parameters = map[string]string{}
+	}
+	for k, v := range t.VolumeSnapshotClassParameters {
+		tvsc.volumeSnapshotClass.Parameters[k] = v
 	}
 	defer cleanup()
 

--- a/test/e2e/testsuites/specs.go
+++ b/test/e2e/testsuites/specs.go
@@ -282,9 +282,17 @@ func (volume *VolumeDetails) SetupPreProvisionedPersistentVolumeClaim(ctx contex
 	return tpvc, cleanupFuncs
 }
 
-func CreateVolumeSnapshotClass(ctx context.Context, client restclientset.Interface, namespace *v1.Namespace, csiDriver driver.VolumeSnapshotTestDriver) (*TestVolumeSnapshotClass, func()) {
+func CreateVolumeSnapshotClass(ctx context.Context, client restclientset.Interface, namespace *v1.Namespace, csiDriver driver.VolumeSnapshotTestDriver, extraParameters map[string]string) (*TestVolumeSnapshotClass, func()) {
 	ginkgo.By("setting up the VolumeSnapshotClass")
 	volumeSnapshotClass := csiDriver.GetVolumeSnapshotClass(namespace.Name)
+	if extraParameters != nil {
+		if volumeSnapshotClass.Parameters == nil {
+			volumeSnapshotClass.Parameters = map[string]string{}
+		}
+		for k, v := range extraParameters {
+			volumeSnapshotClass.Parameters[k] = v
+		}
+	}
 	tvsc := NewTestVolumeSnapshotClass(client, namespace, volumeSnapshotClass)
 	tvsc.Create(ctx)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Exercises the new `metadata` snapshot parameter (added in #3337) in the dynamic provisioning snapshot restore e2e test to make sure snapshot creation still works when custom metadata is supplied.

**Release note**:
```release-note
NONE
```