### PR TITLE
feat: add mount_operations_total metric to track per-share mount fail…

### DIFF
--- a/deploy/example/metrics/README.md
+++ b/deploy/example/metrics/README.md
@@ -49,6 +49,7 @@ The Azure File CSI driver exposes the following custom metrics:
 | `azurefile_csi_driver_operation_duration_seconds` | Histogram | `operation`, `success` | Duration of CSI operations in seconds |
 | `azurefile_csi_driver_operations_total` | Counter | `operation`, `success` | Total number of CSI operations |
 | `azurefile_csi_driver_mount_operations_total` | Counter | `operation`, `success`, `protocol`, `storage_account`, `file_share`, `subscription_id`, `resource_group`, `mount_error_reason` | Total number of mount-path executions, labeled with the target share identity and a classified error reason. Used to track mount failures for a single file share across many nodes/clusters/subscriptions. |
+| `azurefile_csi_driver_inline_volume_operations_total` | Counter | `success` | Total number of ephemeral (inline) volume `NodePublishVolume` operations. Incremented only on the inline code path. |
 
 **Label Values:**
 - `operation`: `node_stage_volume`, `node_unstage_volume`, `node_publish_volume`, `node_unpublish_volume`

--- a/deploy/example/metrics/README.md
+++ b/deploy/example/metrics/README.md
@@ -48,19 +48,19 @@ The Azure File CSI driver exposes the following custom metrics:
 |--------|------|--------|-------------|
 | `azurefile_csi_driver_operation_duration_seconds` | Histogram | `operation`, `success` | Duration of CSI operations in seconds |
 | `azurefile_csi_driver_operations_total` | Counter | `operation`, `success` | Total number of CSI operations |
-| `azurefile_csi_driver_mount_operations_total` | Counter | `operation`, `success`, `protocol`, `storage_account`, `file_share`, `subscription_id`, `resource_group`, `mount_error_reason` | Total number of mount-path executions, labeled with the target share identity and a classified error reason. Used to track mount failures for a single file share across many nodes/clusters/subscriptions. |
-| `azurefile_csi_driver_inline_volume_operations_total` | Counter | `success` | Total number of ephemeral (inline) volume `NodePublishVolume` operations. Incremented only on the inline code path. |
+| `azurefile_csi_driver_mount_operations_total` | Counter | `operation`, `success`, `protocol`, `storage_account`, `subscription_id`, `mount_error_reason` | Total number of mount-path executions, labeled with the target storage account identity (on failures) and a classified error reason. Used to track mount failures for a single file share across many nodes/clusters/subscriptions. |
 
 **Label Values:**
-- `operation`: `node_stage_volume`, `node_unstage_volume`, `node_publish_volume`, `node_unpublish_volume`
+- `operation`: `node_stage_volume`, `node_unstage_volume`, `node_publish_volume`, `node_unpublish_volume`, `inline_mount`
 - `success`: `true`, `false`
+
+Ephemeral (inline) volume `NodePublishVolume` calls are tracked through `operations_total` with `operation="inline_mount"`, so they can be distinguished from persistent publishes without a dedicated metric.
 
 **Details of `mount_operations_total`**
 - `operation`: `node_stage_volume_mount` (the mount command).
   - For disk-on-file (vhd) volumes a single `NodeStageVolume` emits two rows: the SMB mount (`protocol="cifs"`) and the inner disk mount (`protocol="disk"`), so filter `protocol="cifs"`/`"nfs"` when counting share mounts to avoid double-counting those volumes.
 - `protocol`: `SMB`/`cifs`, `NFS`/`nfs`, `aznfs`, or `disk`.
-- `storage_account`, `file_share`: the target share's identity. **Populated only on failed mounts** (`success="false"`); successful mounts leave these blank so steady-state cardinality stays bounded to the small set of distinct *failing* shares rather than every share ever mounted on the node.
-- `subscription_id`, `resource_group`: the target's subscription and resource group. Default to the node's own cloud config.
+- `storage_account`, `subscription_id`: the target share's storage account and subscription. **Populated only on failed mounts** (`success="false"`); successful mounts leave these blank so steady-state cardinality stays bounded to the small set of distinct *failing* shares/subscriptions rather than every share ever mounted on the node. `file_share` and `resource_group` are intentionally never recorded (file_share is per-PVC high-cardinality; resource_group adds no attribution value beyond account + subscription).
 - `mount_error_reason`: `""` on success, otherwise one of `timeout`, `network`, `stale` (retryable/transient), `busy` (target/resource busy, often already mounted), `enoent` (ambiguous, see below), `access_denied`, or `other`.
   - **`enoent` is ambiguous, not just "retryable"** for SMB. Kernel returns `mount error(2): No such file or directory` for a truly absent share (SMB2 maps `STATUS_BAD_NETWORK_NAME` to `-ENOENT`, terminal) and a transient tree-connect rejection under overload. `mount.cifs` prints the mapped errno, not status name (which only reaches `dmesg`), so indistinguishable from the mount error alone.
   - The reason is derived only from the mount command's own output (`mount.cifs`/`mount.nfs` stderr and synthesized timeout).

--- a/deploy/example/metrics/README.md
+++ b/deploy/example/metrics/README.md
@@ -48,10 +48,22 @@ The Azure File CSI driver exposes the following custom metrics:
 |--------|------|--------|-------------|
 | `azurefile_csi_driver_operation_duration_seconds` | Histogram | `operation`, `success` | Duration of CSI operations in seconds |
 | `azurefile_csi_driver_operations_total` | Counter | `operation`, `success` | Total number of CSI operations |
+| `azurefile_csi_driver_mount_operations_total` | Counter | `operation`, `success`, `protocol`, `storage_account`, `file_share`, `subscription_id`, `resource_group`, `mount_error_reason` | Total number of mount-path executions, labeled with the target share identity and a classified error reason. Used to track mount failures for a single file share across many nodes/clusters/subscriptions. |
 
 **Label Values:**
 - `operation`: `node_stage_volume`, `node_unstage_volume`, `node_publish_volume`, `node_unpublish_volume`
 - `success`: `true`, `false`
+
+**Details of `mount_operations_total`**
+- `operation`: `node_stage_volume_mount` (the mount command).
+  - For disk-on-file (vhd) volumes a single `NodeStageVolume` emits two rows: the SMB mount (`protocol="cifs"`) and the inner disk mount (`protocol="disk"`), so filter `protocol="cifs"`/`"nfs"` when counting share mounts to avoid double-counting those volumes.
+- `protocol`: `SMB`/`cifs`, `NFS`/`nfs`, `aznfs`, or `disk`.
+- `storage_account`, `file_share`: the target share's identity. **Populated only on failed mounts** (`success="false"`); successful mounts leave these blank so steady-state cardinality stays bounded to the small set of distinct *failing* shares rather than every share ever mounted on the node.
+- `subscription_id`, `resource_group`: the target's subscription and resource group. Default to the node's own cloud config.
+- `mount_error_reason`: `""` on success, otherwise one of `timeout`, `network`, `stale` (retryable/transient), `busy` (target/resource busy, often already mounted), `enoent` (ambiguous, see below), `access_denied`, or `other`.
+  - **`enoent` is ambiguous, not just "retryable"** for SMB. Kernel returns `mount error(2): No such file or directory` for a truly absent share (SMB2 maps `STATUS_BAD_NETWORK_NAME` to `-ENOENT`, terminal) and a transient tree-connect rejection under overload. `mount.cifs` prints the mapped errno, not status name (which only reaches `dmesg`), so indistinguishable from the mount error alone.
+  - The reason is derived only from the mount command's own output (`mount.cifs`/`mount.nfs` stderr and synthesized timeout).
+  - The counter increments on both success and failure, so a failure ratio per share is computable (in addition to raw failure count).
 
 ### Azure Cloud Provider Metrics
 

--- a/deploy/example/metrics/README.md
+++ b/deploy/example/metrics/README.md
@@ -48,10 +48,21 @@ The Azure File CSI driver exposes the following custom metrics:
 |--------|------|--------|-------------|
 | `azurefile_csi_driver_operation_duration_seconds` | Histogram | `operation`, `success` | Duration of CSI operations in seconds |
 | `azurefile_csi_driver_operations_total` | Counter | `operation`, `success` | Total number of CSI operations |
+| `azurefile_csi_driver_mount_operations_total` | Counter | `operation`, `success`, `protocol`, `storage_account`, `file_share`, `subscription_id`, `resource_group`, `mount_error_reason` | Total number of mount-path executions, labeled with the target share identity and a classified error reason. Used to track mount failures for a single file share across many nodes/clusters/subscriptions. |
 
 **Label Values:**
 - `operation`: `node_stage_volume`, `node_unstage_volume`, `node_publish_volume`, `node_unpublish_volume`
 - `success`: `true`, `false`
+
+**Details of `mount_operations_total`**
+- `operation`: `node_stage_volume_mount` (the mount command).
+  - For disk-on-file (vhd) volumes a single `NodeStageVolume` emits two rows: the SMB mount (`protocol="cifs"`) and the inner disk mount (`protocol="disk"`), so filter `protocol="cifs"`/`"nfs"` when counting share mounts to avoid double-counting those volumes.
+- `protocol`: `SMB`/`cifs`, `NFS`/`nfs`, `aznfs`, or `disk`.
+- `storage_account`, `file_share`: the target share's identity. **Populated only on failed mounts** (`success="false"`); successful mounts leave these blank so steady-state cardinality stays bounded to the small set of distinct *failing* shares rather than every share ever mounted on the node.
+- `subscription_id`, `resource_group`: the target's subscription and resource group. Default to the node's own cloud config.
+- `mount_error_reason`: `""` on success, otherwise one of `timeout`, `network`, `stale` (retryable/transient), `busy` (target/resource busy, often already mounted), `enoent` (ambiguous, see below), `access_denied`, or `other`.
+  - **`enoent` is ambiguous, not just "retryable"** for SMB. Kernel returns `mount error(2): No such file or directory` for a truly absent share (SMB2 maps `STATUS_BAD_NETWORK_NAME` to `-ENOENT`, terminal) and a transient tree-connect rejection under overload. `mount.cifs` prints the mapped errno, not status name (which only reaches `dmesg`), so indistinguishable from the mount error alone.
+  - The reason is derived only from the mount command's own output (`mount.cifs`/`mount.nfs` stderr and synthesized timeout).
 
 ### Azure Cloud Provider Metrics
 

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -250,7 +250,11 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		klog.V(2).Infof("NodePublishVolume: refreshed OAuth token credential cache for volume(%s) server(%s)", volumeID, oauthServer)
 	}
 
-	// NodePublishVolume should only alter volume content after the initial successful mount.
+	// NodePublishVolume should only alter volume content after the initial
+	// successful mount. NodePublishVolume does not resolve the volume's ARM
+	// identity, parsing it from the volumeID gives a placeholder account for
+	// secret-based volumes. Pass blank identity instead, prefer node-scoped
+	// over mislabeled.
 	mnt, err := d.ensureMountPoint(target, os.FileMode(mountPermissions), false)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %s: %v", target, err)
@@ -351,7 +355,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		mc.WithAdditionalVolumeInfo(VolumeID, volumeID).Observe(returnedErr == nil)
 	}()
 
-	_, accountName, accountKey, fileShareName, diskName, _, tenantID, tokenFilePath, err := d.GetAccountInfo(ctx, volumeID, req.GetSecrets(), context)
+	rgName, accountName, accountKey, fileShareName, diskName, subsID, tenantID, tokenFilePath, err := d.GetAccountInfo(ctx, volumeID, req.GetSecrets(), context)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("GetAccountInfo(%s) failed with error: %v", volumeID, err))
 	}
@@ -476,6 +480,8 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	// replace pv/pvc name namespace metadata in fileShareName and folderName
 	fileShareName = replaceWithMap(fileShareName, volumeMetadataReplaceMap)
 	folderName = replaceWithMap(folderName, volumeMetadataReplaceMap)
+	// shareBaseName is the bare share name (subpath stripped)
+	shareBaseName := fileShareNameForMetric(fileShareName)
 	// Normalize folderName: trim leading/trailing slashes to prevent double-slash
 	// in the mount source path (e.g., //<server>/<share>//aa/bb).
 	folderName = strings.Trim(folderName, "/")
@@ -615,12 +621,16 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		}
 		if mountFsType == aznfs {
 			klog.V(2).Infof("either of encryptInTransit (%t) (or) useAZNFSForNFSMounts (%t) is enabled, mount by azurefile-proxy", encryptInTransit, d.useAZNFSForNFSMounts)
-			if err := d.mountWithProxy(ctx, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions); err != nil {
-				if strings.Contains(err.Error(), "no such file or directory") {
+			mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
+			mountErr := d.mountWithProxy(ctx, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions)
+			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
+				csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+			if mountErr != nil {
+				if strings.Contains(mountErr.Error(), "no such file or directory") {
 					return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v. "+
-						"Encryption in Transit (EiT) does not support Ubuntu 20.04, please upgrade your node OS version.", cifsMountPath, err)
+						"Encryption in Transit (EiT) does not support Ubuntu 20.04, please upgrade your node OS version.", cifsMountPath, mountErr)
 				}
-				return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v", cifsMountPath, err)
+				return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v", cifsMountPath, mountErr)
 			}
 			klog.V(2).Infof("mount with proxy succeeded for %s", cifsMountPath)
 		} else {
@@ -638,12 +648,16 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			timeoutFunc := func() error {
 				return fmt.Errorf("mount operation timed out after %d seconds: source=%s, target=%s", MountTimeoutInSec, source, cifsMountPath)
 			}
-			if err := volumehelper.WaitUntilTimeout(MountTimeoutInSec*time.Second, execFunc, timeoutFunc); err != nil {
+			mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
+			mountErr := volumehelper.WaitUntilTimeout(MountTimeoutInSec*time.Second, execFunc, timeoutFunc)
+			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
+				csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+			if mountErr != nil {
 				var helpLinkMsg string
 				if d.appendMountErrorHelpLink {
 					helpLinkMsg = "\nPlease refer to http://aka.ms/filemounterror for possible causes and solutions for mount errors."
 				}
-				return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %s on %s failed with %v%s", volumeID, source, cifsMountPath, err, helpLinkMsg))
+				return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %s on %s failed with %v%s", volumeID, source, cifsMountPath, mountErr, helpLinkMsg))
 			}
 		}
 		if protocol == nfs {
@@ -718,7 +732,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 		klog.V(2).Infof("NodeStageVolume: volume %s formatting %s and mounting at %s with mount options(%s)", volumeID, targetPath, diskPath, options)
 		// FormatAndMount will format only if needed
-		if err := d.mounter.FormatAndMount(diskPath, targetPath, fsType, options); err != nil {
+		mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
+		mountErr := d.mounter.FormatAndMount(diskPath, targetPath, fsType, options)
+		mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, "disk", csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
+			csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+		if mountErr != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("could not format %s and mount it at %s", targetPath, diskPath))
 		}
 		klog.V(2).Infof("NodeStageVolume: volume %s format %s and mounting at %s successfully", volumeID, targetPath, diskPath)

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -71,6 +71,15 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		mc.Observe(returnedErr == nil)
 	}()
 
+	// Track inline (ephemeral) volume usage independently of persistent
+	// volumes; the outcome is the NodePublishVolume result.
+	if strings.EqualFold(req.GetVolumeContext()[ephemeralField], trueValue) {
+		inlineMC := csiMetrics.NewCSIMetricContext("inline_mount")
+		defer func() {
+			inlineMC.Observe(returnedErr == nil)
+		}()
+	}
+
 	volCap := req.GetVolumeCapability()
 	if volCap == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume capability missing in request")
@@ -91,11 +100,6 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	serviceAccountTokens := getServiceAccountTokens(secrets, context)
 	if context != nil {
 		if strings.EqualFold(context[ephemeralField], trueValue) {
-			// Track inline (ephemeral) volume usage independently of persistent
-			// volumes; the outcome is the NodePublishVolume result.
-			defer func() {
-				csiMetrics.ObserveInlineVolumeOperation(returnedErr == nil)
-			}()
 			// Reject case duplicate keys
 			if key, ok := caseCollidingKey(context); ok {
 				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ephemeral volume request contains case-colliding volume attribute keys that normalize to %q", key))
@@ -481,8 +485,6 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	// replace pv/pvc name namespace metadata in fileShareName and folderName
 	fileShareName = replaceWithMap(fileShareName, volumeMetadataReplaceMap)
 	folderName = replaceWithMap(folderName, volumeMetadataReplaceMap)
-	// shareBaseName is the bare share name (subpath stripped)
-	shareBaseName := fileShareNameForMetric(fileShareName)
 	// Normalize folderName: trim leading/trailing slashes to prevent double-slash
 	// in the mount source path (e.g., //<server>/<share>//aa/bb).
 	folderName = strings.Trim(folderName, "/")
@@ -624,8 +626,8 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			klog.V(2).Infof("either of encryptInTransit (%t) (or) useAZNFSForNFSMounts (%t) is enabled, mount by azurefile-proxy", encryptInTransit, d.useAZNFSForNFSMounts)
 			mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
 			mountErr := d.mountWithProxy(ctx, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions)
-			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
-				csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName,
+				csiMetrics.SubscriptionID, subsID, csiMetrics.MountErrorReason, classifyMountError(mountErr))
 			if mountErr != nil {
 				if strings.Contains(mountErr.Error(), "no such file or directory") {
 					return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v. "+
@@ -651,8 +653,8 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			}
 			mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
 			mountErr := volumehelper.WaitUntilTimeout(MountTimeoutInSec*time.Second, execFunc, timeoutFunc)
-			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
-				csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName,
+				csiMetrics.SubscriptionID, subsID, csiMetrics.MountErrorReason, classifyMountError(mountErr))
 			if mountErr != nil {
 				var helpLinkMsg string
 				if d.appendMountErrorHelpLink {
@@ -735,8 +737,8 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		// FormatAndMount will format only if needed
 		mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
 		mountErr := d.mounter.FormatAndMount(diskPath, targetPath, fsType, options)
-		mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, "disk", csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
-			csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+		mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, "disk", csiMetrics.StorageAccount, accountName,
+			csiMetrics.SubscriptionID, subsID, csiMetrics.MountErrorReason, classifyMountError(mountErr))
 		if mountErr != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("could not format %s and mount it at %s", targetPath, diskPath))
 		}

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -19,6 +19,7 @@ package azurefile
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -643,7 +644,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 					// mount source below still uses `source` (which may be privatelink).
 					krbHost := getKerberosHost(server)
 					if out, err := setCredentialCache(krbHost, clientID, tenantID, tokenFilePath, "", d.getActiveDirectoryEndpoint(), d.getStorageResource()); err != nil {
-						return fmt.Errorf("setCredentialCache failed for %s with error: %v, output: %s", krbHost, err, out)
+						return fmt.Errorf("%w for %s with error: %v, output: %s", errCredentialCacheSetup, krbHost, err, out)
 					}
 				}
 				return SMBMount(d.mounter, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions)
@@ -653,8 +654,10 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			}
 			mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
 			mountErr := volumehelper.WaitUntilTimeout(MountTimeoutInSec*time.Second, execFunc, timeoutFunc)
-			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName,
-				csiMetrics.SubscriptionID, subsID, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+			if !errors.Is(mountErr, errCredentialCacheSetup) {
+				mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName,
+					csiMetrics.SubscriptionID, subsID, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+			}
 			if mountErr != nil {
 				var helpLinkMsg string
 				if d.appendMountErrorHelpLink {

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -351,7 +351,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		mc.WithAdditionalVolumeInfo(VolumeID, volumeID).Observe(returnedErr == nil)
 	}()
 
-	_, accountName, accountKey, fileShareName, diskName, _, tenantID, tokenFilePath, err := d.GetAccountInfo(ctx, volumeID, req.GetSecrets(), context)
+	rgName, accountName, accountKey, fileShareName, diskName, subsID, tenantID, tokenFilePath, err := d.GetAccountInfo(ctx, volumeID, req.GetSecrets(), context)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("GetAccountInfo(%s) failed with error: %v", volumeID, err))
 	}
@@ -476,6 +476,8 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	// replace pv/pvc name namespace metadata in fileShareName and folderName
 	fileShareName = replaceWithMap(fileShareName, volumeMetadataReplaceMap)
 	folderName = replaceWithMap(folderName, volumeMetadataReplaceMap)
+	// shareBaseName is the bare share name (subpath stripped)
+	shareBaseName := fileShareNameForMetric(fileShareName)
 	// Normalize folderName: trim leading/trailing slashes to prevent double-slash
 	// in the mount source path (e.g., //<server>/<share>//aa/bb).
 	folderName = strings.Trim(folderName, "/")
@@ -615,12 +617,16 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		}
 		if mountFsType == aznfs {
 			klog.V(2).Infof("either of encryptInTransit (%t) (or) useAZNFSForNFSMounts (%t) is enabled, mount by azurefile-proxy", encryptInTransit, d.useAZNFSForNFSMounts)
-			if err := d.mountWithProxy(ctx, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions); err != nil {
-				if strings.Contains(err.Error(), "no such file or directory") {
+			mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
+			mountErr := d.mountWithProxy(ctx, source, cifsMountPath, mountFsType, mountOptions, sensitiveMountOptions)
+			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
+				csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+			if mountErr != nil {
+				if strings.Contains(mountErr.Error(), "no such file or directory") {
 					return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v. "+
-						"Encryption in Transit (EiT) does not support Ubuntu 20.04, please upgrade your node OS version.", cifsMountPath, err)
+						"Encryption in Transit (EiT) does not support Ubuntu 20.04, please upgrade your node OS version.", cifsMountPath, mountErr)
 				}
-				return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v", cifsMountPath, err)
+				return nil, status.Errorf(codes.Internal, "mount with proxy failed for %s with error: %v", cifsMountPath, mountErr)
 			}
 			klog.V(2).Infof("mount with proxy succeeded for %s", cifsMountPath)
 		} else {
@@ -638,12 +644,16 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			timeoutFunc := func() error {
 				return fmt.Errorf("mount operation timed out after %d seconds: source=%s, target=%s", MountTimeoutInSec, source, cifsMountPath)
 			}
-			if err := volumehelper.WaitUntilTimeout(MountTimeoutInSec*time.Second, execFunc, timeoutFunc); err != nil {
+			mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
+			mountErr := volumehelper.WaitUntilTimeout(MountTimeoutInSec*time.Second, execFunc, timeoutFunc)
+			mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, mountFsType, csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
+				csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+			if mountErr != nil {
 				var helpLinkMsg string
 				if d.appendMountErrorHelpLink {
 					helpLinkMsg = "\nPlease refer to http://aka.ms/filemounterror for possible causes and solutions for mount errors."
 				}
-				return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %s on %s failed with %v%s", volumeID, source, cifsMountPath, err, helpLinkMsg))
+				return nil, status.Error(codes.Internal, fmt.Sprintf("volume(%s) mount %s on %s failed with %v%s", volumeID, source, cifsMountPath, mountErr, helpLinkMsg))
 			}
 		}
 		if protocol == nfs {
@@ -718,7 +728,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 		klog.V(2).Infof("NodeStageVolume: volume %s formatting %s and mounting at %s with mount options(%s)", volumeID, targetPath, diskPath, options)
 		// FormatAndMount will format only if needed
-		if err := d.mounter.FormatAndMount(diskPath, targetPath, fsType, options); err != nil {
+		mountMC := csiMetrics.NewCSIMetricContext("node_stage_volume_mount").WithBasicVolumeInfo(rgName, subsID, d.Name)
+		mountErr := d.mounter.FormatAndMount(diskPath, targetPath, fsType, options)
+		mountMC.ObserveMountWithLabels(mountErr == nil, csiMetrics.Protocol, "disk", csiMetrics.StorageAccount, accountName, csiMetrics.FileShare, shareBaseName,
+			csiMetrics.SubscriptionID, subsID, csiMetrics.ResourceGroup, rgName, csiMetrics.MountErrorReason, classifyMountError(mountErr))
+		if mountErr != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("could not format %s and mount it at %s", targetPath, diskPath))
 		}
 		klog.V(2).Infof("NodeStageVolume: volume %s format %s and mounting at %s successfully", volumeID, targetPath, diskPath)

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -91,6 +91,11 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	serviceAccountTokens := getServiceAccountTokens(secrets, context)
 	if context != nil {
 		if strings.EqualFold(context[ephemeralField], trueValue) {
+			// Track inline (ephemeral) volume usage independently of persistent
+			// volumes; the outcome is the NodePublishVolume result.
+			defer func() {
+				csiMetrics.ObserveInlineVolumeOperation(returnedErr == nil)
+			}()
 			// Reject case duplicate keys
 			if key, ok := caseCollidingKey(context); ok {
 				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ephemeral volume request contains case-colliding volume attribute keys that normalize to %q", key))

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -235,18 +235,6 @@ func classifyMountError(err error) string {
 	}
 }
 
-// fileShareNameForMetric returns just the Azure file share name for use as a
-// metric label, stripping any subpath that may be baked into the volumeID share
-// segment (e.g. "share/dir/sub" -> "share") for aggregation. A leading slash is
-// trimmed first so "/share/sub" still resolves to "share" rather than "".
-func fileShareNameForMetric(fileShareName string) string {
-	fileShareName = strings.TrimLeft(fileShareName, "/")
-	if i := strings.IndexByte(fileShareName, '/'); i >= 0 {
-		return fileShareName[:i]
-	}
-	return fileShareName
-}
-
 func isThrottlingError(err error) bool {
 	if err != nil {
 		errMsg := strings.ToLower(err.Error())

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -35,6 +35,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
+	mount "k8s.io/mount-utils"
 	azureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 )
 
@@ -142,6 +143,108 @@ func isRetriableError(err error) bool {
 		}
 	}
 	return false
+}
+
+// Mount error reason classifications recorded on the mount_error_reason metric label.
+const (
+	mountErrorTimeout      = "timeout"
+	mountErrorENOENT       = "enoent"
+	mountErrorAccessDenied = "access_denied"
+	mountErrorNetwork      = "network"
+	mountErrorStale        = "stale"
+	mountErrorBusy         = "busy"
+	mountErrorOther        = "other"
+)
+
+// classifyMountError buckets a mount command failure into a small, bounded set
+// of reasons so queries can separate failure modes. For dashboards the reasons
+// can be grouped like:
+//   - retryable/transient: timeout, network, stale
+//   - ambiguous:           enoent (see note), busy (target/resource busy, often already mounted)
+//   - terminal:            access_denied
+//
+// Note on enoent: for SMB, kernel surfaces "mount error(2): No such file or
+// directory" for both an absent share (SMB2 maps STATUS_BAD_NETWORK_NAME to
+// -ENOENT, terminal; see fs/smb/client/smb2maperror.c) and a transient
+// tree-connect rejection when the share/account is overloaded (retryable).
+// mount.cifs prints the mapped errno, not the status name
+// (STATUS_BAD_NETWORK_NAME only reaches dmesg), so indistinguishable from mount
+// stderr alone.
+//
+// The string switch runs first (mount.cifs / mount.aznfs stderr and CIFS kernel
+// error codes); mount.IsCorruptedMnt is only a typed fallback so a wrapped
+// syscall error with text matching a bucket (e.g. EACCES -> "permission
+// denied", EHOSTDOWN -> "host is down") is classified rather than collapsed to
+// stale. Returns "" when err is nil.
+func classifyMountError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timed out") ||
+		strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "deadline exceeded"):
+		// mount.cifs/mount.nfs print "timed out", non-proxy path surfaces
+		// "mount operation timed out after N seconds", azurefile-proxy gRPC
+		// path surfaces "context deadline exceeded".
+		return mountErrorTimeout
+	case strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "error(13)") ||
+		strings.Contains(msg, "access denied"):
+		// mount.cifs prints "mount error(13): Permission denied". mount.nfs
+		// prints "access denied by server while mounting ...".
+		// STATUS_LOGON_FAILURE / STATUS_ACCESS_DENIED (-EACCES) only appears in
+		// dmesg, not mount stderr.
+		return mountErrorAccessDenied
+	case strings.Contains(msg, "error(16)") ||
+		strings.Contains(msg, "device or resource busy") ||
+		strings.Contains(msg, "target is busy"):
+		return mountErrorBusy
+	case strings.Contains(msg, "no such file or directory") ||
+		strings.Contains(msg, "error(2)"):
+		return mountErrorENOENT
+	case strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "host is down") ||
+		strings.Contains(msg, "no route to host") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "could not connect to") ||
+		strings.Contains(msg, "could not resolve address") ||
+		strings.Contains(msg, "unable to find suitable address") ||
+		strings.Contains(msg, "error(111)") ||
+		strings.Contains(msg, "error(112)") ||
+		strings.Contains(msg, "error(113)") ||
+		strings.Contains(msg, "error(115)"):
+		// mount.cifs prints "mount error(<111|113|115>): could not connect to
+		// <ip>" (ECONNREFUSED/EHOSTUNREACH/EINPROGRESS) while cycling addresses,
+		// then "Unable to find suitable address." once exhausted; EHOSTDOWN(112)
+		// prints "mount error(112): Host is down". A getaddrinfo/DNS failure
+		// prints "could not resolve address for <host>" (NXDOMAIN for a
+		// deleted/mistyped account, transient SERVFAIL, or DNS server
+		// unreachable). mount.nfs surfaces RPC-layer "Connection refused".
+		// error(110)/"connection timed out" (ETIMEDOUT) is caught by the
+		// timeout case above.
+		return mountErrorNetwork
+	default:
+		// Typed fallback for stale/broken mounts (wrapped syscall.ESTALE /
+		// ENOTCONN / EIO from IsLikelyNotMountPoint on a dead mount).
+		if mount.IsCorruptedMnt(err) {
+			return mountErrorStale
+		}
+		return mountErrorOther
+	}
+}
+
+// fileShareNameForMetric returns just the Azure file share name for use as a
+// metric label, stripping any subpath that may be baked into the volumeID share
+// segment (e.g. "share/dir/sub" -> "share") for aggregation. A leading slash is
+// trimmed first so "/share/sub" still resolves to "share" rather than "".
+func fileShareNameForMetric(fileShareName string) string {
+	fileShareName = strings.TrimLeft(fileShareName, "/")
+	if i := strings.IndexByte(fileShareName, '/'); i >= 0 {
+		return fileShareName[:i]
+	}
+	return fileShareName
 }
 
 func isThrottlingError(err error) bool {

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -18,6 +18,7 @@ package azurefile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -156,6 +157,10 @@ const (
 	mountErrorOther        = "other"
 )
 
+// errCredentialCacheSetup marks a managed-identity credential-cache setup
+// failure that happens before the SMB mount is attempted.
+var errCredentialCacheSetup = errors.New("setCredentialCache failed")
+
 // classifyMountError buckets a mount command failure into a small, bounded set
 // of reasons so queries can separate failure modes. For dashboards the reasons
 // can be grouped like:
@@ -207,10 +212,12 @@ func classifyMountError(err error) string {
 	case strings.Contains(msg, "connection reset") ||
 		strings.Contains(msg, "host is down") ||
 		strings.Contains(msg, "no route to host") ||
+		strings.Contains(msg, "network is unreachable") ||
 		strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "could not connect to") ||
 		strings.Contains(msg, "could not resolve address") ||
 		strings.Contains(msg, "unable to find suitable address") ||
+		strings.Contains(msg, "error(101)") ||
 		strings.Contains(msg, "error(111)") ||
 		strings.Contains(msg, "error(112)") ||
 		strings.Contains(msg, "error(113)") ||
@@ -218,7 +225,8 @@ func classifyMountError(err error) string {
 		// mount.cifs prints "mount error(<111|113|115>): could not connect to
 		// <ip>" (ECONNREFUSED/EHOSTUNREACH/EINPROGRESS) while cycling addresses,
 		// then "Unable to find suitable address." once exhausted; EHOSTDOWN(112)
-		// prints "mount error(112): Host is down". A getaddrinfo/DNS failure
+		// prints "mount error(112): Host is down"; ENETUNREACH(101) prints
+		// "mount error(101): Network is unreachable". A getaddrinfo/DNS failure
 		// prints "could not resolve address for <host>" (NXDOMAIN for a
 		// deleted/mistyped account, transient SERVFAIL, or DNS server
 		// unreachable). mount.nfs surfaces RPC-layer "Connection refused".

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -35,6 +35,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
+	mount "k8s.io/mount-utils"
 	azureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 )
 
@@ -142,6 +143,98 @@ func isRetriableError(err error) bool {
 		}
 	}
 	return false
+}
+
+// Mount error reason classifications recorded on the mount_error_reason metric label.
+const (
+	mountErrorTimeout      = "timeout"
+	mountErrorENOENT       = "enoent"
+	mountErrorAccessDenied = "access_denied"
+	mountErrorNetwork      = "network"
+	mountErrorStale        = "stale"
+	mountErrorBusy         = "busy"
+	mountErrorOther        = "other"
+)
+
+// classifyMountError buckets a mount command failure into a small, bounded set
+// of reasons so queries can separate failure modes. For dashboards the reasons
+// can be grouped like:
+//   - retryable/transient: timeout, network, stale
+//   - ambiguous:           enoent (see note), busy (target/resource busy, often already mounted)
+//   - terminal:            access_denied
+//
+// Note on enoent: for SMB, kernel surfaces "mount error(2): No such file or
+// directory" for both an absent share (SMB2 maps STATUS_BAD_NETWORK_NAME to
+// -ENOENT, terminal; see fs/smb/client/smb2maperror.c) and a transient
+// tree-connect rejection when the share/account is overloaded (retryable).
+// mount.cifs prints the mapped errno, not the status name
+// (STATUS_BAD_NETWORK_NAME only reaches dmesg), so indistinguishable from mount
+// stderr alone.
+//
+// The string switch runs first (mount.cifs / mount.aznfs stderr and CIFS kernel
+// error codes); mount.IsCorruptedMnt is only a typed fallback so a wrapped
+// syscall error with text matching a bucket (e.g. EACCES -> "permission
+// denied", EHOSTDOWN -> "host is down") is classified rather than collapsed to
+// stale. Returns "" when err is nil.
+func classifyMountError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timed out") || strings.Contains(msg, "timeout"):
+		return mountErrorTimeout
+	case strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "error(13)") ||
+		strings.Contains(msg, "access denied"):
+		// mount.cifs prints "mount error(13): Permission denied". mount.nfs
+		// prints "access denied by server while mounting ...".
+		// STATUS_LOGON_FAILURE / STATUS_ACCESS_DENIED (-EACCES) only appears in
+		// dmesg, not mount stderr.
+		return mountErrorAccessDenied
+	case strings.Contains(msg, "error(16)") ||
+		strings.Contains(msg, "device or resource busy") ||
+		strings.Contains(msg, "target is busy"):
+		return mountErrorBusy
+	case strings.Contains(msg, "no such file or directory") ||
+		strings.Contains(msg, "error(2)"):
+		return mountErrorENOENT
+	case strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "host is down") ||
+		strings.Contains(msg, "no route to host") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "could not connect to") ||
+		strings.Contains(msg, "unable to find suitable address") ||
+		strings.Contains(msg, "error(111)") ||
+		strings.Contains(msg, "error(112)") ||
+		strings.Contains(msg, "error(113)"):
+		// mount.cifs prints "mount error(<111|112|113|115>): could not connect
+		// to <ip>" while cycling addresses, then "Unable to find suitable
+		// address." when all are exhausted; EHOSTDOWN(112) also falls through to
+		// "mount error(112): Host is down". mount.nfs surfaces RPC-layer
+		// "Connection refused". error(110)/"connection timed out" (ETIMEDOUT) is
+		// caught by the timeout case above.
+		return mountErrorNetwork
+	default:
+		// Typed fallback for stale/broken mounts (wrapped syscall.ESTALE /
+		// ENOTCONN / EIO from IsLikelyNotMountPoint on a dead mount).
+		if mount.IsCorruptedMnt(err) {
+			return mountErrorStale
+		}
+		return mountErrorOther
+	}
+}
+
+// fileShareNameForMetric returns just the Azure file share name for use as a
+// metric label, stripping any subpath that may be baked into the volumeID share
+// segment (e.g. "share/dir/sub" -> "share") for aggregation. A leading slash is
+// trimmed first so "/share/sub" still resolves to "share" rather than "".
+func fileShareNameForMetric(fileShareName string) string {
+	fileShareName = strings.TrimLeft(fileShareName, "/")
+	if i := strings.IndexByte(fileShareName, '/'); i >= 0 {
+		return fileShareName[:i]
+	}
+	return fileShareName
 }
 
 func isThrottlingError(err error) bool {

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -340,21 +339,6 @@ func TestClassifyMountError(t *testing.T) {
 			expected: "",
 		},
 		{
-			desc:     "stale/corrupted mount (typed ESTALE)",
-			err:      &os.PathError{Op: "stat", Path: "/mnt/x", Err: syscall.ESTALE},
-			expected: mountErrorStale,
-		},
-		{
-			desc:     "typed EACCES classified precisely, not stale",
-			err:      &os.PathError{Op: "open", Path: "/mnt/x", Err: syscall.EACCES},
-			expected: mountErrorAccessDenied,
-		},
-		{
-			desc:     "typed EHOSTDOWN classified as network, not stale",
-			err:      &os.PathError{Op: "stat", Path: "/mnt/x", Err: syscall.EHOSTDOWN},
-			expected: mountErrorNetwork,
-		},
-		{
 			desc:     "timed out",
 			err:      errors.New("mount.cifs: mount error(110): Connection timed out"),
 			expected: mountErrorTimeout,
@@ -431,7 +415,7 @@ func TestClassifyMountError(t *testing.T) {
 		},
 		{
 			desc:     "cifs could not connect / unable to find suitable address",
-			err:      errors.New("mount error(113): could not connect to 10.0.0.4\nUnable to find suitable address."),
+			err:      errors.New("mount error(113): could not connect to 10.0.0.4\nUnable to find suitable address"),
 			expected: mountErrorNetwork,
 		},
 		{
@@ -460,27 +444,6 @@ func TestClassifyMountError(t *testing.T) {
 		if result := classifyMountError(test.err); result != test.expected {
 			t.Errorf("desc: (%s), input: err(%v), classifyMountError returned (%q), expected (%q)",
 				test.desc, test.err, result, test.expected)
-		}
-	}
-}
-
-func TestFileShareNameForMetric(t *testing.T) {
-	tests := []struct {
-		desc     string
-		input    string
-		expected string
-	}{
-		{desc: "empty", input: "", expected: ""},
-		{desc: "bare share name", input: "myshare", expected: "myshare"},
-		{desc: "share with subpath", input: "myshare/dir1/dir2/dir3", expected: "myshare"},
-		{desc: "share with single subdir", input: "myshare/subdir", expected: "myshare"},
-		{desc: "leading slash", input: "/share/sub", expected: "share"},
-		{desc: "only slash", input: "/", expected: ""},
-	}
-	for _, test := range tests {
-		if result := fileShareNameForMetric(test.input); result != test.expected {
-			t.Errorf("desc: (%s), input: %q, fileShareNameForMetric returned (%q), expected (%q)",
-				test.desc, test.input, result, test.expected)
 		}
 	}
 }

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -323,6 +324,163 @@ func TestIsRetriableError(t *testing.T) {
 		if result != test.expectedBool {
 			t.Errorf("desc: (%s), input: rpcErr(%v), isRetriableError returned with bool(%v), not equal to expectedBool(%v)",
 				test.desc, test.rpcErr, result, test.expectedBool)
+		}
+	}
+}
+
+func TestClassifyMountError(t *testing.T) {
+	tests := []struct {
+		desc     string
+		err      error
+		expected string
+	}{
+		{
+			desc:     "nil error",
+			err:      nil,
+			expected: "",
+		},
+		{
+			desc:     "stale/corrupted mount (typed ESTALE)",
+			err:      &os.PathError{Op: "stat", Path: "/mnt/x", Err: syscall.ESTALE},
+			expected: mountErrorStale,
+		},
+		{
+			desc:     "typed EACCES classified precisely, not stale",
+			err:      &os.PathError{Op: "open", Path: "/mnt/x", Err: syscall.EACCES},
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "typed EHOSTDOWN classified as network, not stale",
+			err:      &os.PathError{Op: "stat", Path: "/mnt/x", Err: syscall.EHOSTDOWN},
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "timed out",
+			err:      errors.New("mount.cifs: mount error(110): Connection timed out"),
+			expected: mountErrorTimeout,
+		},
+		{
+			desc:     "generic timeout keyword",
+			err:      errors.New("context deadline exceeded: operation timeout"),
+			expected: mountErrorTimeout,
+		},
+		{
+			desc:     "proxy grpc deadline exceeded (no timeout keyword)",
+			err:      errors.New("rpc error: code = DeadlineExceeded desc = context deadline exceeded"),
+			expected: mountErrorTimeout,
+		},
+		{
+			desc:     "permission denied",
+			err:      errors.New("mount error: Permission denied"),
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "cifs error(13)",
+			err:      errors.New("mount.cifs: mount error(13): Permission denied"),
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "nfs access denied by server",
+			err:      errors.New("mount.nfs: access denied by server while mounting server:/share"),
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "no such file or directory (transient SMB enoent)",
+			err:      errors.New("mount: no such file or directory"),
+			expected: mountErrorENOENT,
+		},
+		{
+			desc:     "cifs error(2)",
+			err:      errors.New("mount.cifs: mount error(2): No such file or directory"),
+			expected: mountErrorENOENT,
+		},
+		{
+			desc:     "device or resource busy",
+			err:      errors.New("mount.cifs: mount error(16): Device or resource busy"),
+			expected: mountErrorBusy,
+		},
+		{
+			desc:     "target is busy",
+			err:      errors.New("unmount failed: target is busy"),
+			expected: mountErrorBusy,
+		},
+		{
+			desc:     "connection reset",
+			err:      errors.New("read: connection reset by peer"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "host is down",
+			err:      errors.New("mount.cifs: host is down"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "no route to host",
+			err:      errors.New("connect: no route to host"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "connection refused",
+			err:      errors.New("dial tcp: connection refused"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "cifs error(111)",
+			err:      errors.New("mount.cifs: mount error(111): Connection refused"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "cifs could not connect / unable to find suitable address",
+			err:      errors.New("mount error(113): could not connect to 10.0.0.4\nUnable to find suitable address."),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "cifs error(115) EINPROGRESS during connect",
+			err:      errors.New("mount.cifs: mount error(115): Operation now in progress"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "dns resolution failure (getaddrinfo)",
+			err:      errors.New("mount error: could not resolve address for nonexistentacct.file.core.windows.net: Unknown error"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "status codes only in dmesg fall through to other",
+			err:      errors.New("cifs: STATUS_LOGON_FAILURE"),
+			expected: mountErrorOther,
+		},
+		{
+			desc:     "unclassified error",
+			err:      errors.New("some unexpected failure"),
+			expected: mountErrorOther,
+		},
+	}
+
+	for _, test := range tests {
+		if result := classifyMountError(test.err); result != test.expected {
+			t.Errorf("desc: (%s), input: err(%v), classifyMountError returned (%q), expected (%q)",
+				test.desc, test.err, result, test.expected)
+		}
+	}
+}
+
+func TestFileShareNameForMetric(t *testing.T) {
+	tests := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{desc: "empty", input: "", expected: ""},
+		{desc: "bare share name", input: "myshare", expected: "myshare"},
+		{desc: "share with subpath", input: "myshare/dir1/dir2/dir3", expected: "myshare"},
+		{desc: "share with single subdir", input: "myshare/subdir", expected: "myshare"},
+		{desc: "leading slash", input: "/share/sub", expected: "share"},
+		{desc: "only slash", input: "/", expected: ""},
+	}
+	for _, test := range tests {
+		if result := fileShareNameForMetric(test.input); result != test.expected {
+			t.Errorf("desc: (%s), input: %q, fileShareNameForMetric returned (%q), expected (%q)",
+				test.desc, test.input, result, test.expected)
 		}
 	}
 }

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -414,6 +414,11 @@ func TestClassifyMountError(t *testing.T) {
 			expected: mountErrorNetwork,
 		},
 		{
+			desc:     "cifs error(101) network is unreachable",
+			err:      errors.New("mount.cifs: mount error(101): Network is unreachable"),
+			expected: mountErrorNetwork,
+		},
+		{
 			desc:     "cifs could not connect / unable to find suitable address",
 			err:      errors.New("mount error(113): could not connect to 10.0.0.4\nUnable to find suitable address"),
 			expected: mountErrorNetwork,

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -323,6 +324,148 @@ func TestIsRetriableError(t *testing.T) {
 		if result != test.expectedBool {
 			t.Errorf("desc: (%s), input: rpcErr(%v), isRetriableError returned with bool(%v), not equal to expectedBool(%v)",
 				test.desc, test.rpcErr, result, test.expectedBool)
+		}
+	}
+}
+
+func TestClassifyMountError(t *testing.T) {
+	tests := []struct {
+		desc     string
+		err      error
+		expected string
+	}{
+		{
+			desc:     "nil error",
+			err:      nil,
+			expected: "",
+		},
+		{
+			desc:     "stale/corrupted mount (typed ESTALE)",
+			err:      &os.PathError{Op: "stat", Path: "/mnt/x", Err: syscall.ESTALE},
+			expected: mountErrorStale,
+		},
+		{
+			desc:     "typed EACCES classified precisely, not stale",
+			err:      &os.PathError{Op: "open", Path: "/mnt/x", Err: syscall.EACCES},
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "typed EHOSTDOWN classified as network, not stale",
+			err:      &os.PathError{Op: "stat", Path: "/mnt/x", Err: syscall.EHOSTDOWN},
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "timed out",
+			err:      errors.New("mount.cifs: mount error(110): Connection timed out"),
+			expected: mountErrorTimeout,
+		},
+		{
+			desc:     "generic timeout keyword",
+			err:      errors.New("context deadline exceeded: operation timeout"),
+			expected: mountErrorTimeout,
+		},
+		{
+			desc:     "permission denied",
+			err:      errors.New("mount error: Permission denied"),
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "cifs error(13)",
+			err:      errors.New("mount.cifs: mount error(13): Permission denied"),
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "nfs access denied by server",
+			err:      errors.New("mount.nfs: access denied by server while mounting server:/share"),
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "no such file or directory (transient SMB enoent)",
+			err:      errors.New("mount: no such file or directory"),
+			expected: mountErrorENOENT,
+		},
+		{
+			desc:     "cifs error(2)",
+			err:      errors.New("mount.cifs: mount error(2): No such file or directory"),
+			expected: mountErrorENOENT,
+		},
+		{
+			desc:     "device or resource busy",
+			err:      errors.New("mount.cifs: mount error(16): Device or resource busy"),
+			expected: mountErrorBusy,
+		},
+		{
+			desc:     "target is busy",
+			err:      errors.New("unmount failed: target is busy"),
+			expected: mountErrorBusy,
+		},
+		{
+			desc:     "connection reset",
+			err:      errors.New("read: connection reset by peer"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "host is down",
+			err:      errors.New("mount.cifs: host is down"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "no route to host",
+			err:      errors.New("connect: no route to host"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "connection refused",
+			err:      errors.New("dial tcp: connection refused"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "cifs error(111)",
+			err:      errors.New("mount.cifs: mount error(111): Connection refused"),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "cifs could not connect / unable to find suitable address",
+			err:      errors.New("mount error(113): could not connect to 10.0.0.4\nUnable to find suitable address."),
+			expected: mountErrorNetwork,
+		},
+		{
+			desc:     "status codes only in dmesg fall through to other",
+			err:      errors.New("cifs: STATUS_LOGON_FAILURE"),
+			expected: mountErrorOther,
+		},
+		{
+			desc:     "unclassified error",
+			err:      errors.New("some unexpected failure"),
+			expected: mountErrorOther,
+		},
+	}
+
+	for _, test := range tests {
+		if result := classifyMountError(test.err); result != test.expected {
+			t.Errorf("desc: (%s), input: err(%v), classifyMountError returned (%q), expected (%q)",
+				test.desc, test.err, result, test.expected)
+		}
+	}
+}
+
+func TestFileShareNameForMetric(t *testing.T) {
+	tests := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{desc: "empty", input: "", expected: ""},
+		{desc: "bare share name", input: "myshare", expected: "myshare"},
+		{desc: "share with subpath", input: "myshare/dir1/dir2/dir3", expected: "myshare"},
+		{desc: "share with single subdir", input: "myshare/subdir", expected: "myshare"},
+		{desc: "leading slash", input: "/share/sub", expected: "share"},
+		{desc: "only slash", input: "/", expected: ""},
+	}
+	for _, test := range tests {
+		if result := fileShareNameForMetric(test.input); result != test.expected {
+			t.Errorf("desc: (%s), input: %q, fileShareNameForMetric returned (%q), expected (%q)",
+				test.desc, test.input, result, test.expected)
 		}
 	}
 }

--- a/pkg/azurefile/utils_unix_test.go
+++ b/pkg/azurefile/utils_unix_test.go
@@ -1,0 +1,61 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurefile
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestClassifyMountErrorTypedErrno covers the typed syscall.Errno fallback in
+// classifyMountError. These cases rely on Unix errno values and
+// mount.IsCorruptedMnt's Unix semantics, so they are constrained to non-Windows
+// platforms; Windows uses a different numeric error list and errno text.
+func TestClassifyMountErrorTypedErrno(t *testing.T) {
+	tests := []struct {
+		desc     string
+		err      error
+		expected string
+	}{
+		{
+			desc:     "stale/corrupted mount (typed ESTALE)",
+			err:      &os.PathError{Op: "stat", Path: "/mnt/x", Err: syscall.ESTALE},
+			expected: mountErrorStale,
+		},
+		{
+			desc:     "typed EACCES classified precisely, not stale",
+			err:      &os.PathError{Op: "open", Path: "/mnt/x", Err: syscall.EACCES},
+			expected: mountErrorAccessDenied,
+		},
+		{
+			desc:     "typed EHOSTDOWN classified as network, not stale",
+			err:      &os.PathError{Op: "stat", Path: "/mnt/x", Err: syscall.EHOSTDOWN},
+			expected: mountErrorNetwork,
+		},
+	}
+
+	for _, test := range tests {
+		if result := classifyMountError(test.err); result != test.expected {
+			t.Errorf("desc: (%s), input: err(%v), classifyMountError returned (%q), expected (%q)",
+				test.desc, test.err, result, test.expected)
+		}
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -89,6 +89,18 @@ var (
 		},
 		[]string{"operation", "success"},
 	)
+
+	// inlineVolumeOperationsTotal counts ephemeral (inline) volume
+	// NodePublishVolume operations.
+	inlineVolumeOperationsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      subSystem,
+			Name:           "inline_volume_operations_total",
+			Help:           "Total number of ephemeral (inline) volume NodePublishVolume operations",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"success"},
+	)
 )
 
 func init() {
@@ -96,6 +108,13 @@ func init() {
 	legacyregistry.MustRegister(operationDurationWithLabels)
 	legacyregistry.MustRegister(operationTotal)
 	legacyregistry.MustRegister(mountOperationsTotal)
+	legacyregistry.MustRegister(inlineVolumeOperationsTotal)
+}
+
+// ObserveInlineVolumeOperation records one ephemeral (inline) volume
+// NodePublishVolume operation, incremented only on the inline code path.
+func ObserveInlineVolumeOperation(success bool) {
+	inlineVolumeOperationsTotal.WithLabelValues(strconv.FormatBool(success)).Inc()
 }
 
 // CSIMetricContext represents the context for CSI operation metrics

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -35,13 +35,10 @@ const (
 	// MountErrorReason classifies why a mount command failed (timeout, enoent,
 	// access_denied, network, stale, busy, other). Empty on success.
 	MountErrorReason = "mount_error_reason"
-	// StorageAccount and FileShare identify the mount target.
+	// StorageAccount identifies the mount target's storage account (on failure).
 	StorageAccount = "storage_account"
-	FileShare      = "file_share"
-	// SubscriptionID identifies the subscription that owns the mount target.
+	// SubscriptionID identifies the subscription that owns the mount target (on failure).
 	SubscriptionID = "subscription_id"
-	// ResourceGroup identifies the resource group that owns the mount target.
-	ResourceGroup = "resource_group"
 )
 
 var (
@@ -68,8 +65,9 @@ var (
 	)
 
 	// mountOperationsTotal is a dedicated counter for mount-path operations. It
-	// carries the full identity of the mount target plus an error reason so a
-	// single failing share can be tracked across nodes and subscriptions.
+	// carries the identity of the mount target plus an error reason so a
+	// single failing share can be tracked across nodes. storage_account and
+	// subscription_id are recorded only on failures to keep cardinality bounded.
 	mountOperationsTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      subSystem,
@@ -77,7 +75,7 @@ var (
 			Help:           "Total number of mount command executions, labeled by target identity and error reason",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"operation", "success", Protocol, StorageAccount, FileShare, SubscriptionID, ResourceGroup, MountErrorReason},
+		[]string{"operation", "success", Protocol, StorageAccount, SubscriptionID, MountErrorReason},
 	)
 
 	operationTotal = metrics.NewCounterVec(
@@ -89,18 +87,6 @@ var (
 		},
 		[]string{"operation", "success"},
 	)
-
-	// inlineVolumeOperationsTotal counts ephemeral (inline) volume
-	// NodePublishVolume operations.
-	inlineVolumeOperationsTotal = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:      subSystem,
-			Name:           "inline_volume_operations_total",
-			Help:           "Total number of ephemeral (inline) volume NodePublishVolume operations",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{"success"},
-	)
 )
 
 func init() {
@@ -108,13 +94,6 @@ func init() {
 	legacyregistry.MustRegister(operationDurationWithLabels)
 	legacyregistry.MustRegister(operationTotal)
 	legacyregistry.MustRegister(mountOperationsTotal)
-	legacyregistry.MustRegister(inlineVolumeOperationsTotal)
-}
-
-// ObserveInlineVolumeOperation records one ephemeral (inline) volume
-// NodePublishVolume operation, incremented only on the inline code path.
-func ObserveInlineVolumeOperation(success bool) {
-	inlineVolumeOperationsTotal.WithLabelValues(strconv.FormatBool(success)).Inc()
 }
 
 // CSIMetricContext represents the context for CSI operation metrics
@@ -227,11 +206,10 @@ func (mc *CSIMetricContext) ObserveWithLabels(success bool, labelPairs ...string
 }
 
 // ObserveMountWithLabels records a mount command execution by incrementing
-// mountOperationsTotal. storage_account and file_share are high-cardinality. In
-// dynamic-provisioning clusters every PVC gets its own share, and a Prometheus
-// CounterVec never evicts series. Monitoring for unhealthy shares only needs
-// per-share attribution on failures, so account/share are recorded only when
-// success is false; successful mounts leave them blank.
+// mountOperationsTotal. storage_account and subscription_id are recorded only
+// when success is false, so the series set stays bounded to distinct failing
+// targets. file_share (roughly one per PVC) and resource_group are never
+// recorded.
 func (mc *CSIMetricContext) ObserveMountWithLabels(success bool, labelPairs ...string) {
 	if len(labelPairs)%2 == 0 {
 		for i := 0; i < len(labelPairs); i += 2 {
@@ -239,10 +217,10 @@ func (mc *CSIMetricContext) ObserveMountWithLabels(success bool, labelPairs ...s
 		}
 	}
 
-	var account, share string
+	var account, subscriptionID string
 	if !success {
 		account = strings.ToLower(mc.labels[StorageAccount])
-		share = strings.ToLower(mc.labels[FileShare])
+		subscriptionID = strings.ToLower(mc.labels[SubscriptionID])
 	}
 
 	mountOperationsTotal.WithLabelValues(
@@ -250,9 +228,7 @@ func (mc *CSIMetricContext) ObserveMountWithLabels(success bool, labelPairs ...s
 		strconv.FormatBool(success),
 		mc.labels[Protocol],
 		account,
-		share,
-		strings.ToLower(mc.labels[SubscriptionID]),
-		strings.ToLower(mc.labels[ResourceGroup]),
+		subscriptionID,
 		mc.labels[MountErrorReason],
 	).Inc()
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,6 +32,16 @@ const (
 	// Label keys for metrics
 	Protocol           = "protocol"
 	StorageAccountType = "storage_account_type"
+	// MountErrorReason classifies why a mount command failed (timeout, enoent,
+	// access_denied, network, stale, busy, other). Empty on success.
+	MountErrorReason = "mount_error_reason"
+	// StorageAccount and FileShare identify the mount target.
+	StorageAccount = "storage_account"
+	FileShare      = "file_share"
+	// SubscriptionID identifies the subscription that owns the mount target.
+	SubscriptionID = "subscription_id"
+	// ResourceGroup identifies the resource group that owns the mount target.
+	ResourceGroup = "resource_group"
 )
 
 var (
@@ -56,6 +67,19 @@ var (
 		[]string{"operation", "success", Protocol, StorageAccountType},
 	)
 
+	// mountOperationsTotal is a dedicated counter for mount-path operations. It
+	// carries the full identity of the mount target plus an error reason so a
+	// single failing share can be tracked across nodes and subscriptions.
+	mountOperationsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      subSystem,
+			Name:           "mount_operations_total",
+			Help:           "Total number of mount command executions, labeled by target identity and error reason",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"operation", "success", Protocol, StorageAccount, FileShare, SubscriptionID, ResourceGroup, MountErrorReason},
+	)
+
 	operationTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      subSystem,
@@ -71,6 +95,7 @@ func init() {
 	legacyregistry.MustRegister(operationDuration)
 	legacyregistry.MustRegister(operationDurationWithLabels)
 	legacyregistry.MustRegister(operationTotal)
+	legacyregistry.MustRegister(mountOperationsTotal)
 }
 
 // CSIMetricContext represents the context for CSI operation metrics
@@ -180,4 +205,35 @@ func (mc *CSIMetricContext) ObserveWithLabels(success bool, labelPairs ...string
 		mc.WithLabel(labelPairs[i], labelPairs[i+1])
 	}
 	mc.Observe(success)
+}
+
+// ObserveMountWithLabels records a mount command execution by incrementing
+// mountOperationsTotal. storage_account and file_share are high-cardinality. In
+// dynamic-provisioning clusters every PVC gets its own share, and a Prometheus
+// CounterVec never evicts series. Monitoring for unhealthy shares only needs
+// per-share attribution on failures, so account/share are recorded only when
+// success is false; successful mounts leave them blank.
+func (mc *CSIMetricContext) ObserveMountWithLabels(success bool, labelPairs ...string) {
+	if len(labelPairs)%2 == 0 {
+		for i := 0; i < len(labelPairs); i += 2 {
+			mc.WithLabel(labelPairs[i], labelPairs[i+1])
+		}
+	}
+
+	var account, share string
+	if !success {
+		account = strings.ToLower(mc.labels[StorageAccount])
+		share = strings.ToLower(mc.labels[FileShare])
+	}
+
+	mountOperationsTotal.WithLabelValues(
+		mc.operation,
+		strconv.FormatBool(success),
+		mc.labels[Protocol],
+		account,
+		share,
+		strings.ToLower(mc.labels[SubscriptionID]),
+		strings.ToLower(mc.labels[ResourceGroup]),
+		mc.labels[MountErrorReason],
+	).Inc()
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -404,22 +404,18 @@ func TestCSIMetricContext_ObserveMountWithLabels(t *testing.T) {
 	operationTotal.Reset()
 	mountOperationsTotal.Reset()
 
-	// Failure: account/share recorded (lowercased), sub/rg recorded (lowercased), reason set.
+	// Failure: account recorded (lowercased), sub recorded (lowercased), reason set.
 	NewCSIMetricContext("node_stage_volume_mount").ObserveMountWithLabels(false,
 		Protocol, "cifs",
 		StorageAccount, "MyAccount",
-		FileShare, "MyShare",
 		SubscriptionID, "SUB-ABC",
-		ResourceGroup, "MyRG",
 		MountErrorReason, "enoent")
 
-	// Success: account/share blank, sub/rg still recorded (lowercased), empty reason.
+	// Success: account/sub blank, empty reason.
 	NewCSIMetricContext("node_stage_volume_mount").ObserveMountWithLabels(true,
 		Protocol, "cifs",
 		StorageAccount, "MyAccount",
-		FileShare, "MyShare",
 		SubscriptionID, "SUB-ABC",
-		ResourceGroup, "MyRG",
 		MountErrorReason, "")
 
 	families, err := legacyregistry.DefaultGatherer.Gather()
@@ -450,22 +446,22 @@ func TestCSIMetricContext_ObserveMountWithLabels(t *testing.T) {
 			switch lbl["success"] {
 			case "false":
 				foundFailure = true
-				if lbl[StorageAccount] != "myaccount" || lbl[FileShare] != "myshare" {
-					t.Errorf("failure row: expected lowercased account/share, got %v", lbl)
+				if lbl[StorageAccount] != "myaccount" {
+					t.Errorf("failure row: expected lowercased account, got %v", lbl)
 				}
-				if lbl[SubscriptionID] != "sub-abc" || lbl[ResourceGroup] != "myrg" {
-					t.Errorf("failure row: expected lowercased sub/rg, got %v", lbl)
+				if lbl[SubscriptionID] != "sub-abc" {
+					t.Errorf("failure row: expected lowercased sub, got %v", lbl)
 				}
 				if lbl[MountErrorReason] != "enoent" {
 					t.Errorf("failure row: expected reason enoent, got %v", lbl)
 				}
 			case "true":
 				foundSuccess = true
-				if lbl[StorageAccount] != "" || lbl[FileShare] != "" {
-					t.Errorf("success row: expected blank account/share, got %v", lbl)
+				if lbl[StorageAccount] != "" {
+					t.Errorf("success row: expected blank account, got %v", lbl)
 				}
-				if lbl[SubscriptionID] != "sub-abc" || lbl[ResourceGroup] != "myrg" {
-					t.Errorf("success row: expected sub/rg still set, got %v", lbl)
+				if lbl[SubscriptionID] != "" {
+					t.Errorf("success row: expected blank sub, got %v", lbl)
 				}
 			}
 		}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -400,6 +400,84 @@ func TestCSIMetricContext_WithLogLevel_Chaining(t *testing.T) {
 	}
 }
 
+func TestCSIMetricContext_ObserveMountWithLabels(t *testing.T) {
+	operationTotal.Reset()
+	mountOperationsTotal.Reset()
+
+	// Failure: account/share recorded (lowercased), sub/rg recorded (lowercased), reason set.
+	NewCSIMetricContext("node_stage_volume_mount").ObserveMountWithLabels(false,
+		Protocol, "cifs",
+		StorageAccount, "MyAccount",
+		FileShare, "MyShare",
+		SubscriptionID, "SUB-ABC",
+		ResourceGroup, "MyRG",
+		MountErrorReason, "enoent")
+
+	// Success: account/share blank, sub/rg still recorded (lowercased), empty reason.
+	NewCSIMetricContext("node_stage_volume_mount").ObserveMountWithLabels(true,
+		Protocol, "cifs",
+		StorageAccount, "MyAccount",
+		FileShare, "MyShare",
+		SubscriptionID, "SUB-ABC",
+		ResourceGroup, "MyRG",
+		MountErrorReason, "")
+
+	families, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	var foundFailure, foundSuccess bool
+	for _, family := range families {
+		// Standalone: must NOT pollute operations_total with the mount operation.
+		if family.GetName() == "azurefile_csi_driver_operations_total" {
+			for _, m := range family.GetMetric() {
+				for _, l := range m.GetLabel() {
+					if l.GetName() == "operation" && l.GetValue() == "node_stage_volume_mount" {
+						t.Errorf("mount operation leaked into operations_total")
+					}
+				}
+			}
+		}
+		if family.GetName() != "azurefile_csi_driver_mount_operations_total" {
+			continue
+		}
+		for _, m := range family.GetMetric() {
+			lbl := make(map[string]string)
+			for _, l := range m.GetLabel() {
+				lbl[l.GetName()] = l.GetValue()
+			}
+			switch lbl["success"] {
+			case "false":
+				foundFailure = true
+				if lbl[StorageAccount] != "myaccount" || lbl[FileShare] != "myshare" {
+					t.Errorf("failure row: expected lowercased account/share, got %v", lbl)
+				}
+				if lbl[SubscriptionID] != "sub-abc" || lbl[ResourceGroup] != "myrg" {
+					t.Errorf("failure row: expected lowercased sub/rg, got %v", lbl)
+				}
+				if lbl[MountErrorReason] != "enoent" {
+					t.Errorf("failure row: expected reason enoent, got %v", lbl)
+				}
+			case "true":
+				foundSuccess = true
+				if lbl[StorageAccount] != "" || lbl[FileShare] != "" {
+					t.Errorf("success row: expected blank account/share, got %v", lbl)
+				}
+				if lbl[SubscriptionID] != "sub-abc" || lbl[ResourceGroup] != "myrg" {
+					t.Errorf("success row: expected sub/rg still set, got %v", lbl)
+				}
+			}
+		}
+	}
+	if !foundFailure {
+		t.Error("expected a failure row in mount_operations_total")
+	}
+	if !foundSuccess {
+		t.Error("expected a success row in mount_operations_total")
+	}
+}
+
 func BenchmarkCSIMetricContext_Observe(b *testing.B) {
 	mc := NewCSIMetricContext("benchmark_test").WithBasicVolumeInfo("test-rg", "test-sub", "test-source")
 	b.ResetTimer()


### PR DESCRIPTION
…ures

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a metric to track mount failures to a single fileshare across multiple nodes and clusters, including for retries, with bucketed reasons.

- Dedicated `azurefile_csi_driver_mount_operations_total` counter, emitted at 3 mount command locations in `NodeStageVolume`, with the target share's `storage_account`, `file_share`, `subscription_id`, and `resource_group` along with `protocol`, `success`, and classified `mount_error_reason`
  - Allows a single fileshare with repeated errors to be tracked across multiple nodes/clusters in a subscription
  - Reason is bucketed by `classifyMountError` into `timeout`, `enoent`, `access_denied`, `network`, `stale`, `busy`, `other` from the mount command's `mount.cifs` or `mount.nfs` stderr
  - `storage_account` and `file_share` are only recorded on failures (left blank on successes) with all identity values lowercased, in order to bound cardinality to the set of distinct failing shares.  

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
