### PR TITLE
[release-1.33] fix: validate SMB authentication parameters

### DIFF
--- a/pkg/azurefile/nodeserver.go
+++ b/pkg/azurefile/nodeserver.go
@@ -396,6 +396,10 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		cifsMountPath = filepath.Join(filepath.Dir(targetPath), proxyMount)
 	}
 
+	if err := validateSMBCredentialValues(accountName, accountKey); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	var mountOptions, sensitiveMountOptions []string
 	if protocol == nfs {
 		mountOptions = util.JoinMountOptions(mountFlags, []string{"vers=4,minorversion=1,sec=sys"})

--- a/pkg/azurefile/utils.go
+++ b/pkg/azurefile/utils.go
@@ -415,3 +415,20 @@ func getDefaultBandwidth(requestGiB int, storageAccountType string) *int32 {
 	}
 	return &bandwidth
 }
+
+// containsMountOptionDelimiter reports whether s contains an option separator
+// or terminator.
+func containsMountOptionDelimiter(s string) bool {
+	return strings.ContainsAny(s, ",\n\r\x00")
+}
+
+// validateSMBCredentialValues rejects invalid storage credentials.
+func validateSMBCredentialValues(accountName, accountKey string) error {
+	if containsMountOptionDelimiter(accountName) {
+		return fmt.Errorf("invalid account name: must not contain comma, newline, carriage return or NUL characters")
+	}
+	if containsMountOptionDelimiter(accountKey) {
+		return fmt.Errorf("invalid account key: must not contain comma, newline, carriage return or NUL characters")
+	}
+	return nil
+}

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -1364,3 +1364,50 @@ func TestGetDefaultBandwidth(t *testing.T) {
 func int32Ptr(i int32) *int32 {
 	return &i
 }
+
+func TestContainsMountOptionDelimiter(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"", false},
+		{"abc123+/=", false},
+		{"validbase64key==", false},
+		{"key,extra", true},
+		{"abc,def", true},
+		{"line1\nline2", true},
+		{"line1\rline2", true},
+		{"has\x00nul", true},
+	}
+	for _, tc := range tests {
+		if got := containsMountOptionDelimiter(tc.input); got != tc.expected {
+			t.Errorf("containsMountOptionDelimiter(%q) = %v, want %v", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestValidateSMBCredentialValues(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountName string
+		accountKey  string
+		expectErr   bool
+	}{
+		{"valid empty (identity auth)", "", "", false},
+		{"valid account and base64 key", "myaccount", "ZmFrZS1rZXktdmFsdWU+Pj8/", false},
+		{"comma in key value", "myaccount", "abc,def", true},
+		{"comma in key value alt", "myaccount", "key,extra", true},
+		{"newline in key", "myaccount", "abc\ndef", true},
+		{"carriage return in key", "myaccount", "abc\rdef", true},
+		{"nul in key", "myaccount", "abc\x00def", true},
+		{"comma in account name", "my,account", "validkey", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSMBCredentialValues(tc.accountName, tc.accountKey)
+			if (err != nil) != tc.expectErr {
+				t.Errorf("validateSMBCredentialValues(%q, <key>) error = %v, expectErr %v", tc.accountName, err, tc.expectErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #3382 to release-1.33.

**What this PR does:**
- Adds `containsMountOptionDelimiter` and `validateSMBCredentialValues` helpers to reject credentials containing commas, newlines, CR, or NUL
- Calls validation in `NodeStageVolume` before SMB mount, returning `InvalidArgument` on failure
- Adds unit tests for both helpers

**Original PR:** https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3382