### PR TITLE
[release-1.35] fix: avoid refreshing account key cache on cache hit

### DIFF
--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -895,6 +895,7 @@ func (d *Driver) GetAccountInfo(ctx context.Context, volumeID string, secrets, r
 	var protocol, accountKey, secretName, pvcNamespace string
 	// getAccountKeyFromSecret indicates whether get account key only from k8s secret
 	var getAccountKeyFromSecret, getLatestAccountKey, mountWithManagedIdentity, mountWithOAuthToken, mountWithWIToken bool
+	var accountKeyFromCache bool
 	var clientID, tenantID, tokenFilePath, serviceAccountToken string
 
 	for k, v := range reqContext {
@@ -1046,6 +1047,7 @@ func (d *Driver) GetAccountInfo(ctx context.Context, volumeID string, secrets, r
 		}
 		if cache != nil {
 			accountKey = cache.(string)
+			accountKeyFromCache = true
 		} else {
 			if secretName == "" && accountName != "" {
 				secretName = fmt.Sprintf(secretNameTemplate, accountName)
@@ -1081,7 +1083,7 @@ func (d *Driver) GetAccountInfo(ctx context.Context, volumeID string, secrets, r
 		}
 	}
 
-	if err == nil && accountKey != "" {
+	if err == nil && accountKey != "" && !accountKeyFromCache {
 		d.accountCacheMap.Set(accountName, accountKey)
 	}
 	return rgName, accountName, accountKey, fileShareName, diskName, subsID, tenantID, tokenFilePath, err

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -924,6 +924,92 @@ func TestGetAccountInfo(t *testing.T) {
 	}
 }
 
+func TestGetAccountInfoCacheWriteback(t *testing.T) {
+	t.Run("cache hit does not refresh cache entry timestamp", func(t *testing.T) {
+		d := NewFakeDriver()
+		d.cloud = &storage.AccountRepo{}
+
+		const (
+			accountName = "cacheaccount"
+			staleKey    = "stale-key"
+		)
+		reqContext := map[string]string{
+			resourceGroupField:  "rg",
+			storageAccountField: accountName,
+			shareNameField:      "share",
+		}
+
+		d.accountCacheMap.Set(accountName, staleKey)
+		entry, exists, err := d.accountCacheMap.GetStore().GetByKey(accountName)
+		assert.NoError(t, err)
+		if !assert.True(t, exists) {
+			return
+		}
+		cacheEntry := entry.(*cache.AzureCacheEntry)
+		oldCreatedOn := time.Now().UTC().Add(-2 * time.Minute)
+		cacheEntry.CreatedOn = oldCreatedOn
+
+		_, returnedAccountName, accountKey, fileShareName, _, _, _, _, err := d.GetAccountInfo(context.Background(), "invalid-volume-id", nil, reqContext)
+		assert.NoError(t, err)
+		assert.Equal(t, accountName, returnedAccountName)
+		assert.Equal(t, staleKey, accountKey)
+		assert.Equal(t, "share", fileShareName)
+
+		entry, exists, err = d.accountCacheMap.GetStore().GetByKey(accountName)
+		assert.NoError(t, err)
+		if !assert.True(t, exists) {
+			return
+		}
+		cacheEntry = entry.(*cache.AzureCacheEntry)
+		assert.Equal(t, staleKey, cacheEntry.Data)
+		assert.True(t, cacheEntry.CreatedOn.Equal(oldCreatedOn), "cache hit should not rewrite the same key back into cache")
+	})
+
+	t.Run("request secrets still update cache", func(t *testing.T) {
+		d := NewFakeDriver()
+		d.cloud = &storage.AccountRepo{}
+
+		const (
+			accountName = "secretaccount"
+			staleKey    = "stale-key"
+			freshKey    = "fresh-key"
+		)
+		reqContext := map[string]string{
+			resourceGroupField: "rg",
+			shareNameField:     "share",
+		}
+		secrets := map[string]string{
+			defaultSecretAccountName: accountName,
+			defaultSecretAccountKey:  freshKey,
+		}
+
+		d.accountCacheMap.Set(accountName, staleKey)
+		entry, exists, err := d.accountCacheMap.GetStore().GetByKey(accountName)
+		assert.NoError(t, err)
+		if !assert.True(t, exists) {
+			return
+		}
+		cacheEntry := entry.(*cache.AzureCacheEntry)
+		oldCreatedOn := time.Now().UTC().Add(-2 * time.Minute)
+		cacheEntry.CreatedOn = oldCreatedOn
+
+		_, returnedAccountName, accountKey, fileShareName, _, _, _, _, err := d.GetAccountInfo(context.Background(), "invalid-volume-id", secrets, reqContext)
+		assert.NoError(t, err)
+		assert.Equal(t, accountName, returnedAccountName)
+		assert.Equal(t, freshKey, accountKey)
+		assert.Equal(t, "share", fileShareName)
+
+		entry, exists, err = d.accountCacheMap.GetStore().GetByKey(accountName)
+		assert.NoError(t, err)
+		if !assert.True(t, exists) {
+			return
+		}
+		cacheEntry = entry.(*cache.AzureCacheEntry)
+		assert.Equal(t, freshKey, cacheEntry.Data)
+		assert.True(t, cacheEntry.CreatedOn.After(oldCreatedOn), "secret-derived key should still be written back into cache")
+	})
+}
+
 // TestGetAccountInfoWorkloadIdentityTokenFile covers the workload-identity
 // token-file behaviors: (1) the token cache filename must be unique per volume
 // so shared clientID/accountName do not race on one shared file. (2) when the


### PR DESCRIPTION
## What this PR does

Cherry-picks #3406 onto `release-1.35`.

`GetAccountInfo()` currently reads `accountKey` from `d.accountCacheMap` when `req.Secrets` is empty, but it unconditionally calls `d.accountCacheMap.Set(accountName, accountKey)` again before returning.

Because `TimedCache.Set(...)` resets `CreatedOn` to `time.Now().UTC()`, a pure cache hit keeps extending the cache entry TTL. In practice that means a stale account key can remain effectively "sticky" across kubelet mount retries.

This backport makes the write-back conditional:

- if the returned account key came from `accountCacheMap`, do **not** write it back again
- if the key came from Kubernetes Secret / ARM / explicit request secrets, keep the existing cache write-back behavior

## Backport notes

- cherry-picked source commit: `284bdae103c987faad8788d60ed72c24e71bba0d`
- original PR: #3406
- `release-1.35` had a small conflict in `pkg/azurefile/azurefile.go` because the branch already contains newer workload-identity token handling; the backport keeps that branch-specific logic and applies only the cache write-back fix.

## Test coverage

Added `TestGetAccountInfoCacheWriteback` to verify:

1. a cache hit does not refresh the cache entry timestamp
2. request-secret derived keys are still written back into cache

## Validation

- `git diff --check`
- attempted targeted `go test -mod=mod ./pkg/azurefile -run 'TestGetAccountInfoCacheWriteback$' -count=1 -vet=off`
  - local environment did not produce a conclusive test result before termination during compilation/execution, so this PR reports the attempt transparently rather than overstating validation
