### PR TITLE
test: add workload identity account-key mode e2e test

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1997,6 +1997,8 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 	})
 
 	ginkgo.It("should create a volume on demand with workload identity account key retrieval [file.csi.azure.com]", ginkgo.Serial, func(ctx ginkgo.SpecContext) {
+		skipIfUsingInTreeVolumePlugin()
+		skipIfTestingInWindowsCluster()
 		skipIfTestingInMigrationCluster()
 		if !isCapzTest {
 			ginkgo.Skip("test case is only available for capz test")

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1996,6 +1996,55 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test.Run(ctx, cs, defaultNS)
 	})
 
+	ginkgo.It("should create a volume on demand with workload identity account key retrieval [file.csi.azure.com]", ginkgo.Serial, func(ctx ginkgo.SpecContext) {
+		skipIfTestingInMigrationCluster()
+		if !isCapzTest {
+			ginkgo.Skip("test case is only available for capz test")
+		}
+
+		// Wait for background AAD OIDC cache warm-up to complete.
+		ginkgo.By("Waiting for AAD OIDC cache warm-up to complete")
+		<-wiReady
+
+		gomega.Expect(wiSetupSucceeded).To(gomega.BeTrue(), "Workload identity setup failed, cannot run WI account key mount test")
+		gomega.Expect(wiClientID).NotTo(gomega.BeEmpty(), "WI client ID not set after background warm-up")
+		gomega.Expect(errWISetup).NotTo(gomega.HaveOccurred(),
+			"background AAD OIDC warm-up failed; WI account key retrieval will not work")
+		clientID := wiClientID
+
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "100Gi",
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		// Account-key mode: WI is used to retrieve the storage account key,
+		// then the key is used for the actual SMB mount. No mountWithWorkloadIdentityToken.
+		// Requires Storage Account Contributor role on the managed identity.
+		scParameters := map[string]string{
+			"skuName":  "Premium_LRS",
+			"clientID": clientID,
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver:              testDriver,
+			Pods:                   pods,
+			StorageClassParameters: scParameters,
+			ServiceAccountName:     wiServiceAccountName,
+		}
+		// Use default namespace because the federated identity credential is bound to
+		// system:serviceaccount:default:<sa-name>, so the SA must be in default namespace.
+		defaultNS2 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+		test.Run(ctx, cs, defaultNS2)
+	})
+
 })
 
 func restClient(group string, version string) (restclientset.Interface, error) {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -441,6 +441,7 @@ const (
 	wiServiceAccountNamespace   = "default"
 	wiFederatedCredentialName   = "azurefile-e2e-wi-fic"
 	wiStorageFileDataSMBMIAdmin = "a235d3ee-5935-4cfb-8cc5-a3303ad5995e" // Storage File Data SMB MI Admin role GUID
+	wiStorageAccountContributor = "17d1049b-9a84-46fb-8f53-869881c3d3ab" // Storage Account Contributor role GUID
 )
 
 // setupWorkloadIdentity configures workload identity for e2e tests:
@@ -524,6 +525,14 @@ func setupWorkloadIdentity(ctx context.Context, cs clientset.Interface, azureCli
 		return "", fmt.Errorf("failed to assign Storage File Data SMB MI Admin role: %v", err)
 	}
 	log.Printf("Assigned Storage File Data SMB MI Admin role to identity")
+
+	// Also assign Storage Account Contributor so account-key-mode WI tests
+	// (without mountWithWorkloadIdentityToken) can retrieve storage keys.
+	err = azureClient.AssignRoleToIdentity(ctx, creds.ResourceGroup, identityInfo.PrincipalID, wiStorageAccountContributor)
+	if err != nil {
+		return "", fmt.Errorf("failed to assign Storage Account Contributor role: %v", err)
+	}
+	log.Printf("Assigned Storage Account Contributor role to identity")
 
 	// Step 6: Verify OIDC JWKS endpoint is accessible
 	if err := waitForOIDCJWKS(oidcIssuerURL, 5*time.Minute); err != nil {


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/blob-csi-driver/pull/2655

## What this PR does / why we need it

The existing workload identity e2e test only covers **token-only mode** (`mountWithWorkloadIdentityToken: "true"` with `Storage File Data SMB MI Admin` role). This PR adds a new test for the **default account-key mode**, where:

1. The managed identity has `Storage Account Contributor` role
2. The CSI driver uses WI token exchange to authenticate to ARM and retrieve the storage account key
3. The actual SMB mount uses the retrieved account key (no OIDC token passed to the mount)

This is the more common WI deployment pattern and does not require `mountWithWorkloadIdentityToken` in StorageClass parameters.

## What's changed

1. **`test/e2e/suite_test.go`**: Add `Storage Account Contributor` role assignment in `setupWorkloadIdentity` (alongside existing `Storage File Data SMB MI Admin`) so both WI modes are exercised.

2. **`test/e2e/dynamic_provisioning_test.go`**: New Serial test case `"should create a volume on demand with workload identity account key retrieval"` — uses `clientID` in StorageClass parameters without `mountWithWorkloadIdentityToken`, runs in default namespace with the WI-annotated service account.

## Which issue(s) this PR fixes

None — test coverage improvement.

## Release note

```release-note
NONE
```