### PR TITLE
docs: clarify inline (ephemeral) CSI volumes are not supported for managed identity mount

### DIFF
--- a/docs/managed-identity-mount.md
+++ b/docs/managed-identity-mount.md
@@ -6,7 +6,7 @@
 This article demonstrates how to mount an SMB file share using user-assigned managed identity authentication, without relying on account key authentication.
 
 > [!IMPORTANT]
-> **Inline (ephemeral) CSI volumes are not supported.** Requests with `mountWithManagedIdentity: "true"` on a `csi:` inline volume in a Pod spec are rejected by the node driver. Use a StorageClass (dynamic) or PersistentVolume (static) so the identity and `clientID` are controlled by the cluster admin, not by tenant Pods. This prevents arbitrary Pods from mounting file shares under the node's managed identity.
+> **Managed identity mount is not supported for inline (ephemeral) CSI volumes.** Requests with `mountWithManagedIdentity: "true"` on a `csi:` inline volume in a Pod spec are rejected by the node driver; use a StorageClass (dynamic) or PersistentVolume (static) so the identity and `clientID` are controlled by the cluster admin, not by tenant Pods. Inline volumes remain supported with workload identity (`mountWithWorkloadIdentityToken: "true"`) or secret-based authentication.
 
 > [!NOTE]
 > By default, you can leverage the built-in user-assigned managed identity (kubelet identity) bound to the AKS agent node pool (with the naming convention [`<AKS Cluster Name>-agentpool`](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#summary-of-managed-identities)).

--- a/docs/managed-identity-mount.md
+++ b/docs/managed-identity-mount.md
@@ -5,6 +5,9 @@
 
 This article demonstrates how to mount an SMB file share using user-assigned managed identity authentication, without relying on account key authentication.
 
+> [!IMPORTANT]
+> **Inline (ephemeral) CSI volumes are not supported.** Requests with `mountWithManagedIdentity: "true"` on a `csi:` inline volume in a Pod spec are rejected by the node driver. Use a StorageClass (dynamic) or PersistentVolume (static) so the identity and `clientID` are controlled by the cluster admin, not by tenant Pods. This prevents arbitrary Pods from mounting file shares under the node's managed identity.
+
 > [!NOTE]
 > By default, you can leverage the built-in user-assigned managed identity (kubelet identity) bound to the AKS agent node pool (with the naming convention [`<AKS Cluster Name>-agentpool`](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#summary-of-managed-identities)).
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Clarify in `docs/managed-identity-mount.md` that **inline (ephemeral) CSI volumes are not a supported path** for managed identity authentication.

The node driver already rejects `mountWithManagedIdentity: "true"` on ephemeral volumes ([`pkg/azurefile/nodeserver.go`](https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/pkg/azurefile/nodeserver.go#L118-L120)) so tenant Pods cannot mount arbitrary file shares under the node's identity, but the docs do not currently call this out. Users occasionally try inline volume + managed identity and hit an `InvalidArgument` at NodePublish time without a clear pointer to the supported StorageClass/PV path.

> Note: this PR intentionally does **not** touch `docs/workload-identity-static-pv-mount.md` — inline volumes with `mountWithWorkloadIdentityToken: "true"` **are** supported by the node driver (see the `useWIToken` path following the MI/OAuth guard).

**Which issue(s) this PR fixes**:
Docs-only clarification, no behavior change.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```