### PR TITLE
test: cover ephemeral+serviceAccountToken+clientID denied mount option path

### DIFF
--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -486,6 +486,30 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			// Regression guard: an ephemeral request that also carries serviceAccountToken+clientID
+			// must still go through inline-mount-option validation. Ensures denied mount options
+			// cannot be smuggled in via an ephemeral request that would otherwise be routed
+			// through the token+clientID code path.
+			desc: "[Error] Ephemeral volume with serviceAccountToken+clientID must still validate denied mount options",
+			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:   "csi-inline-denied-token-clientid",
+				TargetPath: targetTest,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					ephemeralField:           "true",
+					shareNameField:           "testshare",
+					serverNameField:          "testaccount.file.core.windows.net",
+					serviceAccountTokenField: "fake-token",
+					clientIDField:            "test-client-id",
+					mountOptionsField:        "nosharesock,bind",
+				},
+			},
+			expectedErr: testutil.TestError{
+				DefaultError: status.Error(codes.InvalidArgument, `mount option "bind" is not supported for ephemeral volumes`),
+				WindowsError: status.Error(codes.InvalidArgument, `mount option "bind" is not supported for ephemeral volumes`),
+			},
+		},
+		{
 			desc: "[Error] Ephemeral volume with mountWithWIToken should preserve storageAccount",
 			req: &csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
 				VolumeId:   "csi-94637b24200724b604b0e2c92e0fcdfabb0e109f656857c5a3c9585777c8ed84",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Adds one regression test case to `TestNodePublishVolume` covering an ephemeral request that also carries `serviceAccountToken` + `clientID` + a denied inline mount option (`bind`).

This guards against a future refactor that would route ephemeral+token+clientID requests through the token/clientID code path **before** running `validateInlineSMBMountOptions`, which would silently reopen the inline-mount-option validation bypass fixed by #3347.

**Which issue(s) this PR fixes**:

Follow-up to #3347 and PR #3364 (release-1.34 backport). Caught during Copilot review on #3364.

**Special notes for your reviewer**:

Test-only; no production code change.