### PR TITLE
chore: upgrade azcopy to v10.32.7 to fix CVEs (cherry-pick #3351 to release-1.34)

### DIFF
--- a/pkg/azurefileplugin/Dockerfile
+++ b/pkg/azurefileplugin/Dockerfile
@@ -23,7 +23,7 @@ ARG ARCH
 RUN apt update \
     && apt install -y curl \
     && curl -Lso /tmp/packages-microsoft-prod-22.04.deb https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb \
-    && curl -Ls https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.6/azcopy_linux_${ARCH}_10.32.6.tar.gz \
+    && curl -Ls https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.7/azcopy_linux_${ARCH}_10.32.7.tar.gz \
         | tar xvzf - --strip-components=1 -C /usr/local/bin/ --wildcards "*/azcopy"
 
 FROM base

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -40,7 +40,7 @@ azcopyPath="/usr/local/bin/azcopy"
 if [ ! -f "$azcopyPath" ]; then
   azcopyTarFile="azcopy.tar.gz"
   echo 'Downloading azcopy...'
-  wget -O $azcopyTarFile https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.6/azcopy_linux_amd64_10.32.6.tar.gz
+  wget -O $azcopyTarFile https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.7/azcopy_linux_amd64_10.32.7.tar.gz
   tar -zxvf $azcopyTarFile
   mv ./azcopy*/azcopy /usr/local/bin/azcopy
   rm -rf ./$azcopyTarFile


### PR DESCRIPTION
Cherry-pick of #3351 to `release-1.34`.

Upgrades bundled azcopy from v10.32.6 to v10.32.7 to pick up upstream CVE fixes.

**Changes:**
- `pkg/azurefileplugin/Dockerfile` — bump azcopy download URL to v10.32.7
- `test/sanity/run-test.sh` — bump azcopy download URL to v10.32.7

**Not carried over:**
- `.trivyignore` changes — `release-1.34` already contains the full CVE list (CVE-2024-3744, CVE-2026-33818, CVE-2026-39821, CVE-2026-39822, CVE-2026-39883, CVE-2026-42505, CVE-2026-46600, CVE-2026-56852, CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860, CVE-2026-56862, GHSA-hrxh-6v49-42gf), so no change needed there.

Original PR: #3351
