### PR TITLE
cherry-pick #3347 into release-1.34: validate inline volume request before performing cifs mount

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -88,18 +88,9 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	mountPermissions := d.mountPermissions
 	context := req.GetVolumeContext()
 	if context != nil {
-		if !strings.EqualFold(getValueInMap(context, mountWithManagedIdentityField), trueValue) && getValueInMap(context, serviceAccountTokenField) != "" && getValueInMap(context, clientIDField) != "" {
-			klog.V(2).Infof("NodePublishVolume: volume(%s) mount on %s with service account token, clientID: %s", volumeID, target, getValueInMap(context, clientIDField))
-			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
-				StagingTargetPath: target,
-				VolumeContext:     context,
-				VolumeCapability:  volCap,
-				VolumeId:          volumeID,
-			})
-			return &csi.NodePublishVolumeResponse{}, err
-		}
-
-		// ephemeral volume
+		// Run all ephemeral volume validation before any early-return path
+		// (e.g. service-account-token + clientID) to prevent bypassing
+		// security checks via alternate code paths.
 		if strings.EqualFold(context[ephemeralField], trueValue) {
 			// Reject case duplicate keys
 			if key, ok := caseCollidingKey(context); ok {
@@ -142,6 +133,21 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 			if err := d.authorizeInlineVolumeSecret(ctx, context); err != nil {
 				return nil, err
 			}
+		}
+
+		if !strings.EqualFold(getValueInMap(context, mountWithManagedIdentityField), trueValue) && getValueInMap(context, serviceAccountTokenField) != "" && getValueInMap(context, clientIDField) != "" {
+			klog.V(2).Infof("NodePublishVolume: volume(%s) mount on %s with service account token, clientID: %s", volumeID, target, getValueInMap(context, clientIDField))
+			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
+				StagingTargetPath: target,
+				VolumeContext:     context,
+				VolumeCapability:  volCap,
+				VolumeId:          volumeID,
+			})
+			return &csi.NodePublishVolumeResponse{}, err
+		}
+
+		// ephemeral volume
+		if strings.EqualFold(context[ephemeralField], trueValue) {
 			klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s", volumeID, target)
 			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
 				StagingTargetPath: target,

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -19,6 +19,8 @@ package azurefile
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -118,8 +120,12 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 			if err := validateInlineVolumeMountSource(getValueInMap(context, serverNameField), getValueInMap(context, shareNameField)); err != nil {
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
-			if opt, found := findLocalMountModeOption(getValueInMap(context, mountOptionsField)); found {
-				return nil, status.Errorf(codes.InvalidArgument, "mount option %q is not supported for ephemeral volumes", opt)
+			mountOptions := strings.TrimSpace(getValueInMap(context, mountOptionsField))
+			mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
+			inlineMountOptions := append([]string(nil), mountFlags...)
+			inlineMountOptions = append(inlineMountOptions, mountOptions)
+			if err := validateInlineSMBMountOptions(inlineMountOptions); err != nil {
+				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
 			// When Managed Identity is used for ephemeral volumes then reject the request.
 			// Allowing access for inline volume with identity will open up risk of arbitrary pods accessing fileshares with node identity permissions.
@@ -410,8 +416,18 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 	defer d.volumeLocks.Release(lockKey)
 
-	if strings.TrimSpace(storageEndpointSuffix) == "" {
-		storageEndpointSuffix = d.getStorageEndPointSuffix()
+	trueStorageEndPointSuffix := d.getStorageEndPointSuffix()
+	if ephemeralVol {
+		requestedSuffix := strings.Trim(strings.TrimSpace(storageEndpointSuffix), ".")
+		trustedSuffix := strings.Trim(strings.TrimSpace(trueStorageEndPointSuffix), ".")
+		if requestedSuffix != "" && !strings.EqualFold(requestedSuffix, trustedSuffix) {
+			return nil, status.Errorf(codes.InvalidArgument, "storageEndpointSuffix %q does not match configured cloud suffix %q", storageEndpointSuffix, trueStorageEndPointSuffix)
+		}
+		// Use the configured suffix for every inline endpoint, including data-plane
+		// requests made by createFolderIfNotExists.
+		storageEndpointSuffix = trueStorageEndPointSuffix
+	} else if strings.TrimSpace(storageEndpointSuffix) == "" {
+		storageEndpointSuffix = trueStorageEndPointSuffix
 	}
 
 	// replace pv/pvc name namespace metadata in fileShareName
@@ -421,6 +437,12 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	if strings.TrimSpace(server) == "" {
 		// server address is "accountname.file.core.windows.net" by default
 		server = fmt.Sprintf("%s.file.%s", accountName, storageEndpointSuffix)
+	}
+	// Validate inline ephemeral volume server.
+	if ephemeralVol {
+		if err := validateInlineVolumeServer(server, accountName, trueStorageEndPointSuffix); err != nil {
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid server error: %s", err.Error()))
+		}
 	}
 	source := fmt.Sprintf("%s%s%s%s%s", osSeparator, osSeparator, server, osSeparator, fileShareName)
 	if protocol == nfs {
@@ -987,4 +1009,155 @@ func (d *Driver) authorizeInlineVolumeSecret(ctx context.Context, volumeContext 
 		return deny(fmt.Sprintf("service account %s is not authorized to get it", serviceAccountUser))
 	}
 	return nil
+}
+
+// deniedInlineSMBMountOptions is a set of mount options that are not allowed for ephemeral volumes with inline SMB mounts
+var deniedInlineSMBMountOptions = map[string]struct{}{
+	"bind":          {},
+	"rbind":         {},
+	"cred":          {},
+	"credentials":   {},
+	"addr":          {},
+	"ip":            {},
+	"unc":           {},
+	"target":        {},
+	"path":          {},
+	"sec":           {},
+	"cruid":         {},
+	"upcall_target": {},
+	"cifsacl":       {},
+	"modefromsid":   {},
+}
+
+func validateInlineSMBMountOptions(mountOptions []string) error {
+	for _, options := range mountOptions {
+		for _, option := range strings.Split(options, ",") {
+			key, _, _ := strings.Cut(strings.TrimSpace(option), "=")
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			if _, denied := deniedInlineSMBMountOptions[strings.ToLower(key)]; denied {
+				return fmt.Errorf("mount option %q is not supported for ephemeral volumes", key)
+			}
+		}
+	}
+	return nil
+}
+
+func validateInlineVolumeServer(server, accountName, storageEndPointSuffix string) error {
+	account := strings.ToLower(strings.TrimSpace(accountName))
+	suffix := strings.ToLower(strings.Trim(strings.TrimSpace(storageEndPointSuffix), "."))
+	host, err := parseInlineVolumeServer(server)
+	if err != nil {
+		return err
+	}
+
+	if account == "" || suffix == "" {
+		return fmt.Errorf("invalid server configuration: account name or storage endpoint suffix is empty")
+	}
+	secondaryAccount := account + "-secondary"
+	// Allowed server formats:
+	allowedHosts := map[string]struct{}{
+		fmt.Sprintf("%s.file.%s", account, suffix):                      {},
+		fmt.Sprintf("%s.afs.%s", account, suffix):                       {},
+		fmt.Sprintf("%s.privatelink.file.%s", account, suffix):          {},
+		fmt.Sprintf("%s.privatelink.afs.%s", account, suffix):           {},
+		fmt.Sprintf("%s.file.%s", secondaryAccount, suffix):             {},
+		fmt.Sprintf("%s.afs.%s", secondaryAccount, suffix):              {},
+		fmt.Sprintf("%s.privatelink.file.%s", secondaryAccount, suffix): {},
+		fmt.Sprintf("%s.privatelink.afs.%s", secondaryAccount, suffix):  {},
+	}
+	if _, ok := allowedHosts[strings.TrimSuffix(strings.ToLower(server), ".")]; ok {
+		return nil
+	}
+	if suffix == defaultStorageEndPointSuffix && isAzureDNSZoneStorageHost(host, account) {
+		return nil
+	}
+	return fmt.Errorf("invalid server %q: hostname must match storage account %q in the configured Azure cloud", server, accountName)
+}
+
+// parseInlineVolumeServer extracts a normalized hostname from a server value
+// and rejects URL components that are unsafe for inline volumes.
+func parseInlineVolumeServer(server string) (string, error) {
+	if server == "" {
+		return "", fmt.Errorf("server must not be empty")
+	}
+	if strings.TrimSpace(server) != server {
+		return "", fmt.Errorf("server %q must not contain leading or trailing whitespace", server)
+	}
+
+	serverURL := "https://" + server
+	// Always use HTTPS scheme for inline volume server
+
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid server %q: %w", server, err)
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return "", fmt.Errorf("invalid server %q: only HTTPS endpoints are allowed", server)
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("invalid server %q: user information is not allowed", server)
+	}
+	if parsed.Port() != "" {
+		return "", fmt.Errorf("invalid server %q: explicit ports are not allowed", server)
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", fmt.Errorf("invalid server %q: paths are not allowed", server)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("invalid server %q: query strings and fragments are not allowed", server)
+	}
+
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if host == "" {
+		return "", fmt.Errorf("invalid server %q: hostname is required", server)
+	}
+	if net.ParseIP(host) != nil {
+		return "", fmt.Errorf("invalid server %q: IP addresses are not allowed", server)
+	}
+
+	return host, nil
+}
+
+// isAzureDNSZoneStorageHost validates the public Azure DNS-zone endpoint
+// format without requiring a storage management-plane lookup from the node.
+func isAzureDNSZoneStorageHost(host, account string) bool {
+	parts := strings.Split(host, ".")
+	if len(parts) != 6 && len(parts) != 7 {
+		return false
+	}
+	if parts[0] != account && parts[0] != account+"-secondary" {
+		return false
+	}
+	zone := parts[1]
+	zoneID, hasZonePrefix := strings.CutPrefix(zone, "z")
+	if !hasZonePrefix {
+		return false
+	}
+	if len(zoneID) == 1 &&
+		(zoneID[0] < '1' || zoneID[0] > '9') {
+		return false
+	}
+	if len(zoneID) == 2 &&
+		(zoneID[0] < '1' || zoneID[0] > '9' ||
+			zoneID[1] < '0' || zoneID[1] > '9') {
+		return false
+	}
+	if len(zoneID) < 1 || len(zoneID) > 2 {
+		return false
+	}
+
+	serviceIndex := 2
+	if len(parts) == 7 {
+		if parts[serviceIndex] != "privatelink" {
+			return false
+		}
+		serviceIndex++
+	}
+	if parts[serviceIndex] != "file" && parts[serviceIndex] != "afs" {
+		return false
+	}
+	return strings.Join(parts[serviceIndex+1:], ".") == "storage.azure.net"
 }

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -235,6 +235,90 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			desc: "[Error] Ephemeral volume with comma-packed bind option in mountOptions should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-inline-denied-bind",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:    "true",
+					shareNameField:    "testshare",
+					serverNameField:   "testaccount.file.core.windows.net",
+					mountOptionsField: "dir_mode=0777,bind",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "mount option \"bind\" is not supported for ephemeral volumes"),
+				WindowsError: status.Error(codes.InvalidArgument, "mount option \"bind\" is not supported for ephemeral volumes"),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with mixed-case denied option in mountOptions should fail",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-inline-denied-mixedcase",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:    "true",
+					shareNameField:    "testshare",
+					serverNameField:   "testaccount.file.core.windows.net",
+					mountOptionsField: "nosharesock,ADDR=203.0.113.10",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "mount option \"ADDR\" is not supported for ephemeral volumes"),
+				WindowsError: status.Error(codes.InvalidArgument, "mount option \"ADDR\" is not supported for ephemeral volumes"),
+			},
+		},
+		{
+			desc: "[Error] Ephemeral volume with packed denied option in MountFlags capability should fail",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &volumeCap,
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							MountFlags: []string{"nosharesock,sec=krb5"},
+						},
+					},
+				},
+				VolumeId:   "csi-inline-denied-mountflags",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:  "true",
+					shareNameField:  "testshare",
+					serverNameField: "testaccount.file.core.windows.net",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "mount option \"sec\" is not supported for ephemeral volumes"),
+				WindowsError: status.Error(codes.InvalidArgument, "mount option \"sec\" is not supported for ephemeral volumes"),
+			},
+		},
+		{
+			// Regression guard: an ephemeral request that also carries serviceAccountToken+clientID
+			// must still go through inline-mount-option validation before hitting the token+clientID
+			// early-return path in NodePublishVolume.
+			desc: "[Error] Ephemeral volume with serviceAccountToken+clientID must still validate denied mount options",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-inline-denied-token-clientid",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:           "true",
+					shareNameField:           "testshare",
+					serverNameField:          "testaccount.file.core.windows.net",
+					serviceAccountTokenField: "fake-token",
+					clientIDField:            "test-client-id",
+					mountOptionsField:        "nosharesock,bind",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, "mount option \"bind\" is not supported for ephemeral volumes"),
+				WindowsError: status.Error(codes.InvalidArgument, "mount option \"bind\" is not supported for ephemeral volumes"),
+			},
+		},
+		{
 			desc: "[Success] Regular volume mounting with mountWithManagedIdentity should succeed",
 			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
 				VolumeId:          "vol_1",

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -483,7 +483,7 @@ func TestNodeStageVolume(t *testing.T) {
 		serverNameField: "test_servername",
 	}
 	errorSource := `\\test_servername\test_sharename`
-	errorSourceNFS := `test_servername://test_sharename`
+	errorSourceNFS := `test_servername.file.test_suffix:/test_servername/test_sharename`
 
 	secrets := map[string]string{
 		"accountname": "k8s",
@@ -654,13 +654,15 @@ func TestNodeStageVolume(t *testing.T) {
 			req: &csi.NodeStageVolumeRequest{VolumeId: "vol_1##", StagingTargetPath: sourceTest,
 				VolumeCapability: &stdVolCap,
 				VolumeContext: map[string]string{
-					fsTypeField:       "ext4",
-					protocolField:     "nfs",
-					diskNameField:     "test_disk.vhd",
-					shareNameField:    "test_sharename",
-					serverNameField:   "test_servername",
-					ephemeralField:    "true",
-					mountOptionsField: "test_ephemeral",
+					fsTypeField:                "ext4",
+					protocolField:              "nfs",
+					diskNameField:              "test_disk.vhd",
+					shareNameField:             "test_sharename",
+					serverNameField:            "test_servername.file.test_suffix",
+					ephemeralField:             "true",
+					mountOptionsField:          "test_ephemeral",
+					storageEndpointSuffixField: "test_suffix",
+					storageAccountField:        "test_servername",
 				},
 				Secrets: secrets},
 			execScripts: []ExecArgs{

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -277,17 +277,24 @@ func SetVolumeOwnership(path, gid, policy string) error {
 
 // setKeyValueInMap set key/value pair in map
 // key in the map is case insensitive, if key already exists, overwrite existing value
-// caseCollidingKey reports the first key in m that collides with an earlier key
-// under case-insensitive (lowercase) normalization. The returned
-// string is the normalized (lowercase) key that collided.
+// caseCollidingKey reports the first pair of keys in m that collide under
+// Unicode case folding. The returned string contains the two lowercased keys
+// in lexical order.
 func caseCollidingKey(m map[string]string) (string, bool) {
-	seen := make(map[string]struct{}, len(m))
-	for k := range m {
-		lower := strings.ToLower(k)
-		if _, ok := seen[lower]; ok {
-			return lower, true
+	// Since context map contains very limited values, we can use a simple O(n^2) algorithm to check for UNICODE case-insensitive collisions.
+	for validatingKey := range m {
+		for curKey := range m {
+			if validatingKey != curKey {
+				if strings.EqualFold(validatingKey, curKey) {
+					firstKey := strings.ToLower(validatingKey)
+					secondKey := strings.ToLower(curKey)
+					if secondKey < firstKey {
+						firstKey, secondKey = secondKey, firstKey
+					}
+					return fmt.Sprintf("%s, %s", firstKey, secondKey), true
+				}
+			}
 		}
-		seen[lower] = struct{}{}
 	}
 	return "", false
 }
@@ -443,18 +450,6 @@ func setCredentialCache(server, clientID string) ([]byte, error) {
 	cmd.Env = append(os.Environ(), cmd.Env...)
 	klog.V(2).Infof("Executing command: %q", cmd.String())
 	return cmd.CombinedOutput()
-}
-
-// findLocalMountModeOption returns the first comma-separated option in
-// mountOptions that requests a local bind mount.
-func findLocalMountModeOption(mountOptions string) (string, bool) {
-	for _, opt := range strings.Split(mountOptions, ",") {
-		trimmed := strings.TrimSpace(opt)
-		if strings.EqualFold(trimmed, "bind") || strings.EqualFold(trimmed, "rbind") {
-			return trimmed, true
-		}
-	}
-	return "", false
 }
 
 // validateInlineVolumeMountSource validates that there are no path

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -1423,13 +1423,13 @@ func TestCaseCollidingKey(t *testing.T) {
 		{
 			desc:         "secretNamespace case collision",
 			m:            map[string]string{"secretNamespace": "attacker", "SecretNamespace": "victim"},
-			expectedKey:  "secretnamespace",
+			expectedKey:  "secretnamespace, secretnamespace",
 			expectedColl: true,
 		},
 		{
 			desc:         "managed identity case collision",
 			m:            map[string]string{"mountwithmanagedidentity": "false", "MOUNTWITHMANAGEDIDENTITY": "true"},
-			expectedKey:  "mountwithmanagedidentity",
+			expectedKey:  "mountwithmanagedidentity, mountwithmanagedidentity",
 			expectedColl: true,
 		},
 	}
@@ -1442,33 +1442,6 @@ func TestCaseCollidingKey(t *testing.T) {
 		if ok && key != test.expectedKey {
 			t.Errorf("test[%s]: unexpected colliding key: %v, expected: %v", test.desc, key, test.expectedKey)
 		}
-	}
-}
-
-func TestFindLocalMountModeOption(t *testing.T) {
-	tests := []struct {
-		name    string
-		options string
-		wantOpt string
-		wantOk  bool
-	}{
-		{name: "empty", options: "", wantOpt: "", wantOk: false},
-		{name: "normal cifs options", options: "dir_mode=0777,file_mode=0777,cache=strict", wantOpt: "", wantOk: false},
-		{name: "bind present", options: "dir_mode=0777,bind", wantOpt: "bind", wantOk: true},
-		{name: "bind with spaces", options: "dir_mode=0777, bind ", wantOpt: "bind", wantOk: true},
-		{name: "uppercase bind", options: "BIND", wantOpt: "BIND", wantOk: true},
-		{name: "rbind", options: "ro,rbind", wantOpt: "rbind", wantOk: true},
-		{name: "remount not blocked", options: "remount", wantOpt: "", wantOk: false},
-		{name: "move not blocked", options: "move,ro", wantOpt: "", wantOk: false},
-		{name: "substring is not matched", options: "rebindable", wantOpt: "", wantOk: false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			opt, ok := findLocalMountModeOption(tc.options)
-			if ok != tc.wantOk || opt != tc.wantOpt {
-				t.Fatalf("findLocalMountModeOption(%q) = (%q, %v), want (%q, %v)", tc.options, opt, ok, tc.wantOpt, tc.wantOk)
-			}
-		})
 	}
 }
 

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -1432,6 +1432,14 @@ func TestCaseCollidingKey(t *testing.T) {
 			expectedKey:  "mountwithmanagedidentity, mountwithmanagedidentity",
 			expectedColl: true,
 		},
+		{
+			// Regression guard: Unicode case-folding collision (e.g. "ſ" folds to "s").
+			// Using strings.ToLower here would miss the collision; strings.EqualFold catches it.
+			desc:         "unicode collision",
+			m:            map[string]string{"mountoptions": "option1,option2", "mountoptionſ": "option3"},
+			expectedKey:  "mountoptions, mountoptionſ",
+			expectedColl: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1409,7 +1409,11 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 				Cmd: convertToPowershellCommandIfNecessary("echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data"),
 				Volumes: []testsuites.VolumeDetails{
 					{
-						ClaimSize: "100Gi",
+						VolumeID:           "onprem#USERNAME#share",
+						ShareName:          "share",
+						Server:             server,
+						NodeStageSecretRef: secretName,
+						ClaimSize:          "100Gi",
 						MountOptions: []string{
 							"dir_mode=0777",
 							"file_mode=0777",
@@ -1430,14 +1434,9 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			},
 		}
 
-		test := testsuites.DynamicallyProvisionedInlineVolumeTest{
-			CSIDriver:       testDriver,
-			Pods:            pods,
-			SecretName:      secretName,
-			Server:          server,
-			ShareName:       "share",
-			ReadOnly:        false,
-			CSIInlineVolume: true,
+		test := testsuites.PreProvisionedMultiplePods{
+			CSIDriver: testDriver,
+			Pods:      pods,
 		}
 		test.Run(ctx, cs, ns)
 	})

--- a/test/e2e/testsuites/specs.go
+++ b/test/e2e/testsuites/specs.go
@@ -56,6 +56,7 @@ type VolumeDetails struct {
 	// Optional, used with specified StorageClass
 	StorageClass       *storagev1.StorageClass
 	ShareName          string
+	Server             string
 	NodeStageSecretRef string
 	AccessModes        []v1.PersistentVolumeAccessMode
 }
@@ -267,8 +268,12 @@ func (volume *VolumeDetails) SetupPreProvisionedPersistentVolumeClaim(ctx contex
 	if volume.ShareName != "" {
 		attrib["shareName"] = volume.ShareName
 	}
+	if volume.Server != "" {
+		attrib["server"] = volume.Server
+	}
 	nodeStageSecretRef := volume.NodeStageSecretRef
 	pv := csiDriver.GetPersistentVolume(volume.VolumeID, volume.FSType, volume.ClaimSize, volume.ReclaimPolicy, namespace.Name, attrib, nodeStageSecretRef)
+	pv.Spec.MountOptions = volume.MountOptions
 	tpv := NewTestPreProvisionedPersistentVolume(client, pv)
 	tpv.Create(ctx)
 	ginkgo.By("setting up the PVC")


### PR DESCRIPTION
This is a cherry-pick of #3347 into `release-1.34`.

Squashed and adapted for the release-1.34 branch which does not have workload-identity token / OAuth token support in inline volumes, so the `useWIToken` / `mountWithOAuthToken` / `canSkipRepublishNodeStage` bits from the upstream PR are omitted. Everything else — the `validateInlineSMBMountOptions` denylist, `validateInlineVolumeServer` / `parseInlineVolumeServer` / `isAzureDNSZoneStorageHost`, the `storageEndpointSuffix` tightening in `NodeStageVolume`, and the `caseCollidingKey` fix — is preserved.

Unit tests updated:
- `TestCaseCollidingKey` expectations use the new `"foo, foo"` pair format
- Ephemeral NFS `TestNodeStageVolume` case now passes a well-formed `<account>.file.<suffix>` server + matching `storageAccount` / `storageEndpointSuffix` so it reaches the mount path
- `TestFindLocalMountModeOption` removed (function superseded by denylist)

Local `go test ./pkg/azurefile/ -run 'TestNodePublishVolume|TestNodeStageVolume|TestCaseColliding|TestValidateInline*|TestParseInline*|TestIsAzureDNSZone*'` passes.

/kind bug

**Release note**:
```
none
```