### PR TITLE
fix: invalidate account key cache on SMB mount failure

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -685,6 +685,23 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 					csiMetrics.SubscriptionID, subsID, csiMetrics.MountErrorReason, classifyMountError(mountErr))
 			}
 			if mountErr != nil {
+				// Invalidate the cached account key so the next mount retry
+				// re-fetches a fresh key. When a customer rotates their
+				// storage account key, the driver's account key cache
+				// (default TTL 3min, and refreshed on every read) can keep
+				// handing back the stale key for the lifetime of the pod,
+				// because every kubelet retry re-reads and extends the
+				// entry. Dropping it here breaks that loop: the next
+				// NodeStageVolume goes through GetStorageAccesskey ->
+				// GetStorageAccesskeyWithSubsID and picks up the new key.
+				if accountName != "" && d.accountCacheMap != nil {
+					if dErr := d.accountCacheMap.Delete(accountName); dErr != nil {
+						klog.Warningf("NodeStageVolume: failed to invalidate account key cache for %s after mount failure: %v", accountName, dErr)
+					} else {
+						klog.V(2).Infof("NodeStageVolume: invalidated account key cache for %s after mount failure on volume %s", accountName, volumeID)
+					}
+				}
+
 				var helpLinkMsg string
 				if d.appendMountErrorHelpLink {
 					helpLinkMsg = "\nPlease refer to http://aka.ms/filemounterror for possible causes and solutions for mount errors."

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -695,11 +695,16 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 				// NodeStageVolume goes through GetStorageAccesskey ->
 				// GetStorageAccesskeyWithSubsID and picks up the new key.
 				//
-				// Only applies to SMB (CIFS) — NFS mounts don't use the
-				// account key at all (Kerberos / private endpoint /
-				// mount options), so invalidating the cache for NFS is a
-				// pointless extra ListKeys call on every failure.
-				if protocol != nfs && accountName != "" && d.accountCacheMap != nil {
+				// Only applies when the mount actually used the storage
+				// account key:
+				//   - NFS mounts (protocol == nfs) authenticate via
+				//     Kerberos / private endpoint / mount options.
+				//   - SMB with managed identity or workload-identity token
+				//     authenticate via Kerberos.
+				// Invalidating the cache in those cases is a pointless
+				// extra ListKeys call on every failure.
+				usesAccountKey := protocol != nfs && !mountWithManagedIdentity && !mountWithWIToken && clientID == ""
+				if usesAccountKey && accountName != "" && d.accountCacheMap != nil {
 					if dErr := d.accountCacheMap.Delete(accountName); dErr != nil {
 						klog.Warningf("NodeStageVolume: failed to invalidate account key cache for %s after mount failure: %v", accountName, dErr)
 					} else {

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -709,10 +709,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 				// extra ListKeys call on the next attempt.
 				//
 				// This intentionally also covers the Windows SMB path:
-				// SMBMount on Windows delegates to New-SmbGlobalMapping via
-				// the CSI proxy (see pkg/azurefile/azure_common_windows.go),
-				// which authenticates with the same cached account key, so
-				// the same stale-cache problem applies after key rotation.
+				// SMBMount on Windows also authenticates with the same
+				// cached account key (via New-SmbGlobalMapping when running
+				// inside a host-process container, which is the default
+				// deployment mode today), so the same stale-cache problem
+				// applies after key rotation.
 				usesAccountKey := protocol != nfs && !mountWithManagedIdentity && !mountWithWIToken && !mountWithOAuthToken && clientID == ""
 				if usesAccountKey && accountName != "" && d.accountCacheMap != nil {
 					if dErr := d.accountCacheMap.Delete(accountName); dErr != nil {

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -699,11 +699,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 				// account key:
 				//   - NFS mounts (protocol == nfs) authenticate via
 				//     Kerberos / private endpoint / mount options.
-				//   - SMB with managed identity or workload-identity token
-				//     authenticate via Kerberos.
+				//   - SMB with managed identity, workload-identity token,
+				//     or OAuth token authenticate via Kerberos.
 				// Invalidating the cache in those cases is a pointless
 				// extra ListKeys call on every failure.
-				usesAccountKey := protocol != nfs && !mountWithManagedIdentity && !mountWithWIToken && clientID == ""
+				usesAccountKey := protocol != nfs && !mountWithManagedIdentity && !mountWithWIToken && !mountWithOAuthToken && clientID == ""
 				if usesAccountKey && accountName != "" && d.accountCacheMap != nil {
 					if dErr := d.accountCacheMap.Delete(accountName); dErr != nil {
 						klog.Warningf("NodeStageVolume: failed to invalidate account key cache for %s after mount failure: %v", accountName, dErr)

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -686,34 +686,18 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			}
 			if mountErr != nil {
 				// Invalidate the cached account key so the next mount retry
-				// re-fetches a fresh key from ARM. When a customer rotates
-				// their storage account key, the driver's account key cache
-				// (fixed TTL, default 3 minutes; reads do NOT extend the TTL,
-				// see TimedCache.Get in cloud-provider-azure) will keep
-				// serving the stale key until the entry naturally ages out.
-				// While the entry is still fresh, every kubelet retry mounts
-				// with the stale key and fails with `Permission denied`.
-				// Dropping the entry on failure shortens the recovery window
-				// from "up to TTL" to "one retry": the next NodeStageVolume
-				// goes through GetStorageAccesskey ->
-				// GetStorageAccesskeyWithSubsID and picks up the new key.
+				// re-fetches a fresh key from ARM. After a storage account
+				// key rotation the cache (fixed TTL, ~3min; reads do NOT
+				// extend the TTL) keeps serving the stale key until it ages
+				// out, and every kubelet retry mounts with the stale key and
+				// fails. Dropping the entry on failure shortens the recovery
+				// window from "up to TTL" to "one retry".
 				//
-				// Only applies when the mount actually used the storage
-				// account key. Skipped for auth modes that do not read from
-				// the cache:
-				//   - NFS mounts (protocol == nfs) authenticate via
-				//     Kerberos / private endpoint / mount options.
-				//   - SMB with managed identity, workload-identity token,
-				//     or OAuth token authenticate via Kerberos.
-				// Invalidating the cache in those cases is a pointless
-				// extra ListKeys call on the next attempt.
-				//
-				// This intentionally also covers the Windows SMB path:
-				// SMBMount on Windows also authenticates with the same
-				// cached account key (via New-SmbGlobalMapping when running
-				// inside a host-process container, which is the default
-				// deployment mode today), so the same stale-cache problem
-				// applies after key rotation.
+				// Skipped for auth modes that do not use the cached account
+				// key (NFS, and SMB with managed identity / workload-identity
+				// token / OAuth token — all Kerberos-based); invalidating
+				// there would just cost a pointless ListKeys on the next
+				// attempt.
 				usesAccountKey := protocol != nfs && !mountWithManagedIdentity && !mountWithWIToken && !mountWithOAuthToken && clientID == ""
 				if usesAccountKey && accountName != "" && d.accountCacheMap != nil {
 					if dErr := d.accountCacheMap.Delete(accountName); dErr != nil {

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -686,23 +686,33 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			}
 			if mountErr != nil {
 				// Invalidate the cached account key so the next mount retry
-				// re-fetches a fresh key. When a customer rotates their
-				// storage account key, the driver's account key cache
-				// (default TTL 3min, and refreshed on every read) can keep
-				// handing back the stale key for the lifetime of the pod,
-				// because every kubelet retry re-reads and extends the
-				// entry. Dropping it here breaks that loop: the next
-				// NodeStageVolume goes through GetStorageAccesskey ->
+				// re-fetches a fresh key from ARM. When a customer rotates
+				// their storage account key, the driver's account key cache
+				// (fixed TTL, default 3 minutes; reads do NOT extend the TTL,
+				// see TimedCache.Get in cloud-provider-azure) will keep
+				// serving the stale key until the entry naturally ages out.
+				// While the entry is still fresh, every kubelet retry mounts
+				// with the stale key and fails with `Permission denied`.
+				// Dropping the entry on failure shortens the recovery window
+				// from "up to TTL" to "one retry": the next NodeStageVolume
+				// goes through GetStorageAccesskey ->
 				// GetStorageAccesskeyWithSubsID and picks up the new key.
 				//
 				// Only applies when the mount actually used the storage
-				// account key:
+				// account key. Skipped for auth modes that do not read from
+				// the cache:
 				//   - NFS mounts (protocol == nfs) authenticate via
 				//     Kerberos / private endpoint / mount options.
 				//   - SMB with managed identity, workload-identity token,
 				//     or OAuth token authenticate via Kerberos.
 				// Invalidating the cache in those cases is a pointless
-				// extra ListKeys call on every failure.
+				// extra ListKeys call on the next attempt.
+				//
+				// This intentionally also covers the Windows SMB path:
+				// SMBMount on Windows delegates to New-SmbGlobalMapping via
+				// the CSI proxy (see pkg/azurefile/azure_common_windows.go),
+				// which authenticates with the same cached account key, so
+				// the same stale-cache problem applies after key rotation.
 				usesAccountKey := protocol != nfs && !mountWithManagedIdentity && !mountWithWIToken && !mountWithOAuthToken && clientID == ""
 				if usesAccountKey && accountName != "" && d.accountCacheMap != nil {
 					if dErr := d.accountCacheMap.Delete(accountName); dErr != nil {

--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -694,7 +694,12 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 				// entry. Dropping it here breaks that loop: the next
 				// NodeStageVolume goes through GetStorageAccesskey ->
 				// GetStorageAccesskeyWithSubsID and picks up the new key.
-				if accountName != "" && d.accountCacheMap != nil {
+				//
+				// Only applies to SMB (CIFS) — NFS mounts don't use the
+				// account key at all (Kerberos / private endpoint /
+				// mount options), so invalidating the cache for NFS is a
+				// pointless extra ListKeys call on every failure.
+				if protocol != nfs && accountName != "" && d.accountCacheMap != nil {
 					if dErr := d.accountCacheMap.Delete(accountName); dErr != nil {
 						klog.Warningf("NodeStageVolume: failed to invalidate account key cache for %s after mount failure: %v", accountName, dErr)
 					} else {

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -2750,25 +2750,31 @@ func TestValidateDiskIsRegularFile(t *testing.T) {
 	}
 }
 
-// TestInvalidateAccountKeyCacheOnMountFailure verifies the small helper
-// contract used by NodeStageVolume when an SMB mount attempt fails: the
-// cached account key entry is dropped so the next kubelet retry re-fetches
-// a fresh key (covering the storage-account-key-rotation recovery path).
-//
-// A successful mount must NOT drop the entry — that would defeat the
-// point of the cache and cause an extra ListKeys call per retry when the
-// key is still valid.
+// TestInvalidateAccountKeyCacheOnMountFailure exercises the actual
+// NodeStageVolume mount-failure branch (not the helper in isolation) to
+// verify that:
+//   - a failed SMB mount that authenticated with the account key drops
+//     the cached entry so the next kubelet retry re-fetches a fresh key
+//     (covers the storage-account-key-rotation recovery path);
+//   - a failed NFS mount (which does not use the account key) preserves
+//     the cache entry, avoiding a wasted ListKeys call.
 func TestInvalidateAccountKeyCacheOnMountFailure(t *testing.T) {
-	d := NewFakeDriver()
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		t.Skip("skipped on windows/darwin")
+	}
 
-	const accountName = "acct1"
-	const accountKey = "key1"
+	stdVolCap := &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+	}
+	secrets := map[string]string{
+		"accountname": "k8s",
+		"accountkey":  "testkey",
+	}
 
-	// Seed the cache the same way GetAccountInfo / GetStorageAccesskey would.
-	d.accountCacheMap.Set(accountName, accountKey)
-
-	get := func() (string, bool) {
-		v, err := d.accountCacheMap.Get(context.Background(), accountName, azcache.CacheReadTypeDefault)
+	get := func(d *Driver, name string) (string, bool) {
+		v, err := d.accountCacheMap.Get(context.Background(), name, azcache.CacheReadTypeDefault)
 		if err != nil || v == nil {
 			return "", false
 		}
@@ -2776,29 +2782,90 @@ func TestInvalidateAccountKeyCacheOnMountFailure(t *testing.T) {
 		return s, ok
 	}
 
-	// Pre-condition: entry is present.
-	if v, ok := get(); !ok || v != accountKey {
-		t.Fatalf("pre-condition: expected cache to hold %q for %q, got (%q, %v)", accountKey, accountName, v, ok)
+	newDriver := func(t *testing.T) (*Driver, *gomock.Controller) {
+		d := NewFakeDriver()
+		d.isKataNode = false
+		d.useAZNFSForNFSMounts = false
+		d.enableAzurefileProxy = false
+		mounter, err := NewFakeMounter()
+		if err != nil {
+			t.Fatalf("failed to get fake mounter: %v", err)
+		}
+		d.mounter = mounter
+		ctrl := gomock.NewController(t)
+		clientFactory := mock_azclient.NewMockClientFactory(ctrl)
+		mockAccountClient := mock_accountclient.NewMockInterface(ctrl)
+		clientFactory.EXPECT().GetAccountClientForSub(gomock.Any()).Return(mockAccountClient, nil).AnyTimes()
+		d.cloud = &storage.AccountRepo{
+			Environment:          &azclient.Environment{StorageEndpointSuffix: defaultStorageEndPointSuffix},
+			NetworkClientFactory: clientFactory,
+			ComputeClientFactory: clientFactory,
+		}
+		return d, ctrl
 	}
 
-	// Success path: cache must be preserved (we do not touch it on success).
-	if v, ok := get(); !ok || v != accountKey {
-		t.Fatalf("success path: expected cache to still hold %q for %q, got (%q, %v)", accountKey, accountName, v, ok)
-	}
+	t.Run("failed SMB mount invalidates account key cache", func(t *testing.T) {
+		d, ctrl := newDriver(t)
+		defer ctrl.Finish()
 
-	// Failure path (mirrors the branch in NodeStageVolume): invalidate the
-	// entry so the next kubelet retry goes to ARM for a rotated key.
-	if err := d.accountCacheMap.Delete(accountName); err != nil {
-		t.Fatalf("failed to invalidate account key cache: %v", err)
-	}
-	if v, ok := get(); ok {
-		t.Fatalf("failure path: expected cache entry for %q to be gone, still got %q", accountName, v)
-	}
+		errorMountSensSource := testutil.GetWorkDirPath("error_mount_sens_source_smb_invalidate", t)
+		defer os.RemoveAll(errorMountSensSource)
 
-	// After invalidation, a re-seed (simulating the next Get -> ListKeys ->
-	// Set flow with a rotated key) must not surface the stale key.
-	d.accountCacheMap.Set(accountName, "key2-rotated")
-	if v, ok := get(); !ok || v != "key2-rotated" {
-		t.Fatalf("post-rotation: expected rotated key, got (%q, %v)", v, ok)
-	}
+		d.accountCacheMap.Set("k8s", "testkey")
+		if v, ok := get(d, "k8s"); !ok || v != "testkey" {
+			t.Fatalf("pre-condition: expected cache to hold seeded key, got (%q, %v)", v, ok)
+		}
+
+		req := &csi.NodeStageVolumeRequest{
+			VolumeId:          "vol_smb_invalidate##",
+			StagingTargetPath: errorMountSensSource,
+			VolumeCapability:  stdVolCap,
+			VolumeContext: map[string]string{
+				fsTypeField:           "smb",
+				diskNameField:         "test_disk.vhd",
+				shareNameField:        "test_sharename",
+				serverNameField:       "test_servername",
+				mountPermissionsField: "0755",
+			},
+			Secrets: secrets,
+		}
+		if _, err := d.NodeStageVolume(context.Background(), req); err == nil {
+			t.Fatalf("expected SMB mount to fail (fake mounter returns error), got nil")
+		}
+		if v, ok := get(d, "k8s"); ok {
+			t.Fatalf("expected cache entry for account %q to be invalidated after SMB mount failure, still got %q", "k8s", v)
+		}
+	})
+
+	t.Run("NFS mount does not invalidate account key cache", func(t *testing.T) {
+		d, ctrl := newDriver(t)
+		defer ctrl.Finish()
+
+		stagingTargetPath := testutil.GetWorkDirPath("source_test_nfs_preserve", t)
+		defer os.RemoveAll(stagingTargetPath)
+
+		d.accountCacheMap.Set("k8s", "testkey")
+
+		req := &csi.NodeStageVolumeRequest{
+			VolumeId:          "vol_nfs_preserve##",
+			StagingTargetPath: stagingTargetPath,
+			VolumeCapability:  stdVolCap,
+			VolumeContext: map[string]string{
+				fsTypeField:           "nfs",
+				protocolField:         "nfs",
+				diskNameField:         "test_disk.vhd",
+				shareNameField:        "test_sharename",
+				serverNameField:       "test_servername",
+				mountPermissionsField: "0755",
+			},
+			Secrets: secrets,
+		}
+		// Ignore the mount outcome: whether the fake mount succeeds or
+		// fails, the NFS branch (protocol == nfs) must never invalidate
+		// the account key cache because the mount does not use it.
+		_, _ = d.NodeStageVolume(context.Background(), req)
+		if v, ok := get(d, "k8s"); !ok || v != "testkey" {
+			t.Fatalf("expected cache entry for account %q to be preserved for NFS mount, got (%q, %v)", "k8s", v, ok)
+		}
+	})
 }

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -2758,6 +2758,15 @@ func TestValidateDiskIsRegularFile(t *testing.T) {
 //     (covers the storage-account-key-rotation recovery path);
 //   - a failed NFS mount (which does not use the account key) preserves
 //     the cache entry, avoiding a wasted ListKeys call.
+//
+// The tests intentionally do NOT pass Secrets on the CSI request. When
+// Secrets carries accountname/accountkey, GetAccountInfo bypasses the
+// cache read entirely and Set()s a fresh value at the end (see
+// azurefile.go: else branch of !hasStorageAccountCredentials), which
+// would make the seeded stale entry irrelevant to the mount attempt.
+// Instead, we drive account-key discovery through the cache path:
+// pre-populate accountCacheMap[accountName], and let GetAccountInfo
+// return that cached value to the SMB mount.
 func TestInvalidateAccountKeyCacheOnMountFailure(t *testing.T) {
 	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		t.Skip("skipped on windows/darwin")
@@ -2768,10 +2777,12 @@ func TestInvalidateAccountKeyCacheOnMountFailure(t *testing.T) {
 			Mount: &csi.VolumeCapability_MountVolume{},
 		},
 	}
-	secrets := map[string]string{
-		"accountname": "k8s",
-		"accountkey":  "testkey",
-	}
+
+	const accountName = "k8s"
+	const staleKey = "stale-key-before-rotation"
+	// volumeID format: <rg>#<accountName>#<shareName>#<diskName>#<namespace>#<subsID>
+	// GetFileShareInfo extracts accountName from segment[1].
+	const volumeID = "rg#k8s#test_sharename##"
 
 	get := func(d *Driver, name string) (string, bool) {
 		v, err := d.accountCacheMap.Get(context.Background(), name, azcache.CacheReadTypeDefault)
@@ -2804,68 +2815,80 @@ func TestInvalidateAccountKeyCacheOnMountFailure(t *testing.T) {
 		return d, ctrl
 	}
 
-	t.Run("failed SMB mount invalidates account key cache", func(t *testing.T) {
+	t.Run("failed SMB mount invalidates account key cache and next attempt does not see stale key", func(t *testing.T) {
 		d, ctrl := newDriver(t)
 		defer ctrl.Finish()
 
 		errorMountSensSource := testutil.GetWorkDirPath("error_mount_sens_source_smb_invalidate", t)
 		defer os.RemoveAll(errorMountSensSource)
 
-		d.accountCacheMap.Set("k8s", "testkey")
-		if v, ok := get(d, "k8s"); !ok || v != "testkey" {
+		// Seed the cache with the stale key. GetAccountInfo will read this
+		// via accountCacheMap.Get (no Secrets on the request, so the
+		// hasStorageAccountCredentials branch is not taken).
+		d.accountCacheMap.Set(accountName, staleKey)
+		if v, ok := get(d, accountName); !ok || v != staleKey {
 			t.Fatalf("pre-condition: expected cache to hold seeded key, got (%q, %v)", v, ok)
 		}
 
 		req := &csi.NodeStageVolumeRequest{
-			VolumeId:          "vol_smb_invalidate##",
+			VolumeId:          volumeID,
 			StagingTargetPath: errorMountSensSource,
 			VolumeCapability:  stdVolCap,
 			VolumeContext: map[string]string{
 				fsTypeField:           "smb",
-				diskNameField:         "test_disk.vhd",
 				shareNameField:        "test_sharename",
 				serverNameField:       "test_servername",
 				mountPermissionsField: "0755",
 			},
-			Secrets: secrets,
+			// intentionally no Secrets — force the cache read path.
 		}
 		if _, err := d.NodeStageVolume(context.Background(), req); err == nil {
 			t.Fatalf("expected SMB mount to fail (fake mounter returns error), got nil")
 		}
-		if v, ok := get(d, "k8s"); ok {
-			t.Fatalf("expected cache entry for account %q to be invalidated after SMB mount failure, still got %q", "k8s", v)
+
+		// The failure branch must have dropped the cached entry.
+		if v, ok := get(d, accountName); ok {
+			t.Fatalf("expected cache entry for account %q to be invalidated after SMB mount failure, still got %q", accountName, v)
+		}
+
+		// Simulate the storage-account-key-rotation recovery path: the
+		// next kubelet retry would re-populate the cache from ARM with
+		// the rotated key. Verify a subsequent read returns the rotated
+		// key, not the stale one.
+		const rotatedKey = "rotated-key-after-arm-refresh"
+		d.accountCacheMap.Set(accountName, rotatedKey)
+		if v, ok := get(d, accountName); !ok || v != rotatedKey {
+			t.Fatalf("post-rotation: expected cache to return rotated key, got (%q, %v)", v, ok)
 		}
 	})
 
-	t.Run("NFS mount does not invalidate account key cache", func(t *testing.T) {
+	t.Run("NFS mount preserves account key cache", func(t *testing.T) {
 		d, ctrl := newDriver(t)
 		defer ctrl.Finish()
 
 		stagingTargetPath := testutil.GetWorkDirPath("source_test_nfs_preserve", t)
 		defer os.RemoveAll(stagingTargetPath)
 
-		d.accountCacheMap.Set("k8s", "testkey")
+		d.accountCacheMap.Set(accountName, staleKey)
 
 		req := &csi.NodeStageVolumeRequest{
-			VolumeId:          "vol_nfs_preserve##",
+			VolumeId:          volumeID,
 			StagingTargetPath: stagingTargetPath,
 			VolumeCapability:  stdVolCap,
 			VolumeContext: map[string]string{
 				fsTypeField:           "nfs",
 				protocolField:         "nfs",
-				diskNameField:         "test_disk.vhd",
 				shareNameField:        "test_sharename",
 				serverNameField:       "test_servername",
 				mountPermissionsField: "0755",
 			},
-			Secrets: secrets,
 		}
-		// Ignore the mount outcome: whether the fake mount succeeds or
-		// fails, the NFS branch (protocol == nfs) must never invalidate
-		// the account key cache because the mount does not use it.
+		// Whether the fake NFS mount succeeds or fails, the NFS branch
+		// (protocol == nfs) must never touch the account key cache
+		// because NFS auth does not use the account key.
 		_, _ = d.NodeStageVolume(context.Background(), req)
-		if v, ok := get(d, "k8s"); !ok || v != "testkey" {
-			t.Fatalf("expected cache entry for account %q to be preserved for NFS mount, got (%q, %v)", "k8s", v, ok)
+		if v, ok := get(d, accountName); !ok || v != staleKey {
+			t.Fatalf("expected cache entry for account %q to be preserved for NFS mount, got (%q, %v)", accountName, v, ok)
 		}
 	})
 }

--- a/pkg/azurefile/nodeserver_test.go
+++ b/pkg/azurefile/nodeserver_test.go
@@ -55,6 +55,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/accountclient/mock_accountclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/mock_azclient"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/storage"
 )
 
@@ -2746,5 +2747,58 @@ func TestValidateDiskIsRegularFile(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+// TestInvalidateAccountKeyCacheOnMountFailure verifies the small helper
+// contract used by NodeStageVolume when an SMB mount attempt fails: the
+// cached account key entry is dropped so the next kubelet retry re-fetches
+// a fresh key (covering the storage-account-key-rotation recovery path).
+//
+// A successful mount must NOT drop the entry — that would defeat the
+// point of the cache and cause an extra ListKeys call per retry when the
+// key is still valid.
+func TestInvalidateAccountKeyCacheOnMountFailure(t *testing.T) {
+	d := NewFakeDriver()
+
+	const accountName = "acct1"
+	const accountKey = "key1"
+
+	// Seed the cache the same way GetAccountInfo / GetStorageAccesskey would.
+	d.accountCacheMap.Set(accountName, accountKey)
+
+	get := func() (string, bool) {
+		v, err := d.accountCacheMap.Get(context.Background(), accountName, azcache.CacheReadTypeDefault)
+		if err != nil || v == nil {
+			return "", false
+		}
+		s, ok := v.(string)
+		return s, ok
+	}
+
+	// Pre-condition: entry is present.
+	if v, ok := get(); !ok || v != accountKey {
+		t.Fatalf("pre-condition: expected cache to hold %q for %q, got (%q, %v)", accountKey, accountName, v, ok)
+	}
+
+	// Success path: cache must be preserved (we do not touch it on success).
+	if v, ok := get(); !ok || v != accountKey {
+		t.Fatalf("success path: expected cache to still hold %q for %q, got (%q, %v)", accountKey, accountName, v, ok)
+	}
+
+	// Failure path (mirrors the branch in NodeStageVolume): invalidate the
+	// entry so the next kubelet retry goes to ARM for a rotated key.
+	if err := d.accountCacheMap.Delete(accountName); err != nil {
+		t.Fatalf("failed to invalidate account key cache: %v", err)
+	}
+	if v, ok := get(); ok {
+		t.Fatalf("failure path: expected cache entry for %q to be gone, still got %q", accountName, v)
+	}
+
+	// After invalidation, a re-seed (simulating the next Get -> ListKeys ->
+	// Set flow with a rotated key) must not surface the stale key.
+	d.accountCacheMap.Set(accountName, "key2-rotated")
+	if v, ok := get(); !ok || v != "key2-rotated" {
+		t.Fatalf("post-rotation: expected rotated key, got (%q, %v)", v, ok)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When a customer rotates their Azure storage account key while a pod is running, the driver's account key cache (`accountCacheMap`, `TimedCache` with a fixed ~3min TTL — reads do NOT extend the TTL) can keep handing back the stale key for up to the full TTL window. During that window, every kubelet `NodeStageVolume` retry uses the stale key and `mount.cifs` fails with `Permission denied`; the mount only recovers once the entry naturally ages out.

Repro reported from field:
1. Kubelet retries `NodeStageVolume` with exponential backoff (cap ~2min).
2. The retries fall inside the ~3min cache TTL window.
3. Every retry reads the stale key from `accountCacheMap` and calls `mount.cifs`, which fails.
4. Recovery only happens when the entry ages out (or the pod is deleted and the driver takes a different code path).

**Fix**: on any SMB mount failure inside `NodeStageVolume`, invalidate the `accountCacheMap` entry for that account when the mount actually used the account key. The next retry goes through `GetStorageAccesskey` → `GetStorageAccesskeyWithSubsID` and picks up the rotated key from ARM. This shortens the recovery window from "up to TTL" to "one retry".

**Scope**:
- Covers Linux SMB (`mount.cifs`) and Windows SMB (host-process container deployment, the default today — `SMBMount` authenticates with the same cached account key), so both suffer the same stale-cache window after rotation.
- Skipped for auth modes that do not read the account key from the cache:
    * NFS (Kerberos / private endpoint / mount options).
    * SMB with managed identity, workload-identity token, or OAuth token (Kerberos).
- On mount success — no change (cache is untouched).
- On mount failure with a still-valid key (e.g. transient network / SMB issue) — we drop and re-fetch the same key on the next retry, which is cheap and self-healing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related docs (customer workaround so far): https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/storage/file-share-mount-failures-azure-files

**Release note**:
```release-note
Fix stale account key cache after storage account key rotation — the driver now invalidates the cached account key when an SMB mount attempt fails, so subsequent retries pick up a rotated key without waiting for the cache TTL to expire.
```
