### PR TITLE
cleanup: reduce log noise for ephemeral (CSI inline) volume NodePublishVolume path

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -139,7 +139,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 					return nil, err
 				}
 			}
-			klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s", volumeID, target)
+			klog.V(6).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s", volumeID, target)
 			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
 				StagingTargetPath: target,
 				VolumeContext:     context,
@@ -251,7 +251,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	}
 
 	// NodePublishVolume should only alter volume content after the initial successful mount.
-	mnt, err := d.ensureMountPoint(target, os.FileMode(mountPermissions), false)
+	mnt, err := d.ensureMountPoint(target, os.FileMode(mountPermissions), false, false)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %s: %v", target, err)
 	}
@@ -583,7 +583,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 	klog.V(2).Infof("cifsMountPath(%v) fstype(%v) volumeID(%v) mountflags(%v) mountOptions(%v) volumeMountGroup(%s)", cifsMountPath, fsType, volumeID, mountFlags, mountOptions, volumeMountGroup)
 
-	isDirMounted, err := d.ensureMountPoint(cifsMountPath, os.FileMode(mountPermissions), true)
+	isDirMounted, err := d.ensureMountPoint(cifsMountPath, os.FileMode(mountPermissions), true, ephemeralVol)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %s: %v", cifsMountPath, err)
 	}
@@ -697,7 +697,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	if isDiskMount {
-		mnt, err := d.ensureMountPoint(targetPath, os.FileMode(mountPermissions), true)
+		mnt, err := d.ensureMountPoint(targetPath, os.FileMode(mountPermissions), true, ephemeralVol)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "mount %s on target %s failed with %v", volumeID, targetPath, err)
 		}
@@ -912,7 +912,10 @@ func (d *Driver) NodeExpandVolume(_ context.Context, _ *csi.NodeExpandVolumeRequ
 
 // ensureMountPoint: create mount point if not exists
 // return <true, nil> if it's already a mounted point otherwise return <false, nil>
-func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount bool) (bool, error) {
+// ephemeralVol indicates whether this call is on the CSI ephemeral (inline) volume
+// short-circuit path; kubelet reconciles those on every sync loop, so the
+// "already mounted" log is demoted to V(6) to avoid log flooding.
+func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount, ephemeralVol bool) (bool, error) {
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
 	if err != nil && !os.IsNotExist(err) {
 		if IsCorruptedDir(target) {
@@ -957,7 +960,11 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 			}
 		}
 		if err == nil {
-			klog.V(2).Infof("already mounted to target %s", target)
+			if ephemeralVol {
+				klog.V(6).Infof("already mounted to target %s", target)
+			} else {
+				klog.V(2).Infof("already mounted to target %s", target)
+			}
 			return !notMnt, nil
 		}
 		if shouldUnmount {

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -1940,6 +1940,10 @@ func TestEnsureMountPointEphemeralLogVerbosity(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
+	// klog defaults to logtostderr=true, which bypasses SetOutput. Disable it
+	// so the buffer captures the log output.
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
 	klog.SetOutput(buf)
 	defer klog.SetOutput(io.Discard)
 	var vLevel klog.Level

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package azurefile
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -44,6 +46,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	testingclient "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 	"k8s.io/utils/exec"
 	testingexec "k8s.io/utils/exec/testing"
@@ -1918,6 +1921,73 @@ func TestEnsureMountPoint(t *testing.T) {
 	assert.NoError(t, err)
 	err = os.RemoveAll(targetTest)
 	assert.NoError(t, err)
+}
+
+func TestEnsureMountPointEphemeralLogVerbosity(t *testing.T) {
+	// The "already mounted to target ..." log is demoted to V(6) for the
+	// ephemeral (CSI inline) volume path to avoid flooding logs on kubelet
+	// republish reconciles. Non-ephemeral callers must keep V(2) visibility.
+	alreadyMountedTarget := "./false_is_likely_ephemeral_target"
+	_ = makeDir(alreadyMountedTarget, 0755)
+	defer func() { _ = os.RemoveAll(alreadyMountedTarget) }()
+
+	d := NewFakeDriver()
+	fakeMounter := &fakeMounter{}
+	fakeExec := &testingexec.FakeExec{ExactOrder: true}
+	d.mounter = &mount.SafeFormatAndMount{
+		Interface: fakeMounter,
+		Exec:      fakeExec,
+	}
+
+	buf := new(bytes.Buffer)
+	klog.SetOutput(buf)
+	defer klog.SetOutput(io.Discard)
+	var vLevel klog.Level
+	defer func() { _ = vLevel.Set("0") }()
+
+	tests := []struct {
+		name         string
+		v            string
+		ephemeralVol bool
+		expectLog    bool
+	}{
+		{
+			name:         "non-ephemeral: already-mounted log is visible at V(2)",
+			v:            "2",
+			ephemeralVol: false,
+			expectLog:    true,
+		},
+		{
+			name:         "ephemeral: already-mounted log is suppressed at V(2)",
+			v:            "2",
+			ephemeralVol: true,
+			expectLog:    false,
+		},
+		{
+			name:         "ephemeral: already-mounted log is visible at V(6)",
+			v:            "6",
+			ephemeralVol: true,
+			expectLog:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_ = vLevel.Set(test.v)
+			buf.Reset()
+
+			// shouldUnmount=false hits the fast "already mounted" branch.
+			_, err := d.ensureMountPoint(alreadyMountedTarget, 0777, false, test.ephemeralVol)
+			assert.NoError(t, err)
+			klog.Flush()
+
+			if test.expectLog {
+				assert.Contains(t, buf.String(), "already mounted to target")
+			} else {
+				assert.NotContains(t, buf.String(), "already mounted to target")
+			}
+		})
+	}
 }
 
 func TestMakeDir(t *testing.T) {

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -1902,7 +1902,7 @@ func TestEnsureMountPoint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := d.ensureMountPoint(test.target, 0777, test.shouldUnmount)
+		_, err := d.ensureMountPoint(test.target, 0777, test.shouldUnmount, false)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("[%s]: Unexpected Error: %v, expected error: %v", test.desc, err, test.expectedErr)
 		}

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -109,7 +109,15 @@ func LogGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
 	} else {
-		klog.V(level).Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
+		respStr := protosanitizer.StripSecrets(resp).String()
+		// Empty response bodies carry zero diagnostic value but dominate node
+		// logs (kubelet reconciles NodePublishVolume/NodeUnpublishVolume on
+		// every sync loop, all of which return "{}" on success). Demote to V(6).
+		respLevel := level
+		if respStr == "{}" {
+			respLevel = klog.Level(6)
+		}
+		klog.V(respLevel).Infof("GRPC response: %s", respStr)
 	}
 	return resp, err
 }

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -108,11 +108,14 @@ func LogGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
-	} else {
-		respStr := protosanitizer.StripSecrets(resp).String()
+	} else if klog.V(level).Enabled() {
+		// Only serialize once we know V(level) is enabled so that
+		// protosanitizer's lazy formatting is preserved for disabled levels
+		// (e.g. probe/NodeGetCapabilities at V(6) in production).
 		// Empty response bodies carry zero diagnostic value but dominate node
 		// logs (kubelet reconciles NodePublishVolume/NodeUnpublishVolume on
 		// every sync loop, all of which return "{}" on success). Demote to V(6).
+		respStr := protosanitizer.StripSecrets(resp).String()
 		respLevel := level
 		if respStr == "{}" {
 			respLevel = klog.Level(6)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Kubelet reconciles CSI inline (ephemeral) volumes on every sync loop, and reconciles every mounted volume on every sync loop generally. For the azurefile node driver this produces multiple log lines per pod per reconcile even when nothing changed. Three of those lines are pure noise on the idempotent short path.

This PR demotes them to `klog.V(6)`:

| # | Log line | Where | When demoted |
|---|---|---|---|
| 1 | `NodePublishVolume: ephemeral volume(csi-xxx) mount on ...` | `nodeserver.go` | ephemeral path only |
| 2 | `already mounted to target ...` | `nodeserver.go` (`ensureMountPoint`) | ephemeral path only |
| 3 | `GRPC response: {}` | `csi-common/utils.go` (`LogGRPC`) | whenever response body is exactly `{}` |

PVC-backed mounts (which only `NodePublishVolume` once per pod lifetime) and any non-empty GRPC response keep their existing `V(2)` verbosity, so real mount events and RPCs with actual payload are still visible at default log level.

`ensureMountPoint` gains an `ephemeralVol` parameter so the `already mounted to target` log can branch on volume type without adding a separate helper. All existing callers are updated:

- `NodePublishVolume` bind-mount path: not ephemeral-aware (kept `false`).
- `NodeStageVolume` (CIFS + disk paths): pass through `ephemeralVol` from the volume context.

**Impact on a real node log**

Sample analysis on a real `csi-azurefile-node` pod log (2355 lines, ~15 min window):

| Pattern | Lines | % of log |
|---|---|---|
| `NodePublishVolume: ephemeral volume(...) mount on ...` | 301 | 12.8% |
| `already mounted to target ...` | 117 | 5.0% |
| `GRPC response: {}` | 202 | 8.6% |
| **Total silenced at default verbosity** | **620** | **~26%** |

Combined with related noise (the successful `GRPC call` / `GRPC request` / metrics latency triples on the same idempotent path — not touched by this PR), the total addressable noise on that log is closer to 70%. This PR is the safe, minimal, log-only slice.

**Which issue(s) this PR fixes:**

Fixes # (n/a — log-noise cleanup)

**Requirements:**

- [x] Does the affected code have corresponding tests? existing `TestEnsureMountPoint` covers the new parameter (passes `false`); no behavior change for non-ephemeral path.
- [x] Are the changes documented? klog-only change.
- [ ] Is the change backward compatible? Log-only change; default verbosity unchanged. Operators who need the previous lines can raise `-v=6`.

**Release note:**

```release-note
Reduce log noise on the ephemeral (CSI inline) volume `NodePublishVolume` reconcile path: `NodePublishVolume: ephemeral volume(...) mount on ...` and `already mounted to target ...` are now emitted at klog `V(6)` for ephemeral volumes. Additionally, `GRPC response: {}` (empty response body) is demoted to `V(6)` across all node RPCs. PVC-backed volume mount logs and non-empty responses are unchanged. On typical node logs this removes ~25% of lines at the default verbosity.
```
